### PR TITLE
fix: report folder name, trigger manual

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -3,7 +3,9 @@ name: CI nightly
 on:
   schedule:
     - cron: '0 0 * * *' # Runs every day at 00:00
-    - cron: '0 * * * *' # Run every hour, for testing purpose
+  workflow_dispatch:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -95,7 +97,7 @@ jobs:
         uses: mgrybyk/allure-report-branch-action@v1
         id: allure
         with:
-          report_id: 'test-report'
+          report_id: 'nightly-test-report'
           gh_pages: 'gh-pages-dir'
           report_dir: ${{ env.ALLURE_REPORT_PATH }}
 


### PR DESCRIPTION
# Description
- Fix report folder name so that results are not in same folder with CI run
- Add manual trigger for nightly ci
