### PR TITLE
feat: create test reporting for backend python tests

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -11,6 +11,7 @@ asmjs
 asyncio
 asyncpg
 auditability
+backendpython
 bech
 bkioshn
 bluefireteam
@@ -78,6 +79,7 @@ Joaquín
 jorm
 jormungandr
 Jörmungandr
+junitxml
 junitreport
 Keyhash
 keyserver

--- a/.github/workflows/generate-allure-report.yml
+++ b/.github/workflows/generate-allure-report.yml
@@ -77,7 +77,7 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-            earthfile: Get backend python test report
+            earthfile: ./catalyst-gateway/tests/api_tests/
             flags: --allow-privileged
             targets: test
             target_flags:

--- a/.github/workflows/generate-allure-report.yml
+++ b/.github/workflows/generate-allure-report.yml
@@ -71,6 +71,18 @@ jobs:
             target_flags:
             runner_address: ${{ secrets.EARTHLY_SATELLITE_ADDRESS }}
             artifact: "false"
+      
+      - name: Get backend python test report
+        uses: input-output-hk/catalyst-ci/actions/run@master
+        if: always()
+        continue-on-error: true
+        with:
+            earthfile: Get backend python test report
+            flags: --allow-privileged
+            targets: test
+            target_flags:
+            runner_address: ${{ secrets.EARTHLY_SATELLITE_ADDRESS }}
+            artifact: "false"
 
       - name: Collect and upload test reports
         uses: actions/upload-artifact@v4

--- a/catalyst-gateway/tests/api_tests/.gitignore
+++ b/catalyst-gateway/tests/api_tests/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+junit-report.xml

--- a/catalyst-gateway/tests/api_tests/Earthfile
+++ b/catalyst-gateway/tests/api_tests/Earthfile
@@ -22,5 +22,8 @@ test:
         --load cat-gateway:latest=(../../+package-cat-gateway-with-preprod-snapshot) \
         --service cat-gateway \
         --allow-privileged
-        RUN poetry run pytest -s
+        RUN poetry run pytest -s --junitxml=junit-report.xml
+    END
+    WAIT
+        SAVE ARTIFACT junit-report.xml AS LOCAL backendpython.junit-report.xml
     END


### PR DESCRIPTION
# Description

Modify the python backend tests that are runned using pytest to generate a junit test report and integrate them with the allure report workflow

- generate xml junit report to the earthly [test target](https://github.com/input-output-hk/catalyst-voices/blob/d00fa4a8159bff34322ec8e8949aee865fa3e213/catalyst-gateway/tests/api_tests/Earthfile#L14)

- add the report to the [allure workflow](https://github.com/input-output-hk/catalyst-voices/blob/main/.github/workflows/generate-allure-report.yml)


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
