### PR TITLE
chore(gateway): Move metadata to the workspace for cat-gateway

### DIFF
--- a/catalyst-gateway/Cargo.toml
+++ b/catalyst-gateway/Cargo.toml
@@ -8,7 +8,13 @@ members = [
 [workspace.package]
 edition = "2021"
 version = "0.0.1"
-authors = []
+authors = [
+    "Steven Johnson <steven.johnson@iohk.io>"
+]
+rust-version = "1.73"
+homepage = "https://input-output-hk.github.io/catalyst-voices"
+repository = "https://github.com/input-output-hk/catalyst-voices"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 

--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cat-gateway"
 description = "The Catalyst Data Gateway"
-license = "Apache-2.0"
-repository = "https://github.com/input-output-hk/catalyst-voices"
 keywords = ["cardano", "catalyst", "gateway"]
 categories = ["command-line-utilities"]
 version.workspace = true
 authors.workspace = true
 edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [[bin]]
 name = "cat-gateway"


### PR DESCRIPTION
# Description

This is a small cleanup to consolidate project metadata into the workspace.

Developers are encouraged to add themselves to `authors` in their next PR for catalyst-gateway code.