### PR TITLE
feat: allow except tests

### DIFF
--- a/catalyst-gateway/clippy.toml
+++ b/catalyst-gateway/clippy.toml
@@ -1,1 +1,1 @@
-allow-unwrap-in-tests = true
+allow-except-in-tests = true

--- a/catalyst-gateway/clippy.toml
+++ b/catalyst-gateway/clippy.toml
@@ -1,1 +1,1 @@
-allow-except-in-tests = true
+allow-expect-in-tests = true


### PR DESCRIPTION
# Description

This PR changes the clippy lint from allow-unwrap-in-tests to allow-except-in-tests, to make sure the tests are better commented

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
