### PR TITLE
feat: add theme mode switcher

### DIFF
--- a/catalyst_voices/uikit_example/lib/examples_list.dart
+++ b/catalyst_voices/uikit_example/lib/examples_list.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:catalyst_voices/widgets/menu/voices_list_tile.dart';
+import 'package:flutter/material.dart';
+import 'package:uikit_example/examples/voices_chip_example.dart';
+import 'package:uikit_example/examples/voices_navigation_example.dart';
+
+class ExamplesListPage extends StatelessWidget {
+  const ExamplesListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('UI kit examples'),
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        itemCount: examples.length,
+        itemBuilder: (context, index) => examples[index],
+        separatorBuilder: (context, index) => const Divider(),
+      ),
+    );
+  }
+
+  static List<ExampleTile> get examples {
+    return const [
+      ExampleTile(
+        title: 'VoicesNavigation (AppBar + Drawer)',
+        route: VoicesNavigationExample.route,
+        page: VoicesNavigationExample(),
+      ),
+      ExampleTile(
+        title: 'Voices Chips',
+        route: VoicesChipExample.route,
+        page: VoicesChipExample(),
+      ),
+    ];
+  }
+}
+
+class ExampleTile extends StatelessWidget {
+  final String title;
+  final String route;
+  final Widget page;
+
+  const ExampleTile({
+    super.key,
+    required this.title,
+    required this.route,
+    required this.page,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return VoicesListTile(
+      title: Text(title),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => unawaited(Navigator.of(context).pushNamed(route)),
+    );
+  }
+}

--- a/catalyst_voices/uikit_example/lib/main.dart
+++ b/catalyst_voices/uikit_example/lib/main.dart
@@ -1,19 +1,22 @@
-import 'dart:async';
-
-import 'package:catalyst_voices/widgets/menu/voices_list_tile.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/generated/catalyst_voices_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localized_locales/flutter_localized_locales.dart';
-import 'package:uikit_example/examples/voices_chip_example.dart';
-import 'package:uikit_example/examples/voices_navigation_example.dart';
+import 'package:uikit_example/examples_list.dart';
 
 void main() {
   runApp(const UIKitExampleApp());
 }
 
-class UIKitExampleApp extends StatelessWidget {
+class UIKitExampleApp extends StatefulWidget {
   const UIKitExampleApp({super.key});
+
+  @override
+  State<UIKitExampleApp> createState() => _UIKitExampleAppState();
+}
+
+class _UIKitExampleAppState extends State<UIKitExampleApp> {
+  ThemeMode _themeMode = ThemeMode.system;
 
   @override
   Widget build(BuildContext context) {
@@ -27,63 +30,76 @@ class UIKitExampleApp extends StatelessWidget {
       localeListResolutionCallback: basicLocaleListResolution,
       theme: ThemeBuilder.buildTheme(BrandKey.catalyst),
       darkTheme: ThemeBuilder.buildDarkTheme(BrandKey.catalyst),
-      routes: {
-        Navigator.defaultRouteName: (_) => const _ExamplesList(),
-        VoicesNavigationExample.route: (_) => const VoicesNavigationExample(),
-        VoicesChipExample.route: (_) => const VoicesChipExample(),
+      themeMode: _themeMode,
+      onGenerateRoute: _onGenerateRoute,
+    );
+  }
+
+  Route<dynamic> _onGenerateRoute(RouteSettings settings) {
+    final page = ExamplesListPage.examples
+            .where((e) => e.route == settings.name)
+            .map((e) => e.page)
+            .firstOrNull ??
+        const ExamplesListPage();
+
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) {
+        return _ThemeModeSwitcherWrapper(
+          onChanged: _onThemeModeChanged,
+          child: page,
+        );
       },
     );
   }
-}
 
-class _ExamplesList extends StatelessWidget {
-  const _ExamplesList();
-
-  @override
-  Widget build(BuildContext context) {
-    final examples = _examples;
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('UI kit examples'),
-      ),
-      body: ListView.separated(
-        padding: const EdgeInsets.symmetric(vertical: 32),
-        itemCount: examples.length,
-        itemBuilder: (context, index) => examples[index],
-        separatorBuilder: (context, index) => const Divider(),
-      ),
-    );
-  }
-
-  List<_Example> get _examples {
-    return const [
-      _Example(
-        title: 'VoicesNavigation (AppBar + Drawer)',
-        route: VoicesNavigationExample.route,
-      ),
-      _Example(
-        title: 'Voices Chips',
-        route: VoicesChipExample.route,
-      ),
-    ];
+  void _onThemeModeChanged(ThemeMode themeMode) {
+    setState(() {
+      _themeMode = themeMode;
+    });
   }
 }
 
-class _Example extends StatelessWidget {
-  final String title;
-  final String route;
+class _ThemeModeSwitcherWrapper extends StatelessWidget {
+  final ValueChanged<ThemeMode> onChanged;
+  final Widget child;
 
-  const _Example({
-    required this.title,
-    required this.route,
+  const _ThemeModeSwitcherWrapper({
+    required this.onChanged,
+    required this.child,
   });
 
   @override
   Widget build(BuildContext context) {
-    return VoicesListTile(
-      title: Text(title),
-      trailing: const Icon(Icons.chevron_right),
-      onTap: () => unawaited(Navigator.of(context).pushNamed(route)),
+    return Column(
+      children: [
+        Expanded(
+          child: child,
+        ),
+        Material(
+          color: Theme.of(context).colorScheme.surface,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                const Text('Light / Dark'),
+                Padding(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: Switch(
+                    value: Theme.of(context).brightness == Brightness.dark,
+                    onChanged: (value) {
+                      onChanged(
+                        value ? ThemeMode.dark : ThemeMode.light,
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
# Description

Adds theme mode switcher between light/dark theme to UIKit example app.

## Screenshots

![Screenshot 2024-06-24 at 21 39 16](https://github.com/input-output-hk/catalyst-voices/assets/166132265/855f2960-1183-4baa-a204-8d236d5b548b)
![Screenshot 2024-06-24 at 21 38 52](https://github.com/input-output-hk/catalyst-voices/assets/166132265/ffe3fde5-f6c2-4a59-a33f-a2f346080034)
![Screenshot 2024-06-24 at 21 38 58](https://github.com/input-output-hk/catalyst-voices/assets/166132265/50cb0c7a-49d7-474d-9834-8f1f686dae4a)
![Screenshot 2024-06-24 at 21 39 06](https://github.com/input-output-hk/catalyst-voices/assets/166132265/d6601e0f-fbce-4736-8651-ad142cd6a0eb)


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
