### PR TITLE
fix: chips light/dark icons

### DIFF
--- a/catalyst_voices/lib/widgets/chips/voices_chip.dart
+++ b/catalyst_voices/lib/widgets/chips/voices_chip.dart
@@ -62,7 +62,7 @@ class VoicesChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final iconTheme = Theme.of(context).iconTheme.copyWith(size: 18);
+    final iconTheme = IconTheme.of(context).copyWith(size: 18);
     return DecoratedBox(
       decoration: BoxDecoration(
         color: backgroundColor,

--- a/catalyst_voices/lib/widgets/chips/voices_chip.dart
+++ b/catalyst_voices/lib/widgets/chips/voices_chip.dart
@@ -62,6 +62,7 @@ class VoicesChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final iconTheme = Theme.of(context).iconTheme.copyWith(size: 18);
     return DecoratedBox(
       decoration: BoxDecoration(
         color: backgroundColor,
@@ -87,7 +88,7 @@ class VoicesChip extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsetsDirectional.only(end: 8),
                     child: IconTheme(
-                      data: const IconThemeData(size: 18),
+                      data: iconTheme,
                       child: leading!,
                     ),
                   ),
@@ -99,7 +100,7 @@ class VoicesChip extends StatelessWidget {
                   Padding(
                     padding: const EdgeInsetsDirectional.only(start: 8),
                     child: IconTheme(
-                      data: const IconThemeData(size: 18),
+                      data: iconTheme,
                       child: trailing!,
                     ),
                   ),


### PR DESCRIPTION
# Description

Fixes icon theme for leading/trailing in the VoicesChip to make sure they have enough contrast in light/dark mode.

## Screenshots
![Screenshot 2024-06-27 at 09 47 42](https://github.com/input-output-hk/catalyst-voices/assets/166132265/e588dbad-50e8-4f65-a138-e4312b2da435)
![Screenshot 2024-06-27 at 09 47 45](https://github.com/input-output-hk/catalyst-voices/assets/166132265/89e1b98f-fa1c-425d-ae4e-0f010c5dc0f7)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
