### PR TITLE
feat: automate melos release

### DIFF
--- a/.github/workflows/flutter-publish-packages.yml
+++ b/.github/workflows/flutter-publish-packages.yml
@@ -1,0 +1,31 @@
+name: Pub.dev release of flutter/dart packages.
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-packages:
+    name: Pub.dev release of flutter/dart packages.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: 3.22.1
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-versioning: true
+          publish-dry-run: true
+          publish: true
+          create-pr: true
+          git-email: melos-action@users.noreply.github.com
+          git-name: "Melos Action"

--- a/.github/workflows/flutter-publish-packages.yml
+++ b/.github/workflows/flutter-publish-packages.yml
@@ -1,4 +1,4 @@
-name: Pub.dev release of flutter/dart packages.
+name: Publish Flutter Packages
 
 on: workflow_dispatch
 
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   publish-packages:
-    name: Pub.dev release of flutter/dart packages.
+    name: Publish Flutter Packages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/pubspec.yaml
@@ -1,5 +1,5 @@
 name: catalyst_cardano
-description: A Flutter plugin exposing the CIP-30 and CIP-95 APIs.
+description: A Flutter plugin exposing the CIP-30 and CIP-95 APIs. Allows to communicate with the Cardano Wallet Extension via js_interop integration.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cardano/catalyst_cardano
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/example/main.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/example/main.dart
@@ -1,0 +1,4 @@
+void main() {
+  // ignore: avoid_print
+  print('Example is located in catalyst_cardano/example directory.');
+}

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/example/main.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/example/main.dart
@@ -1,0 +1,4 @@
+void main() {
+  // ignore: avoid_print
+  print('Example is located in catalyst_cardano/example directory.');
+}

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
@@ -1,5 +1,5 @@
 name: catalyst_cardano_web
-description: Web platform implementation of catalyst_cardano
+description: Web platform implementation of catalyst_cardano. Allows to communicate with the Cardano Wallet Extension via js_interop integration.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]

--- a/catalyst_voices_packages/catalyst_cardano_serialization/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/pubspec.yaml
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   bech32: ^0.2.2
-  bip32_ed25519: ^0.5.0
+  bip32_ed25519: ^0.6.0
   cbor: ^6.2.0
   convert: ^3.1.1
   equatable: ^2.0.5
-  pinenacl: ^0.5.1
+  pinenacl: ^0.6.0
 
 dev_dependencies:
   catalyst_analysis:

--- a/melos.yaml
+++ b/melos.yaml
@@ -28,10 +28,10 @@ command:
       result_type: ^0.2.0
       plugin_platform_interface: ^2.1.7
       bech32: ^0.2.2
-      bip32_ed25519: ^0.5.0
+      bip32_ed25519: ^0.6.0
       cbor: ^6.2.0
       convert: ^3.1.1
-      pinenacl: ^0.5.1
+      pinenacl: ^0.6.0
     dev_dependencies:
       test: ^1.24.9
       build_runner: ^2.3.3


### PR DESCRIPTION
# Description
- Adds a github action that publishes dart/flutter packages to pub.dev when [triggered manually](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) on github actions. The action will also create a PR with changelogs, this is the recommended workflow from the [melos team](https://github.com/marketplace/actions/melos-action#2-directly-publish-to-pubdev-after-each-pr-is-merged).
- Fixes issues that lower the pub.dev score of packages

## Related Issue(s)

Closes #494 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
