### PR TITLE
feat:  cat-gateway must be resiliant in the face of DB schema changes

### DIFF
--- a/catalyst-gateway/bin/src/event_db/error.rs
+++ b/catalyst-gateway/bin/src/event_db/error.rs
@@ -18,6 +18,9 @@ pub(crate) enum Error {
     /// Cannot find this item
     #[error("Cannot find this item, error: {0}")]
     NotFound(String),
+    /// DB connection timeout
+    #[error("Connection to DB timed out")]
+    TimedOut,
     /// Unknown error
     #[error("error: {0}")]
     Unknown(String),
@@ -28,7 +31,10 @@ pub(crate) enum Error {
 
 impl From<RunError<tokio_postgres::Error>> for Error {
     fn from(val: RunError<tokio_postgres::Error>) -> Self {
-        Self::Unknown(val.to_string())
+        match val {
+            RunError::TimedOut => Self::TimedOut,
+            _ => Self::Unknown(val.to_string()),
+        }
     }
 }
 

--- a/catalyst-gateway/bin/src/event_db/error.rs
+++ b/catalyst-gateway/bin/src/event_db/error.rs
@@ -15,6 +15,9 @@ pub(crate) enum Error {
         /// The expected DB schema version.
         expected: i32,
     },
+    /// No DB URL was provided
+    #[error("DB URL is undefined")]
+    NoDatabaseUrl,
     /// Cannot find this item
     #[error("Cannot find this item, error: {0}")]
     NotFound(String),
@@ -33,7 +36,7 @@ impl From<RunError<tokio_postgres::Error>> for Error {
     fn from(val: RunError<tokio_postgres::Error>) -> Self {
         match val {
             RunError::TimedOut => Self::TimedOut,
-            _ => Self::Unknown(val.to_string()),
+            RunError::User(_) => Self::Unknown(val.to_string()),
         }
     }
 }

--- a/catalyst-gateway/bin/src/event_db/mod.rs
+++ b/catalyst-gateway/bin/src/event_db/mod.rs
@@ -38,6 +38,8 @@ pub(crate) struct EventDB {
 ///   database.  IF it is None, then the env var "`DATABASE_URL`" will be used
 ///   for this connection string. eg:
 ///     "`postgres://catalyst-dev:CHANGE_ME@localhost/CatalystDev`"
+/// * `do_schema_check` boolean flag to decide whether to verify the schema version
+///   or not. If it is `true`, a query is made to verify the DB schema version.
 ///
 /// # Errors
 ///
@@ -51,12 +53,15 @@ pub(crate) struct EventDB {
 ///
 /// The env var "`DATABASE_URL`" can be set directly as an anv var, or in a
 /// `.env` file.
-pub(crate) async fn establish_connection(url: Option<&str>) -> Result<EventDB, Error> {
+pub(crate) async fn establish_connection(
+    url: Option<String>,
+    do_schema_check: bool,
+) -> Result<EventDB, Error> {
     // Support env vars in a `.env` file,  doesn't need to exist.
     dotenv().ok();
 
     let database_url = match url {
-        Some(url) => url.to_string(),
+        Some(url) => url,
         // If the Database connection URL is not supplied, try and get from the env var.
         None => std::env::var(DATABASE_URL_ENVVAR).map_err(|_| Error::NoDatabaseUrl)?,
     };
@@ -69,7 +74,9 @@ pub(crate) async fn establish_connection(url: Option<&str>) -> Result<EventDB, E
 
     let db = EventDB { pool };
 
-    db.schema_version_check().await?;
+    if do_schema_check {
+        db.schema_version_check().await?;
+    }
 
     Ok(db)
 }
@@ -96,6 +103,6 @@ mod test {
     /// Check if the schema version in the DB is up to date.
     #[tokio::test]
     async fn check_schema_version() {
-        establish_connection(None).await.unwrap();
+        establish_connection(None, true).await.unwrap();
     }
 }

--- a/catalyst-gateway/bin/src/event_db/mod.rs
+++ b/catalyst-gateway/bin/src/event_db/mod.rs
@@ -58,7 +58,7 @@ pub(crate) async fn establish_connection(url: Option<&str>) -> Result<EventDB, E
     let database_url = match url {
         Some(url) => url.to_string(),
         // If the Database connection URL is not supplied, try and get from the env var.
-        None => std::env::var(DATABASE_URL_ENVVAR)?,
+        None => std::env::var(DATABASE_URL_ENVVAR).map_err(|_| Error::NoDatabaseUrl)?,
     };
 
     let config = tokio_postgres::config::Config::from_str(&database_url)?;

--- a/catalyst-gateway/bin/src/event_db/queries/event/ballot.rs
+++ b/catalyst-gateway/bin/src/event_db/queries/event/ballot.rs
@@ -240,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_ballot_test() {
-        let event_db = establish_connection(None).await.unwrap();
+        let event_db = establish_connection(None, true).await.unwrap();
 
         let ballot = event_db
             .get_ballot(EventId(1), ObjectiveId(1), ProposalId(10))
@@ -273,7 +273,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_objective_ballots_test() {
-        let event_db = establish_connection(None).await.unwrap();
+        let event_db = establish_connection(None, true).await.unwrap();
 
         let ballots = event_db
             .get_objective_ballots(EventId(1), ObjectiveId(1))
@@ -340,7 +340,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_event_ballots_test() {
-        let event_db = establish_connection(None).await.unwrap();
+        let event_db = establish_connection(None, true).await.unwrap();
 
         let ballots = event_db.get_event_ballots(EventId(1)).await.unwrap();
 

--- a/catalyst-gateway/bin/src/event_db/queries/event/proposal.rs
+++ b/catalyst-gateway/bin/src/event_db/queries/event/proposal.rs
@@ -150,7 +150,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_proposal_test() {
-        let event_db = establish_connection(None).await.unwrap();
+        let event_db = establish_connection(None, true).await.unwrap();
 
         let proposal = event_db
             .get_proposal(EventId(1), ObjectiveId(1), ProposalId(10))
@@ -192,7 +192,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_proposals_test() {
-        let event_db = establish_connection(None).await.unwrap();
+        let event_db = establish_connection(None, true).await.unwrap();
 
         let proposal_summary = event_db
             .get_proposals(EventId(1), ObjectiveId(1), None, None)

--- a/catalyst-gateway/bin/src/event_db/queries/event/review.rs
+++ b/catalyst-gateway/bin/src/event_db/queries/event/review.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_reviews_test() {
-        let event_db = establish_connection(None).await.unwrap();
+        let event_db = establish_connection(None, true).await.unwrap();
 
         let reviews = event_db
             .get_reviews(EventId(1), ObjectiveId(1), ProposalId(10), None, None)

--- a/catalyst-gateway/bin/src/event_db/queries/mod.rs
+++ b/catalyst-gateway/bin/src/event_db/queries/mod.rs
@@ -7,7 +7,7 @@ use self::{
     registration::RegistrationQueries,
     search::SearchQueries,
 };
-use crate::event_db::EventDB;
+use crate::event_db::{schema_check::SchemaVersion, EventDB};
 
 pub(crate) mod event;
 pub(crate) mod registration;
@@ -26,6 +26,7 @@ pub(crate) trait EventDbQueries:
     + SearchQueries
     + BallotQueries
     + vit_ss::fund::VitSSFundQueries
+    + SchemaVersion
 {
 }
 

--- a/catalyst-gateway/bin/src/event_db/types/proposal.rs
+++ b/catalyst-gateway/bin/src/event_db/types/proposal.rs
@@ -1,5 +1,5 @@
 //! Proposal Types
-//! 
+//!
 use serde_json::Value;
 
 #[allow(clippy::module_name_repetitions)]

--- a/catalyst-gateway/bin/src/service/api/health/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/health/mod.rs
@@ -1,7 +1,9 @@
 //! Health Endpoints
 //!
-use crate::service::common::tags::ApiTags;
+use crate::{service::common::tags::ApiTags, state::State};
+use poem::web::Data;
 use poem_openapi::OpenApi;
+use std::sync::Arc;
 
 mod live_get;
 mod ready_get;
@@ -48,8 +50,8 @@ impl HealthApi {
     /// * 500 Server Error - If anything within this function fails unexpectedly.
     /// * 503 Service Unavailable - Service is not ready, requests to other
     /// endpoints should not be sent until the service becomes ready.
-    async fn ready_get(&self) -> ready_get::AllResponses {
-        ready_get::endpoint().await
+    async fn ready_get(&self, state: Data<&Arc<State>>) -> ready_get::AllResponses {
+        ready_get::endpoint(state).await
     }
 
     #[oai(path = "/live", method = "get", operation_id = "healthLive")]

--- a/catalyst-gateway/bin/src/state/mod.rs
+++ b/catalyst-gateway/bin/src/state/mod.rs
@@ -1,7 +1,7 @@
 //! Shared state used by all endpoints.
 //!
 use crate::cli::Error;
-use crate::event_db::queries::EventDbQueries;
+use crate::event_db::{establish_connection, queries::EventDbQueries};
 use std::sync::Arc;
 
 /// Global State of the service
@@ -17,11 +17,8 @@ pub(crate) struct State {
 impl State {
     /// Create a new global [`State`]
     pub(crate) async fn new(database_url: Option<String>) -> Result<Self, Error> {
-        // Get a connection to the Database.
-        let event_db = match database_url.clone() {
-            Some(url) => Arc::new(crate::event_db::establish_connection(Some(url.as_str())).await?),
-            None => Arc::new(crate::event_db::establish_connection(None).await?),
-        };
+        // Get a configured pool to the Database.
+        let event_db = Arc::new(establish_connection(database_url, false).await?);
 
         let state = Self { event_db };
 


### PR DESCRIPTION
# Description

Ensure DB Schema mismatch between the service and DB does not cause the service to fail.


## Related Issue(s)

List the issue numbers related to this pull request.

Resolves https://github.com/input-output-hk/catalyst-voices/issues/46

## Description of Changes

Modifies `GET api/health/ready` to validate that not only is the database connected, but that the schema version is the one the application expects.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
