### PR TITLE
fix: readme versioning for catalyst packages

### DIFF
--- a/catalyst_voices/pubspec.yaml
+++ b/catalyst_voices/pubspec.yaml
@@ -52,10 +52,7 @@ dev_dependencies:
   build_runner: ^2.3.3
   build_verify: ^3.1.0
   catalyst_analysis:
-    git:
-      url: https://github.com/input-output-hk/catalyst-voices.git
-      path: catalyst_voices_packages/catalyst_analysis
-      ref: 3431f7b
+    path: ../catalyst_voices_packages/catalyst_analysis
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.4.1

--- a/catalyst_voices_packages/catalyst_analysis/README.md
+++ b/catalyst_voices_packages/catalyst_analysis/README.md
@@ -21,7 +21,7 @@ To use the lints, add as a dev dependency in your `pubspec.yaml`:
 
 ```yaml
 dev_dependencies:
-  catalyst_analysis: ^1.0.0
+  catalyst_analysis: any # or the latest version on Pub
 ```
 
 Then, add an include in `analysis_options.yaml`:

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/README.md
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/README.md
@@ -29,9 +29,9 @@ away all the complexities of using js_interop.
 
 ```yaml
 dependencies:
-    catalyst_cardano_serialization: ^0.1.0
-    catalyst_cardano: ^0.1.0
-    catalyst_cardano_web: ^0.1.0
+    catalyst_cardano_serialization: any # or the latest version on Pub
+    catalyst_cardano: any # or the latest version on Pub
+    catalyst_cardano_web: any # or the latest version on Pub
 ```
 
 ## Web setup

--- a/catalyst_voices_packages/catalyst_cardano_serialization/README.md
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/README.md
@@ -30,7 +30,7 @@ and submission are outside of scope of this package.
 
 ```yaml
 dependencies:
-  catalyst_cardano_serialization: ^0.1.0
+  catalyst_cardano_serialization: any # or the latest version on Pub
 ```
 
 ## Example


### PR DESCRIPTION
# Description

- Removes any explicit package versions in favor of using latest version in README files to avoid manually updating these after each release. Melos can't do it automatically.

- Updates catalyst_voices to use catalyst_analysis from path instead of hardcoded version

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
