### PR TITLE
feat: add `CATALYST_CI_VER` as an earthly arg, and specify it in `.arg` file

### DIFF
--- a/.arg
+++ b/.arg
@@ -1,0 +1,1 @@
+CATALYST_CI_VER=v2.0.3

--- a/Earthfile
+++ b/Earthfile
@@ -5,21 +5,36 @@ FROM debian:stable-slim
 
 # cspell: words livedocs sitedocs
 
+# Markdown check in this repo.
+# Arguments:
+#  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
+#    (Does not need to specify it directrly it is specified in `.arg` file)
 markdown-check:
-    # Check Markdown in this repo.
+    ARG --required CATALYST_CI_VER
+
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v1.3.0+MDLINT_LOCALLY --src=$(echo ${PWD})
+    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:$CATALYST_CI_VER+MDLINT_LOCALLY --src=$(echo ${PWD})
 
+# Markdown check fix in this repo.
+# Arguments:
+#  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
+#    (Does not need to specify it directrly it is specified in `.arg` file)
 markdown-check-fix:
-    # Check Markdown in this repo.
+    ARG --required CATALYST_CI_VER
+
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v1.3.0+MDLINT_LOCALLY --src=$(echo ${PWD}) --fix=--fix
+    DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:$CATALYST_CI_VER+MDLINT_LOCALLY --src=$(echo ${PWD}) --fix=--fix
 
+# Check spelling in this repo.
+# Arguments:
+#  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
+#    (Does not need to specify it directrly it is specified in `.arg` file)
 spell-check:
-    # Check spelling in this repo.
+    ARG --required CATALYST_CI_VER
+
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:v1.3.0+CSPELL_LOCALLY --src=$(echo ${PWD})
+    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:$CATALYST_CI_VER+CSPELL_LOCALLY --src=$(echo ${PWD})
  

--- a/Earthfile
+++ b/Earthfile
@@ -10,7 +10,7 @@ FROM debian:stable-slim
 #  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
 #    (Does not need to specify it directrly it is specified in `.arg` file)
 markdown-check:
-    ARG --required CATALYST_CI_VER
+    ARG CATALYST_CI_VER
 
     LOCALLY
 
@@ -21,7 +21,7 @@ markdown-check:
 #  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
 #    (Does not need to specify it directrly it is specified in `.arg` file)
 markdown-check-fix:
-    ARG --required CATALYST_CI_VER
+    ARG CATALYST_CI_VER
 
     LOCALLY
 
@@ -32,7 +32,7 @@ markdown-check-fix:
 #  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
 #    (Does not need to specify it directrly it is specified in `.arg` file)
 spell-check:
-    ARG --required CATALYST_CI_VER
+    ARG CATALYST_CI_VER
 
     LOCALLY
 

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -3,33 +3,48 @@ VERSION 0.7
 #cspell: words rustup readelf nextest testci testdocs rustfmt toolsets USERARCH
 
 # Set up our target toolchains, and copy our files.
+# Arguments:
+#  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
+#    (Does not need to specify it directrly it is specified in `.arg` file)
 builder:
-    FROM github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+rust-base
+    ARG --required CATALYST_CI_VER
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+SETUP --toolchain=rust-toolchain.toml
+    FROM github.com/input-output-hk/catalyst-ci/earthly/rust:$CATALYST_CI_VER+rust-base
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+CP_SRC --src=".cargo .config Cargo.* clippy.toml deny.toml rustfmt.toml bin crates"
+    DO github.com/input-output-hk/catalyst-ci/earthly/rust:$CATALYST_CI_VER+SETUP --toolchain=rust-toolchain.toml
+
+    DO github.com/input-output-hk/catalyst-ci/earthly/rust:$CATALYST_CI_VER+CP_SRC --src=".cargo .config Cargo.* clippy.toml deny.toml rustfmt.toml bin crates"
 
 # Test rust build container - Use best architecture host tools.
+# Arguments:
+#  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
+#    (Does not need to specify it directrly it is specified in `.arg` file)
 check-hosted:
+    ARG --required CATALYST_CI_VER
+
     FROM +builder
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+CHECK
+    DO github.com/input-output-hk/catalyst-ci/earthly/rust:$CATALYST_CI_VER+CHECK
 
 # Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.
 check-all-hosts:    
     BUILD --platform=linux/amd64 --platform=linux/arm64 +check-hosted
 
+# Arguments:
+#  * TARGETPLATFORM: 
+#  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
+#    (Does not need to specify it directrly it is specified in `.arg` file)
 build-hosted:
     ARG TARGETPLATFORM
+    ARG --required CATALYST_CI_VER
 
     # Build the service
     FROM +builder
  
     RUN /scripts/std_build.sh
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/rust:v2.0.3+SMOKE_TEST --bin=cat-gateway
+    DO github.com/input-output-hk/catalyst-ci/earthly/rust:CATALYST_CI_VER+SMOKE_TEST --bin=cat-gateway
 
     SAVE ARTIFACT target/$TARGETARCH/doc doc
     SAVE ARTIFACT target/$TARGETARCH/release/cat-gateway cat-gateway

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -44,7 +44,7 @@ build-hosted:
  
     RUN /scripts/std_build.sh
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/rust:CATALYST_CI_VER+SMOKE_TEST --bin=cat-gateway
+    DO github.com/input-output-hk/catalyst-ci/earthly/rust:$CATALYST_CI_VER+SMOKE_TEST --bin=cat-gateway
 
     SAVE ARTIFACT target/$TARGETARCH/doc doc
     SAVE ARTIFACT target/$TARGETARCH/release/cat-gateway cat-gateway

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -7,7 +7,7 @@ VERSION 0.7
 #  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
 #    (Does not need to specify it directrly it is specified in `.arg` file)
 builder:
-    ARG --required CATALYST_CI_VER
+    ARG CATALYST_CI_VER
 
     FROM github.com/input-output-hk/catalyst-ci/earthly/rust:$CATALYST_CI_VER+rust-base
 
@@ -20,7 +20,7 @@ builder:
 #  * CATALYST_CI_VER: specific version of the `github.com/input-output-hk/catalyst-ci` dep.
 #    (Does not need to specify it directrly it is specified in `.arg` file)
 check-hosted:
-    ARG --required CATALYST_CI_VER
+    ARG CATALYST_CI_VER
 
     FROM +builder
 
@@ -37,7 +37,7 @@ check-all-hosts:
 #    (Does not need to specify it directrly it is specified in `.arg` file)
 build-hosted:
     ARG TARGETPLATFORM
-    ARG --required CATALYST_CI_VER
+    ARG CATALYST_CI_VER
 
     # Build the service
     FROM +builder


### PR DESCRIPTION
# Description

Added for every Earthly target which uses `github.com/input-output-hk/catalyst-ci` repo as a dependency `CATALYST_CI_VER` arg, and specified it for the project in `.arg` file.

Unfortunately it is not a rock solid solution and it has some implications, because it is needed to run any earhtly target from the root dir.
When run earthly target directly from the catalyst-gateway dir .arg does not propagate in this case, so it will use just the latest version of catalyst-ci.