### PR TITLE
feat: lock specific flutter version on ci

### DIFF
--- a/catalyst_voices/Earthfile
+++ b/catalyst_voices/Earthfile
@@ -10,6 +10,7 @@ IMPORT ../catalyst-gateway AS catalyst-gateway
 deps:
     FROM debian:bookworm-slim
     ARG TARGETARCH
+    ARG FLUTTER_VERSION=3.19.5
     RUN apt-get update
     RUN apt-get install -y git curl unzip bzip2 bash jq gpg lcov
     COPY --dir test_driver/scripts .
@@ -19,10 +20,8 @@ deps:
 
     WORKDIR /frontend
 
-    RUN git clone https://github.com/flutter/flutter.git /usr/local/flutter
+    RUN git clone --depth 1 --branch $FLUTTER_VERSION https://github.com/flutter/flutter.git /usr/local/flutter
     ENV PATH="/usr/local/flutter/bin:/usr/local/flutter/bin/cache/dart-sdk/bin:$HOME/.pub-cache/bin:${PATH}"
-    RUN flutter channel stable
-    RUN flutter upgrade
     RUN flutter --version
     RUN flutter doctor -v
     RUN flutter config --enable-web


### PR DESCRIPTION
# Description

Locks a specific flutter version during Earthfile builds on the CI. Currently every build targets the latest flutter version, since 3.22.0 has just been released the builds are not working.

Incrementing flutter version should be intentional and tested, not automatic.

Note:
- I have investigated if it's easily possible to extract the flutter version from melos.yaml where we define it but it would require manually parsing .yaml file and looking for a specific key. If there will be a suggestion to do it, I'll work on it but the point of the PR is to make CI working again as fast as possible.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
