### PR TITLE
fix: Adds --if-exists to save artifacts

### DIFF
--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -34,8 +34,8 @@ build:
         RUN /scripts/std_build.py   --cov_report="coverage-report.info" \
                                     --bins="cat-gateway/cat-gateway"
     FINALLY
-        SAVE ARTIFACT target/nextest/ci/junit.xml AS LOCAL cat-gateway.junit-report.xml
-        SAVE ARTIFACT coverage-report.info AS LOCAL cat-gateway.coverage-report.info
+        SAVE ARTIFACT --if-exists target/nextest/ci/junit.xml AS LOCAL cat-gateway.junit-report.xml
+        SAVE ARTIFACT --if-exists coverage-report.info AS LOCAL cat-gateway.coverage-report.info
     END
     RUN ./target/$TARGETARCH/release/cat-gateway docs ./target/$TARGETARCH/doc/cat-gateway-api.json
     SAVE ARTIFACT target/$TARGETARCH/doc doc
@@ -56,7 +56,7 @@ package-cat-gateway:
     COPY +build/cat-gateway .
     ENTRYPOINT ./cat-gateway run --address $address --database-url $db_url --log-level $log_level
     SAVE IMAGE cat-gateway:$tag
-    
+
 # Publish packages if all integration tests have passed. (Failure to pass tests will prevent packages being published.)
 # publish:
 #    FROM scratch


### PR DESCRIPTION
# Description

Adding `--if-exists` to `save artifact` after the build script is run. This is because is something fails in the build script earthly fails saying it cannot find the artifact to save. For example when the tests fail the coverage file is not produced 

## Related Issue(s)

List the issue numbers related to this pull request.

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #123, #456

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
