### PR TITLE
build(frontend): Relax flutter/dart version requirements to last minor release

### DIFF
--- a/catalyst_voices/packages/catalyst_voices_assets/example/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_assets/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
   catalyst_voices_assets:

--- a/catalyst_voices/packages/catalyst_voices_assets/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_assets/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
   flutter:

--- a/catalyst_voices/packages/catalyst_voices_blocs/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_blocs/pubspec.yaml
@@ -5,30 +5,30 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
-    bloc: ^8.1.2
-    bloc_concurrency: ^0.2.2
-    catalyst_voices_models:
-      path: ../catalyst_voices_models
-    catalyst_voices_repositories:
-     path: ../catalyst_voices_repositories
-    catalyst_voices_services:
-     path: ../catalyst_voices_services
-    catalyst_voices_view_models:
-     path: ../catalyst_voices_view_models
-    collection: ^1.17.1
-    equatable: ^2.0.5
-    flutter:
-      sdk: flutter
-    formz: ^0.7.0
-    get_it: ^7.6.7
-    meta: ^1.10.0
-    result_type: ^0.2.0
+  bloc: ^8.1.2
+  bloc_concurrency: ^0.2.2
+  catalyst_voices_models:
+    path: ../catalyst_voices_models
+  catalyst_voices_repositories:
+    path: ../catalyst_voices_repositories
+  catalyst_voices_services:
+    path: ../catalyst_voices_services
+  catalyst_voices_view_models:
+    path: ../catalyst_voices_view_models
+  collection: ^1.17.1
+  equatable: ^2.0.5
+  flutter:
+    sdk: flutter
+  formz: ^0.7.0
+  get_it: ^7.6.7
+  meta: ^1.10.0
+  result_type: ^0.2.0
 
 dev_dependencies:
-   bloc_test: ^9.1.4
-   catalyst_analysis:
+  bloc_test: ^9.1.4
+  catalyst_analysis:
     path: ../../../catalyst_voices_packages/catalyst_analysis
-   test: ^1.24.9
+  test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_localization/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_localization/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
   flutter:

--- a/catalyst_voices/packages/catalyst_voices_repositories/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_repositories/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
   catalyst_voices_models:
@@ -18,6 +18,6 @@ dependencies:
   rxdart: ^0.27.7
 
 dev_dependencies:
-   catalyst_analysis:
+  catalyst_analysis:
     path: ../../../catalyst_voices_packages/catalyst_analysis
-   test: ^1.24.9
+  test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_services/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_services/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
   chopper: ^7.2.0

--- a/catalyst_voices/packages/catalyst_voices_shared/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_shared/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: '>=3.3.3 <4.0.0'
-  flutter: 3.19.5
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: 3.19.0
 
 dependencies:
   flutter:
@@ -13,9 +13,8 @@ dependencies:
   web: ^0.5.0
 
 dev_dependencies:
-   catalyst_analysis:
+  catalyst_analysis:
     path: ../../../catalyst_voices_packages/catalyst_analysis
-   flutter_test:
-      sdk: flutter
-   test: ^1.24.9
-
+  flutter_test:
+    sdk: flutter
+  test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_view_models/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_view_models/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.2.6 <4.0.0"
-  flutter: 3.19.5
+  flutter: 3.19.0
 
 dependencies:
   equatable: ^2.0.5
@@ -14,6 +14,6 @@ dependencies:
   formz: ^0.7.0
 
 dev_dependencies:
-   catalyst_analysis:
+  catalyst_analysis:
     path: ../../../catalyst_voices_packages/catalyst_analysis
-   test: ^1.24.9
+  test: ^1.24.9

--- a/catalyst_voices/pubspec.yaml
+++ b/catalyst_voices/pubspec.yaml
@@ -4,8 +4,8 @@ version: 0.1.0+1
 publish_to: none
 
 environment:
-  sdk: '>=3.3.3 <4.0.0'
-  flutter: 3.19.5
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: 3.19.0
 
 dependencies:
   animated_text_kit: ^4.2.2
@@ -44,9 +44,9 @@ dev_dependencies:
   build_verify: ^3.1.0
   catalyst_analysis:
     git:
-        url: https://github.com/input-output-hk/catalyst-voices.git
-        path: catalyst_voices_packages/catalyst_analysis
-        ref: 3431f7b
+      url: https://github.com/input-output-hk/catalyst-voices.git
+      path: catalyst_voices_packages/catalyst_analysis
+      ref: 3431f7b
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.4.1

--- a/catalyst_voices_packages/catalyst_analysis/example/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_analysis/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: A project that showcases how to enable the recommended lints for Ca
 publish_to: none
 
 environment:
-  sdk: '>=3.3.3 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dev_dependencies:
   catalyst_analysis:

--- a/catalyst_voices_packages/catalyst_analysis/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_analysis/pubspec.yaml
@@ -3,4 +3,4 @@ version: 1.0.0
 description: Lint rules for Dart and Flutter used internally at Catalyst.
 
 environment:
-  sdk: '>=3.3.3 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'

--- a/melos.yaml
+++ b/melos.yaml
@@ -12,8 +12,8 @@ command:
     workspaceChangelog: true
   bootstrap:
     environment:
-      sdk: '>=3.3.0 <4.0.0'
-      flutter: 3.19.5
+      sdk: ">=3.3.0 <4.0.0"
+      flutter: 3.19.0
     dependencies:
       bloc_concurrency: ^0.2.2
       bloc: ^8.1.2
@@ -33,8 +33,8 @@ scripts:
     description: Run all static analysis checks.
 
   format:
-      run: melos exec dart format . --fix
-      description: Run `dart format` for all packages.
+    run: melos exec dart format . --fix
+    description: Run `dart format` for all packages.
 
   format-check:
     run: melos exec dart format . --set-exit-if-changed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: catalyst_voices_workspace
 
 environment:
-  sdk: '>=3.3.3 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dev_dependencies:
   melos: ^5.2.2


### PR DESCRIPTION
# Description

This just relaxes the tooling versions to the last minor release rather than the latest point release.

This PR also includes changes to the YML indenting because it seemed inconsistently applied.
These YAML indenting changes were driven by auto-format.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings
* [x] New and existing unit tests pass locally with my changes

