### PR TITLE
refactor: update schema_validation check

### DIFF
--- a/catalyst-gateway/bin/src/cli.rs
+++ b/catalyst-gateway/bin/src/cli.rs
@@ -58,7 +58,7 @@ impl Cli {
                 let machine_id = settings.follower_settings.machine_uid;
 
                 let state = Arc::new(State::new(Some(settings.database_url)).await?);
-                let event_db = state.event_db()?;
+                let event_db = state.event_db();
 
                 tokio::spawn(async move {
                     match service::run(&settings.docs_settings, state.clone()).await {

--- a/catalyst-gateway/bin/src/event_db/error.rs
+++ b/catalyst-gateway/bin/src/event_db/error.rs
@@ -1,5 +1,4 @@
 //! Database Errors
-use std::env::VarError;
 
 use bb8::RunError;
 
@@ -26,9 +25,6 @@ pub(crate) enum Error {
     /// Unknown error
     #[error("error: {0}")]
     Unknown(String),
-    /// Variable error
-    #[error(transparent)]
-    VarErr(#[from] VarError),
     /// No config
     #[error("No config")]
     NoConfig,

--- a/catalyst-gateway/bin/src/event_db/mod.rs
+++ b/catalyst-gateway/bin/src/event_db/mod.rs
@@ -54,9 +54,7 @@ pub(crate) struct EventDB {
 ///
 /// The env var "`DATABASE_URL`" can be set directly as an anv var, or in a
 /// `.env` file.
-pub(crate) async fn establish_connection(
-    url: Option<String>, do_schema_check: bool,
-) -> Result<EventDB, Error> {
+pub(crate) async fn establish_connection(url: Option<String>) -> Result<EventDB, Error> {
     // Support env vars in a `.env` file,  doesn't need to exist.
     dotenv().ok();
 
@@ -72,11 +70,5 @@ pub(crate) async fn establish_connection(
 
     let pool = Pool::builder().build(pg_mgr).await?;
 
-    let db = EventDB { pool };
-
-    if do_schema_check {
-        db.schema_version_check().await?;
-    }
-
-    Ok(db)
+    Ok(EventDB { pool })
 }

--- a/catalyst-gateway/bin/src/service/api/cardano/staked_ada_get.rs
+++ b/catalyst-gateway/bin/src/service/api/cardano/staked_ada_get.rs
@@ -2,12 +2,11 @@
 
 use poem_extensions::{
     response,
-    UniResponse::{T200, T400, T404, T503},
+    UniResponse::{T200, T400, T404},
 };
 use poem_openapi::payload::Json;
 
 use crate::{
-    cli::Error,
     event_db::{error::Error as DBError, follower::SlotNumber},
     service::{
         common::{
@@ -22,7 +21,7 @@ use crate::{
         },
         utilities::check_network,
     },
-    state::{SchemaVersionStatus, State},
+    state::State,
 };
 
 /// # All Responses
@@ -39,19 +38,7 @@ pub(crate) async fn endpoint(
     state: &State, stake_address: StakeAddress, provided_network: Option<Network>,
     slot_num: Option<SlotNumber>,
 ) -> AllResponses {
-    let event_db = match state.event_db() {
-        Ok(event_db) => event_db,
-        Err(Error::EventDb(DBError::MismatchedSchema { was, expected })) => {
-            tracing::error!(
-                expected = expected,
-                current = was,
-                "DB schema version status mismatch"
-            );
-            state.set_schema_version_status(SchemaVersionStatus::Mismatch);
-            return T503(ServiceUnavailable);
-        },
-        Err(err) => return server_error_response!("{err}"),
-    };
+    let event_db = state.event_db();
 
     let date_time = slot_num.unwrap_or(SlotNumber::MAX);
     let stake_credential = stake_address.payload().as_hash().to_vec();

--- a/catalyst-gateway/bin/src/service/api/cardano/sync_state_get.rs
+++ b/catalyst-gateway/bin/src/service/api/cardano/sync_state_get.rs
@@ -2,12 +2,11 @@
 
 use poem_extensions::{
     response,
-    UniResponse::{T200, T404, T503},
+    UniResponse::{T200, T404},
 };
 use poem_openapi::payload::Json;
 
 use crate::{
-    cli::Error,
     event_db::error::Error as DBError,
     service::common::{
         objects::cardano::{network::Network, sync_state::SyncState},
@@ -17,7 +16,7 @@ use crate::{
             resp_5xx::{server_error_response, ServerError, ServiceUnavailable},
         },
     },
-    state::{SchemaVersionStatus, State},
+    state::State,
 };
 
 /// # All Responses
@@ -32,19 +31,7 @@ pub(crate) type AllResponses = response! {
 /// # GET `/sync_state`
 #[allow(clippy::unused_async)]
 pub(crate) async fn endpoint(state: &State, network: Option<Network>) -> AllResponses {
-    let event_db = match state.event_db() {
-        Ok(event_db) => event_db,
-        Err(Error::EventDb(DBError::MismatchedSchema { was, expected })) => {
-            tracing::error!(
-                expected = expected,
-                current = was,
-                "DB schema version status mismatch"
-            );
-            state.set_schema_version_status(SchemaVersionStatus::Mismatch);
-            return T503(ServiceUnavailable);
-        },
-        Err(err) => return server_error_response!("{err}"),
-    };
+    let event_db = state.event_db();
 
     let network = network.unwrap_or(Network::Mainnet);
 

--- a/catalyst-gateway/bin/src/service/api/health/ready_get.rs
+++ b/catalyst-gateway/bin/src/service/api/health/ready_get.rs
@@ -16,7 +16,7 @@ use crate::{
         resp_4xx::ApiValidationError,
         resp_5xx::{server_error_response, ServerError, ServiceUnavailable},
     },
-    state::{SchemaVersionStatus, State},
+    state::State,
 };
 
 /// All responses
@@ -56,7 +56,6 @@ pub(crate) async fn endpoint(state: Data<&Arc<State>>) -> AllResponses {
     match state.schema_version_check().await {
         Ok(_) => {
             tracing::debug!("DB schema version status ok");
-            state.set_schema_version_status(SchemaVersionStatus::Ok);
             T204(NoContent)
         },
         Err(Error::EventDb(DBError::MismatchedSchema { was, expected })) => {
@@ -65,7 +64,6 @@ pub(crate) async fn endpoint(state: Data<&Arc<State>>) -> AllResponses {
                 current = was,
                 "DB schema version status mismatch"
             );
-            state.set_schema_version_status(SchemaVersionStatus::Mismatch);
             T503(ServiceUnavailable)
         },
         Err(Error::EventDb(DBError::TimedOut)) => T503(ServiceUnavailable),

--- a/catalyst-gateway/bin/src/service/mod.rs
+++ b/catalyst-gateway/bin/src/service/mod.rs
@@ -23,9 +23,6 @@ pub(crate) enum Error {
     /// An IO error has occurred
     #[error(transparent)]
     Io(#[from] std::io::Error),
-    /// A mismatch in the expected `EventDB` schema version
-    #[error("expected schema version mismatch")]
-    SchemaVersionMismatch,
 }
 
 /// # Run Catalyst Gateway Service.

--- a/catalyst-gateway/bin/src/service/utilities/middleware/schema_validation.rs
+++ b/catalyst-gateway/bin/src/service/utilities/middleware/schema_validation.rs
@@ -11,10 +11,7 @@ use std::sync::Arc;
 
 use poem::{web::Data, Endpoint, EndpointExt, Middleware, Request, Result};
 
-use crate::{
-    service::common::responses::resp_5xx::ServiceUnavailable,
-    state::{SchemaVersionStatus, State},
-};
+use crate::{service::common::responses::resp_5xx::ServiceUnavailable, state::State};
 
 /// A middleware that raises an error  with `ServiceUnavailable` and 503 status code
 /// if a DB schema version mismatch is found the existing `State`.
@@ -44,7 +41,7 @@ impl<E: Endpoint> Endpoint for SchemaVersionValidationImpl<E> {
             // if so, return the `ServiceUnavailable` error, which implements
             // `ResponseError`, with status code `503`.
             // Otherwise, return the endpoint as usual.
-            if state.is_schema_version_status(&SchemaVersionStatus::Mismatch) {
+            if state.schema_version_check().await.is_err() {
                 return Err(ServiceUnavailable.into());
             }
         }

--- a/catalyst-gateway/bin/src/service/utilities/middleware/schema_validation.rs
+++ b/catalyst-gateway/bin/src/service/utilities/middleware/schema_validation.rs
@@ -41,7 +41,7 @@ impl<E: Endpoint> Endpoint for SchemaVersionValidationImpl<E> {
             // if so, return the `ServiceUnavailable` error, which implements
             // `ResponseError`, with status code `503`.
             // Otherwise, return the endpoint as usual.
-            if state.schema_version_check().await.is_err() {
+            if state.event_db().schema_version_check().await.is_err() {
                 return Err(ServiceUnavailable.into());
             }
         }

--- a/catalyst-gateway/bin/src/state/mod.rs
+++ b/catalyst-gateway/bin/src/state/mod.rs
@@ -37,9 +37,4 @@ impl State {
     pub(crate) fn event_db(&self) -> Arc<EventDB> {
         self.event_db.clone()
     }
-
-    /// Check the DB schema version matches the one expected by the service.
-    pub(crate) async fn schema_version_check(&self) -> Result<i32, Error> {
-        Ok(self.event_db.schema_version_check().await?)
-    }
 }

--- a/catalyst-gateway/bin/src/state/mod.rs
+++ b/catalyst-gateway/bin/src/state/mod.rs
@@ -1,21 +1,10 @@
 //! Shared state used by all endpoints.
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::Arc;
 
 use crate::{
     cli::Error,
     event_db::{establish_connection, EventDB},
-    service::Error as ServiceError,
 };
-
-/// The status of the expected DB schema version.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum SchemaVersionStatus {
-    /// The current DB schema version matches what is expected.
-    Ok,
-    /// There is a mismatch between the current DB schema version
-    /// and what is expected.
-    Mismatch,
-}
 
 /// Global State of the service
 pub(crate) struct State {
@@ -27,22 +16,15 @@ pub(crate) struct State {
     // Private need to get it with a function.
     event_db: Arc<EventDB>, /* This needs to be obsoleted, we want the DB
                              * to be able to be down. */
-    /// Status of the last DB schema version check.
-    schema_version_status: Mutex<SchemaVersionStatus>,
 }
 
 impl State {
     /// Create a new global [`State`]
     pub(crate) async fn new(database_url: Option<String>) -> Result<Self, Error> {
         // Get a configured pool to the Database, runs schema version check internally.
-        let event_db = Arc::new(establish_connection(database_url, false).await?);
+        let event_db = Arc::new(establish_connection(database_url).await?);
 
-        let state = Self {
-            event_db,
-            // It is safe to assume that the schema version matches if `event_db` doesn't fail,
-            // due to the interior check ran by `establish_connection`.
-            schema_version_status: Mutex::new(SchemaVersionStatus::Ok),
-        };
+        let state = Self { event_db };
 
         // We don't care if this succeeds or not.
         // We just try our best to connect to the event DB.
@@ -52,49 +34,12 @@ impl State {
     }
 
     /// Get the reference to the database connection pool for `EventDB`.
-    pub(crate) fn event_db(&self) -> Result<Arc<EventDB>, Error> {
-        let guard = self.schema_version_status_lock();
-        match *guard {
-            SchemaVersionStatus::Ok => Ok(self.event_db.clone()),
-            SchemaVersionStatus::Mismatch => Err(ServiceError::SchemaVersionMismatch.into()),
-        }
+    pub(crate) fn event_db(&self) -> Arc<EventDB> {
+        self.event_db.clone()
     }
 
     /// Check the DB schema version matches the one expected by the service.
     pub(crate) async fn schema_version_check(&self) -> Result<i32, Error> {
         Ok(self.event_db.schema_version_check().await?)
-    }
-
-    /// Compare the `State`'s inner value with a given `&SchemaVersionStatus`, returns
-    /// `bool`.
-    pub(crate) fn is_schema_version_status(&self, svs: &SchemaVersionStatus) -> bool {
-        let guard = self.schema_version_status_lock();
-        &*guard == svs
-    }
-
-    /// Set the state's `SchemaVersionStatus`.
-    pub(crate) fn set_schema_version_status(&self, svs: SchemaVersionStatus) {
-        let mut guard = self.schema_version_status_lock();
-        tracing::debug!(
-            status = format!("{:?}", svs),
-            "db schema version status was set"
-        );
-        *guard = svs;
-    }
-
-    /// Get the `MutexGuard<SchemaVersionStatus>` from inner the variable.
-    ///
-    /// Handle poisoned mutex by recovering the guard, and tracing the error.
-    fn schema_version_status_lock(&self) -> MutexGuard<SchemaVersionStatus> {
-        match self.schema_version_status.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => {
-                tracing::error!(
-                    error = format!("{:?}", poisoned),
-                    "recovering DB schema version status fom poisoned mutex"
-                );
-                poisoned.into_inner()
-            },
-        }
     }
 }

--- a/catalyst-gateway/tests/api_tests/api_tests/__init__.py
+++ b/catalyst-gateway/tests/api_tests/api_tests/__init__.py
@@ -98,40 +98,44 @@ def sync_to(network: str, slot_num: int, timeout: int):
     while True:
         # Get current sync state
         sync_state = get_sync_state(network=network)
-        if last_slot_num == -1:
-            first_slot_num = sync_state["slot_number"]
 
-        # If we reached our target sync state, then continue the test
-        if sync_state != None and sync_state["slot_number"] >= slot_num:
-            logger.info(f"cat-gateway synced to target slot {slot_num}: {sync_state}")
-            break
+        if sync_state != None:
+            if last_slot_num == -1:
+                first_slot_num = sync_state["slot_number"]
 
-        # If the sync state changed since last time, reset the timeout and log the new sync state
-        if last_slot_num != sync_state["slot_number"]:
-            slots_last_interval = (sync_state["slot_number"] - last_slot_num) + 1
-            last_interval = time.time() - start_time
-            sps_last_interval = slots_last_interval / max(last_interval, 1.0)
+            # If we reached our target sync state, then continue the test
+            if sync_state["slot_number"] >= slot_num:
+                logger.info(
+                    f"cat-gateway synced to target slot {slot_num}: {sync_state}"
+                )
+                break
 
-            last_slot_num = sync_state["slot_number"]
-            start_time = time.time()
+            # If the sync state changed since last time, reset the timeout and log the new sync state
+            if last_slot_num != sync_state["slot_number"]:
+                slots_last_interval = (sync_state["slot_number"] - last_slot_num) + 1
+                last_interval = time.time() - start_time
+                sps_last_interval = slots_last_interval / max(last_interval, 1.0)
 
-            total_time = start_time - true_start
-            total_slots = (last_slot_num - first_slot_num) + 1
-            slots_per_second = total_slots / max(total_time, 0.001)
+                last_slot_num = sync_state["slot_number"]
+                start_time = time.time()
 
-            residual_sync_slots = max(slot_num - last_slot_num, 0)
-            estimated_time_remaining = residual_sync_slots / slots_per_second
+                total_time = start_time - true_start
+                total_slots = (last_slot_num - first_slot_num) + 1
+                slots_per_second = total_slots / max(total_time, 0.001)
 
-            # Total slots/second and in the last interval
-            sps = f"{slots_per_second:.2f}({sps_last_interval:.2f})"
+                residual_sync_slots = max(slot_num - last_slot_num, 0)
+                estimated_time_remaining = residual_sync_slots / slots_per_second
 
-            logger.info(
-                f"{last_slot_num : >16} : "
-                + f"{printable_time(total_time) : >16} : "
-                + f"{sps : >20} : "
-                + f"{residual_sync_slots : >16} : "
-                + f"{printable_time(estimated_time_remaining) : >16} :"
-            )
+                # Total slots/second and in the last interval
+                sps = f"{slots_per_second:.2f}({sps_last_interval:.2f})"
+
+                logger.info(
+                    f"{last_slot_num : >16} : "
+                    + f"{printable_time(total_time) : >16} : "
+                    + f"{sps : >20} : "
+                    + f"{residual_sync_slots : >16} : "
+                    + f"{printable_time(estimated_time_remaining) : >16} :"
+                )
 
         # If sync state does not update for timeout seconds, then fail the test
         if start_time + timeout <= time.time():


### PR DESCRIPTION
# Description

- Update service `State` struct, removed `schema_version_status` field.
- Modified `SchemaVersionValidation` middleware, made an explicit check of the even-db version.
- Clean up endpoints

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/412