### PR TITLE
fix: modify the spellcheck from local to call spellcheck in `catalyst-ci`

### DIFF
--- a/.vscode/tasks.recommended.json
+++ b/.vscode/tasks.recommended.json
@@ -40,9 +40,9 @@
 		{
 			"label": "CI - Recursive Spell Check",
 			"type": "shell",
-			"command": "earthly -P +spell-check",
+			"command": "earthly -P +check-spelling",
 			"problemMatcher": {
-				"owner": "spell-check",
+				"owner": "check-spelling",
 				"pattern": {
 					"regexp": "([\\S+]+):(\\d+):(\\d+)\\s-\\s(.+)",
 					"file": 1,

--- a/Earthfile
+++ b/Earthfile
@@ -19,7 +19,6 @@ markdown-check-fix:
 
 # spell-check Check spelling in this repo locally.
 spell-check:
-    # Check spelling in this repo.
     LOCALLY
 
     DO github.com/input-output-hk/catalyst-ci/earthly/cspell:v2.0.10+CSPELL_LOCALLY --src=$(echo ${PWD})

--- a/Earthfile
+++ b/Earthfile
@@ -21,7 +21,14 @@ spell-check:
     # Check spelling in this repo.
     LOCALLY
 
-    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:v2.0.9+CSPELL_LOCALLY --src=$(echo ${PWD})
+    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:v2.0.10+CSPELL_LOCALLY --src=$(echo ${PWD})
+
+# check-spelling Check spelling in this repo inside a container.
+check-spelling:
+    DO github.com/input-output-hk/catalyst-ci/earthly/cspell:v2.0.10+CHECK
+
+check:
+    BUILD +check-spelling
  
 repo-docs:
     # Create artifacts of extra files we embed inside the documentation when its built.

--- a/Earthfile
+++ b/Earthfile
@@ -17,6 +17,7 @@ markdown-check-fix:
 
     DO github.com/input-output-hk/catalyst-ci/earthly/mdlint:v2.0.9+MDLINT_LOCALLY --src=$(echo ${PWD}) --fix=--fix
 
+# spell-check Check spelling in this repo locally.
 spell-check:
     # Check spelling in this repo.
     LOCALLY


### PR DESCRIPTION
# Description

Modify the spellcheck from local to call spellcheck in `catalyst-ci`.

## Related Issue(s)

> Closes #175

## Description of Changes

* added a remote target `check-spelling`
* updated `catalylst-ci` version for `check-spelling` from `v2.0.9` to `v2.0.10`

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
