### PR TITLE
fix: missing chromium version

### DIFF
--- a/catalyst_voices/Earthfile
+++ b/catalyst_voices/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../catalyst-gateway AS catalyst-gateway
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.1.11 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.1.12 AS flutter-ci
 
 # Copy all the necessary files and running bootstrap
 builder:

--- a/catalyst_voices/uikit_example/Earthfile
+++ b/catalyst_voices/uikit_example/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../ AS catalyst-voices
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.1.11 AS flutter-ci 
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.1.12 AS flutter-ci 
 
 # local-build-web - build web version of UIKit example.
 # Prefixed by "local" to make sure it's not auto triggered, the target was


### PR DESCRIPTION
# Description
Updates catalyst-ci to 3.1.12 that addresses the missing chromium version: https://github.com/input-output-hk/catalyst-ci/releases/tag/v3.1.12

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
