### PR TITLE
fix(ci): Increase schemathesis max response time

### DIFF
--- a/catalyst-gateway/tests/schemathesis_tests/Earthfile
+++ b/catalyst-gateway/tests/schemathesis_tests/Earthfile
@@ -13,7 +13,7 @@ package-schemathesis:
                     && st run --checks all $openapi_spec \
                     --workers=2 \
                     --wait-for-schema=15 \
-                    --max-response-time=3000 \
+                    --max-response-time=5000 \
                     --hypothesis-max-examples=1000 \
                     --data-generation-method=all \
                     --skip-deprecated-operations \


### PR DESCRIPTION
# Description

Increased `schemathesis` max response time limit to 5 seconds.