### PR TITLE
chore(fix-stage-data-sql): Upsert event-db stage data

### DIFF
--- a/catalyst-gateway/event-db/stage_data/dev/00001_testfund_event.sql
+++ b/catalyst-gateway/event-db/stage_data/dev/00001_testfund_event.sql
@@ -51,4 +51,30 @@ INSERT INTO event (
   1,                      -- Committee Threshold
   NULL,                   -- Extra
   NULL                    -- Cast to
-);
+)
+ON CONFLICT (row_id) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  registration_snapshot_time = EXCLUDED.registration_snapshot_time,
+  snapshot_start = EXCLUDED.snapshot_start,
+  voting_power_threshold = EXCLUDED.voting_power_threshold,
+  max_voting_power_pct = EXCLUDED.max_voting_power_pct,
+  review_rewards = EXCLUDED.review_rewards,
+  start_time = EXCLUDED.start_time,
+  end_time = EXCLUDED.end_time,
+  insight_sharing_start = EXCLUDED.insight_sharing_start,
+  proposal_submission_start = EXCLUDED.proposal_submission_start,
+  refine_proposals_start = EXCLUDED.refine_proposals_start,
+  finalize_proposals_start = EXCLUDED.finalize_proposals_start,
+  proposal_assessment_start = EXCLUDED.proposal_assessment_start,
+  assessment_qa_start = EXCLUDED.assessment_qa_start,
+  voting_start = EXCLUDED.voting_start,
+  voting_end = EXCLUDED.voting_end,
+  tallying_end = EXCLUDED.tallying_end,
+  block0 = EXCLUDED.block0,
+  block0_hash = EXCLUDED.block0_hash,
+  committee_size = EXCLUDED.committee_size,
+  committee_threshold = EXCLUDED.committee_threshold,
+  extra = EXCLUDED.extra,
+  cast_to = EXCLUDED.cast_to;

--- a/catalyst-gateway/event-db/stage_data/dev/00002_testfund_ideascale_params.sql
+++ b/catalyst-gateway/event-db/stage_data/dev/00002_testfund_ideascale_params.sql
@@ -56,4 +56,5 @@ INSERT INTO config (id, id2, id3, value) VALUES (
   'ideascale_params',
   '0',
   '{"params_id": "TestFund"}'
-);
+) ON CONFLICT (id, id2, id3) DO UPDATE
+SET value = EXCLUDED.value;

--- a/catalyst-gateway/event-db/stage_data/testnet/00001_fund10_event.sql
+++ b/catalyst-gateway/event-db/stage_data/testnet/00001_fund10_event.sql
@@ -51,4 +51,30 @@ INSERT INTO event (
   1,                      -- Committee Threshold
   NULL,                   -- Extra
   NULL                    -- Cast to
-);
+)
+ON CONFLICT (row_id) DO UPDATE
+SET
+  name = EXCLUDED.name,
+  description = EXCLUDED.description,
+  registration_snapshot_time = EXCLUDED.registration_snapshot_time,
+  snapshot_start = EXCLUDED.snapshot_start,
+  voting_power_threshold = EXCLUDED.voting_power_threshold,
+  max_voting_power_pct = EXCLUDED.max_voting_power_pct,
+  review_rewards = EXCLUDED.review_rewards,
+  start_time = EXCLUDED.start_time,
+  end_time = EXCLUDED.end_time,
+  insight_sharing_start = EXCLUDED.insight_sharing_start,
+  proposal_submission_start = EXCLUDED.proposal_submission_start,
+  refine_proposals_start = EXCLUDED.refine_proposals_start,
+  finalize_proposals_start = EXCLUDED.finalize_proposals_start,
+  proposal_assessment_start = EXCLUDED.proposal_assessment_start,
+  assessment_qa_start = EXCLUDED.assessment_qa_start,
+  voting_start = EXCLUDED.voting_start,
+  voting_end = EXCLUDED.voting_end,
+  tallying_end = EXCLUDED.tallying_end,
+  block0 = EXCLUDED.block0,
+  block0_hash = EXCLUDED.block0_hash,
+  committee_size = EXCLUDED.committee_size,
+  committee_threshold = EXCLUDED.committee_threshold,
+  extra = EXCLUDED.extra,
+  cast_to = EXCLUDED.cast_to;

--- a/catalyst-gateway/event-db/stage_data/testnet/00002_fund10_ideascale_params.sql
+++ b/catalyst-gateway/event-db/stage_data/testnet/00002_fund10_ideascale_params.sql
@@ -56,4 +56,5 @@ INSERT INTO config (id, id2, id3, value) VALUES (
   'ideascale_params',
   '10',
   '{"params_id": "F10"}'
-);
+) ON CONFLICT (id, id2, id3) DO UPDATE
+SET value = EXCLUDED.value;


### PR DESCRIPTION
# Description

Fix duplicate key errors by changing stage_data SQL statements to upsert event and config data instead of inserting.

Same change I did in `catalyst-core` https://github.com/input-output-hk/catalyst-core/pull/624.

## Related Issue(s)

https://github.com/input-output-hk/catalyst-core/issues/500

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
