### PR TITLE
chore: bump kotlin version

### DIFF
--- a/catalyst_voices/android/build.gradle
+++ b/catalyst_voices/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
-  bump kotlin version 1.9.22 to fix compatibility issues with the latest Flutter version