### PR TITLE
feat: Printing cat gateway logs in case of failure

### DIFF
--- a/catalyst-gateway/tests/Earthfile
+++ b/catalyst-gateway/tests/Earthfile
@@ -43,6 +43,8 @@ test-fuzzer-api:
     END
     IF [ -f fail ]
         RUN echo "Schemathesis run failed" && \
+            echo "Printing catalyst gateway logs..." && \
+            jq --color-output . cat-gateway.log cat-gateway.log && \
             exit 1
     END
 


### PR DESCRIPTION
# Description

This PR adds a line to pretty print the cat gateway logs on screen in case of schemathesis test fail

## Related Issue(s)

List the issue numbers related to this pull request.


## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #123, #456

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
