### PR TITLE
feat: Change pallas dep to the catalyst-pallas fork's catalyst branch specific commit

### DIFF
--- a/catalyst-gateway/Cargo.lock
+++ b/catalyst-gateway/Cargo.lock
@@ -214,6 +214,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +404,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
+dependencies = [
+ "bitcoin_hashes",
+ "rand_core",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +544,7 @@ name = "cardano-chain-follower"
 version = "0.0.1"
 source = "git+https://github.com/input-output-hk/hermes.git#5a814ce79714ccef2254014b9b1a122f3cebef4d"
 dependencies = [
- "pallas",
+ "pallas 0.24.0",
  "pallas-hardano",
  "thiserror",
  "tokio",
@@ -531,7 +571,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "local-ip-address",
- "pallas",
+ "pallas 0.25.0",
  "panic-message",
  "poem",
  "poem-extensions",
@@ -612,6 +652,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
@@ -936,6 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -984,6 +1026,15 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
+dependencies = [
+ "cryptoxide",
+]
 
 [[package]]
 name = "either"
@@ -1552,6 +1603,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1562,6 +1614,7 @@ checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -1902,10 +1955,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2028,15 +2112,32 @@ name = "pallas"
 version = "0.24.0"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/immutable-secondary#c992da03d63c8fb32c64e1d2142b7d969a90ee44"
 dependencies = [
- "pallas-addresses",
- "pallas-applying",
- "pallas-codec",
- "pallas-configs",
- "pallas-crypto",
- "pallas-network",
- "pallas-primitives",
- "pallas-traverse",
- "pallas-utxorpc",
+ "pallas-addresses 0.24.0",
+ "pallas-applying 0.24.0",
+ "pallas-codec 0.24.0",
+ "pallas-configs 0.24.0",
+ "pallas-crypto 0.24.0",
+ "pallas-network 0.24.0",
+ "pallas-primitives 0.24.0",
+ "pallas-traverse 0.24.0",
+ "pallas-utxorpc 0.24.0",
+]
+
+[[package]]
+name = "pallas"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "pallas-addresses 0.25.0",
+ "pallas-applying 0.25.0",
+ "pallas-codec 0.25.0",
+ "pallas-configs 0.25.0",
+ "pallas-crypto 0.25.0",
+ "pallas-network 0.25.0",
+ "pallas-primitives 0.25.0",
+ "pallas-traverse 0.25.0",
+ "pallas-txbuilder",
+ "pallas-utxorpc 0.25.0",
 ]
 
 [[package]]
@@ -2048,9 +2149,24 @@ dependencies = [
  "bech32",
  "crc",
  "hex",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 0.24.0",
+ "pallas-crypto 0.24.0",
  "sha3",
+ "thiserror",
+]
+
+[[package]]
+name = "pallas-addresses"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "base58",
+ "bech32",
+ "crc",
+ "cryptoxide",
+ "hex",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
  "thiserror",
 ]
 
@@ -2060,11 +2176,25 @@ version = "0.24.0"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/immutable-secondary#c992da03d63c8fb32c64e1d2142b7d969a90ee44"
 dependencies = [
  "hex",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
- "pallas-traverse",
+ "pallas-addresses 0.24.0",
+ "pallas-codec 0.24.0",
+ "pallas-crypto 0.24.0",
+ "pallas-primitives 0.24.0",
+ "pallas-traverse 0.24.0",
+ "rand",
+]
+
+[[package]]
+name = "pallas-applying"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "hex",
+ "pallas-addresses 0.25.0",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
+ "pallas-primitives 0.25.0",
+ "pallas-traverse 0.25.0",
  "rand",
 ]
 
@@ -2080,17 +2210,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallas-codec"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "hex",
+ "minicbor",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "pallas-configs"
 version = "0.24.0"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/immutable-secondary#c992da03d63c8fb32c64e1d2142b7d969a90ee44"
 dependencies = [
  "base64 0.22.0",
  "hex",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-addresses 0.24.0",
+ "pallas-codec 0.24.0",
+ "pallas-crypto 0.24.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "pallas-configs"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "base64 0.22.0",
+ "hex",
+ "num-rational",
+ "pallas-addresses 0.25.0",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
+ "pallas-primitives 0.25.0",
+ "serde",
+ "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -2100,7 +2258,20 @@ source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec",
+ "pallas-codec 0.24.0",
+ "rand_core",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "pallas-crypto"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "cryptoxide",
+ "hex",
+ "pallas-codec 0.25.0",
  "rand_core",
  "serde",
  "thiserror",
@@ -2112,8 +2283,8 @@ version = "0.24.0"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/immutable-secondary#c992da03d63c8fb32c64e1d2142b7d969a90ee44"
 dependencies = [
  "binary-layout",
- "pallas-network",
- "pallas-traverse",
+ "pallas-network 0.24.0",
+ "pallas-traverse 0.24.0",
  "tap",
  "thiserror",
  "tracing",
@@ -2127,8 +2298,25 @@ dependencies = [
  "byteorder",
  "hex",
  "itertools 0.12.1",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 0.24.0",
+ "pallas-crypto 0.24.0",
+ "rand",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "pallas-network"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "byteorder",
+ "hex",
+ "itertools 0.12.1",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
  "rand",
  "socket2",
  "thiserror",
@@ -2145,8 +2333,23 @@ dependencies = [
  "bech32",
  "hex",
  "log",
- "pallas-codec",
- "pallas-crypto",
+ "pallas-codec 0.24.0",
+ "pallas-crypto 0.24.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "pallas-primitives"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "base58",
+ "bech32",
+ "hex",
+ "log",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
  "serde",
  "serde_json",
 ]
@@ -2157,12 +2360,44 @@ version = "0.24.0"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/immutable-secondary#c992da03d63c8fb32c64e1d2142b7d969a90ee44"
 dependencies = [
  "hex",
- "pallas-addresses",
- "pallas-codec",
- "pallas-crypto",
- "pallas-primitives",
+ "pallas-addresses 0.24.0",
+ "pallas-codec 0.24.0",
+ "pallas-crypto 0.24.0",
+ "pallas-primitives 0.24.0",
  "paste",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "pallas-traverse"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "hex",
+ "pallas-addresses 0.25.0",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
+ "pallas-primitives 0.25.0",
+ "paste",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "pallas-txbuilder"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "hex",
+ "pallas-addresses 0.25.0",
+ "pallas-codec 0.25.0",
+ "pallas-crypto 0.25.0",
+ "pallas-primitives 0.25.0",
+ "pallas-traverse 0.25.0",
+ "pallas-wallet",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -2171,10 +2406,35 @@ name = "pallas-utxorpc"
 version = "0.24.0"
 source = "git+https://github.com/input-output-hk/catalyst-pallas.git?branch=fix/immutable-secondary#c992da03d63c8fb32c64e1d2142b7d969a90ee44"
 dependencies = [
- "pallas-codec",
- "pallas-primitives",
- "pallas-traverse",
- "utxorpc-spec",
+ "pallas-codec 0.24.0",
+ "pallas-primitives 0.24.0",
+ "pallas-traverse 0.24.0",
+ "utxorpc-spec 0.3.0",
+]
+
+[[package]]
+name = "pallas-utxorpc"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "pallas-codec 0.25.0",
+ "pallas-primitives 0.25.0",
+ "pallas-traverse 0.25.0",
+ "utxorpc-spec 0.5.1",
+]
+
+[[package]]
+name = "pallas-wallet"
+version = "0.25.0"
+source = "git+https://github.com/input-output-hk/catalyst-pallas.git?rev=954e99db9e9c3e4c4b1677614054fbe18f692504#954e99db9e9c3e4c4b1677614054fbe18f692504"
+dependencies = [
+ "bech32",
+ "bip39",
+ "cryptoxide",
+ "ed25519-bip32",
+ "pallas-crypto 0.25.0",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
@@ -2223,6 +2483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbjson"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1030c719b0ec2a2d25a5df729d6cff1acf3cc230bf766f4f97833591f7577b90"
+dependencies = [
+ "base64 0.21.7",
+ "serde",
+]
+
+[[package]]
 name = "pbjson-build"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2230,8 +2500,20 @@ checksum = "bdbb7b706f2afc610f3853550cdbbf6372fd324824a087806bd4480ea4996e24"
 dependencies = [
  "heck 0.4.1",
  "itertools 0.10.5",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2580e33f2292d34be285c5bc3dba5259542b083cfad6037b6d70345f24dcb735"
+dependencies = [
+ "heck 0.4.1",
+ "itertools 0.11.0",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
 ]
 
 [[package]]
@@ -2242,10 +2524,25 @@ checksum = "4a88c8d87f99a4ac14325e7a4c24af190fca261956e3b82dd7ed67e77e6c7043"
 dependencies = [
  "bytes",
  "chrono",
- "pbjson",
- "pbjson-build",
- "prost",
- "prost-build",
+ "pbjson 0.5.1",
+ "pbjson-build 0.5.1",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f596653ba4ac51bdecbb4ef6773bc7f56042dc13927910de1684ad3d32aa12"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson 0.6.0",
+ "pbjson-build 0.6.2",
+ "prost 0.12.4",
+ "prost-build 0.12.4",
  "serde",
 ]
 
@@ -2595,6 +2892,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,7 +2965,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.4",
 ]
 
 [[package]]
@@ -2674,13 +2991,34 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.17",
+ "prost 0.12.4",
+ "prost-types 0.12.4",
+ "regex",
+ "syn 2.0.53",
+ "tempfile",
 ]
 
 [[package]]
@@ -2697,12 +3035,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
+dependencies = [
+ "prost 0.12.4",
 ]
 
 [[package]]
@@ -3048,6 +3408,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.0",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.5",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -3503,7 +3893,34 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.4",
  "tokio",
  "tokio-stream",
  "tower",
@@ -3685,9 +4102,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -3760,11 +4177,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f80e24bfe310d0972406d15c0892ff09b6c81ded2cdefc0183aac35cf0514f"
 dependencies = [
  "bytes",
- "pbjson",
- "pbjson-types",
- "prost",
+ "pbjson 0.5.1",
+ "pbjson-types 0.5.1",
+ "prost 0.11.9",
  "serde",
- "tonic",
+ "tonic 0.9.2",
+]
+
+[[package]]
+name = "utxorpc-spec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ed1da9027ea2010458a9aa5da7d896518176165d630f0325ad2c994f69772b"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "pbjson 0.6.0",
+ "pbjson-types 0.6.0",
+ "prost 0.12.4",
+ "serde",
+ "tonic 0.11.0",
 ]
 
 [[package]]

--- a/catalyst-gateway/Cargo.toml
+++ b/catalyst-gateway/Cargo.toml
@@ -49,7 +49,7 @@ handlebars = "5.1.2"
 anyhow = "1.0.71"
 cddl = "0.9.2"
 ciborium = "0.2"
-pallas = { git = "https://github.com/input-output-hk/catalyst-pallas.git", branch = "fix/immutable-secondary", version = "0.24.0" }
+pallas = { git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "954e99db9e9c3e4c4b1677614054fbe18f692504", version = "0.25.0" }
 cardano-chain-follower= { git = "https://github.com/input-output-hk/hermes.git", version="0.0.1" }
 
 [workspace.lints.rust]


### PR DESCRIPTION
# Description

Changed `pallas` dep to the `catalyst-pallas` fork's `catalyst` branch specific commit.
`catalyst` branch would our upstream branch with all our updates which are not merged to the `pallas` main branch yet.
Also specified a commit instead of branch to make a more reliable and robust build, so any changes inside `catalyst` branch will not affect to the hermes without explicit updating of the this dependency.

Part of https://github.com/input-output-hk/hermes/pull/229