### PR TITLE
fix: catalyst cardano integration with Typhoon wallet

### DIFF
--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/README.md
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/README.md
@@ -83,7 +83,11 @@ Future<void> main() async {
   print(await api.getUsedAddresses());
 
   final unsignedTx = _buildUnsignedTx(
-    utxos: await api.getUtxos(amount: const Coin(1000000)),
+    utxos: await api.getUtxos(
+      amount: const Balance(
+        coin: Coin(1000000),
+      ),
+    ),
     changeAddress: await api.getChangeAddress(),
   );
 

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/main.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/main.dart
@@ -276,21 +276,21 @@ class _WalletDetailsState extends State<_WalletDetails> {
         });
       }
 
-      // if (extensions.contains(const CipExtension(cip: 95))) {
-      //   final pubDRepKey = await widget.api.cip95.getPubDRepKey();
-      //   final registeredPubStakeKeys =
-      //       await widget.api.cip95.getRegisteredPubStakeKeys();
-      //   final unregisteredPubStakeKeys =
-      //       await widget.api.cip95.getUnregisteredPubStakeKeys();
+      if (extensions.contains(const CipExtension(cip: 95))) {
+        final pubDRepKey = await widget.api.cip95.getPubDRepKey();
+        final registeredPubStakeKeys =
+            await widget.api.cip95.getRegisteredPubStakeKeys();
+        final unregisteredPubStakeKeys =
+            await widget.api.cip95.getUnregisteredPubStakeKeys();
 
-      //   if (mounted) {
-      //     setState(() {
-      //       _pubDRepKey = pubDRepKey;
-      //       _registeredPubStakeKeys = registeredPubStakeKeys;
-      //       _unregisteredPubStakeKeys = unregisteredPubStakeKeys;
-      //     });
-      //   }
-      // }
+        if (mounted) {
+          setState(() {
+            _pubDRepKey = pubDRepKey;
+            _registeredPubStakeKeys = registeredPubStakeKeys;
+            _unregisteredPubStakeKeys = unregisteredPubStakeKeys;
+          });
+        }
+      }
     } catch (error) {
       if (mounted) {
         await _showDialog(

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/main.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/main.dart
@@ -97,7 +97,11 @@ class _MyHomePageState extends State<MyHomePage> {
     try {
       setState(() => _isLoading = true);
       final api = await wallet.enable(
-        extensions: const [CipExtension(cip: 95)],
+        extensions: [
+          const CipExtension(cip: 30),
+          if (wallet.supportedExtensions.contains(const CipExtension(cip: 95)))
+            const CipExtension(cip: 95),
+        ],
       );
       setState(() => _api = api);
     } catch (error) {
@@ -272,21 +276,21 @@ class _WalletDetailsState extends State<_WalletDetails> {
         });
       }
 
-      if (extensions.contains(const CipExtension(cip: 95))) {
-        final pubDRepKey = await widget.api.cip95.getPubDRepKey();
-        final registeredPubStakeKeys =
-            await widget.api.cip95.getRegisteredPubStakeKeys();
-        final unregisteredPubStakeKeys =
-            await widget.api.cip95.getUnregisteredPubStakeKeys();
+      // if (extensions.contains(const CipExtension(cip: 95))) {
+      //   final pubDRepKey = await widget.api.cip95.getPubDRepKey();
+      //   final registeredPubStakeKeys =
+      //       await widget.api.cip95.getRegisteredPubStakeKeys();
+      //   final unregisteredPubStakeKeys =
+      //       await widget.api.cip95.getUnregisteredPubStakeKeys();
 
-        if (mounted) {
-          setState(() {
-            _pubDRepKey = pubDRepKey;
-            _registeredPubStakeKeys = registeredPubStakeKeys;
-            _unregisteredPubStakeKeys = unregisteredPubStakeKeys;
-          });
-        }
-      }
+      //   if (mounted) {
+      //     setState(() {
+      //       _pubDRepKey = pubDRepKey;
+      //       _registeredPubStakeKeys = registeredPubStakeKeys;
+      //       _unregisteredPubStakeKeys = unregisteredPubStakeKeys;
+      //     });
+      //   }
+      // }
     } catch (error) {
       if (mounted) {
         await _showDialog(

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_rbac_tx.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_rbac_tx.dart
@@ -75,7 +75,9 @@ Future<void> _signAndSubmitRbacTx({
     final changeAddress = await api.getChangeAddress();
 
     final utxos = await api.getUtxos(
-      amount: const Coin(1000000),
+      amount: const Balance(
+        coin: Coin(1000000),
+      ),
     );
 
     final x509Envelope = await _buildMetadataEnvelope(

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_tx.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_tx.dart
@@ -9,7 +9,9 @@ Future<void> _signAndSubmitTx({
     final changeAddress = await api.getChangeAddress();
 
     final utxos = await api.getUtxos(
-      amount: const Coin(1000000),
+      amount: const Balance(
+        coin: Coin(1000000),
+      ),
     );
 
     final unsignedTx = _buildUnsignedTx(

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
@@ -23,7 +23,7 @@ abstract interface class CardanoWallet {
   String get icon;
 
   /// The version number of the API that the wallet supports.
-  String? get apiVersion;
+  String get apiVersion;
 
   /// A list of extensions supported by the wallet.
   ///

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
@@ -23,7 +23,7 @@ abstract interface class CardanoWallet {
   String get icon;
 
   /// The version number of the API that the wallet supports.
-  String get apiVersion;
+  String? get apiVersion;
 
   /// A list of extensions supported by the wallet.
   ///

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
@@ -117,7 +117,7 @@ abstract interface class CardanoWalletApi {
   /// null shall be returned. The results can be further paginated by
   /// [paginate] if it is not null.
   Future<List<TransactionUnspentOutput>> getUtxos({
-    Coin? amount,
+    Balance? amount,
     Paginate? paginate,
   });
 

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/assets/js/catalyst_cardano.js
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/assets/js/catalyst_cardano.js
@@ -5,7 +5,7 @@ function _getWallets() {
     if (cardano) {
         const keys = Object.keys(window.cardano);
         const possibleWallets = keys.map((k) => cardano[k]);
-        return possibleWallets.filter((w) => typeof w === "object" && "enable" in w);
+        return possibleWallets.filter((w) => typeof w === "object" && "enable" in w && "apiVersion" in w);
     }
 
     return [];

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/assets/js/catalyst_cardano.js
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/assets/js/catalyst_cardano.js
@@ -12,7 +12,7 @@ function _getWallets() {
 }
 
 // Returns an instance of `undefined` to dart layer as `undefined`
-// cannot be constructed in dart layer. Dart nulls are translated
+// cannot be constructed directly in dart layer. Dart nulls are translated
 // to JS nulls and JS distinguishes between undefined and null.
 function _makeUndefined() {
     return undefined;

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/assets/js/catalyst_cardano.js
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/assets/js/catalyst_cardano.js
@@ -11,10 +11,18 @@ function _getWallets() {
     return [];
 }
 
+// Returns an instance of `undefined` to dart layer as `undefined`
+// cannot be constructed in dart layer. Dart nulls are translated
+// to JS nulls and JS distinguishes between undefined and null.
+function _makeUndefined() {
+    return undefined;
+}
+
 // A namespace containing the JS functions that
 // can be executed from dart side
 const catalyst_cardano = {
     getWallets: _getWallets,
+    makeUndefined: _makeUndefined,
 }
 
 // Expose cardano multiplatform as globally accessible

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
@@ -6,6 +6,13 @@ import 'dart:js_interop';
 import 'package:catalyst_cardano_platform_interface/catalyst_cardano_platform_interface.dart';
 import 'package:catalyst_cardano_web/src/interop/catalyst_cardano_wallet_proxy.dart';
 
+/// Returns a JS undefined object.
+///
+/// Use this function to obtain an instance of `undefined`
+/// when you need to distinguish between `null` and `undefined`.
+@JS()
+external JSAny? makeUndefined();
+
 /// Lists all injected Cardano wallet extensions that are reachable
 /// via window.cardano.{walletName} in javascript.
 @JS()
@@ -62,13 +69,13 @@ extension type JSCardanoWalletApi(JSObject _) implements JSObject {
 
   /// See [CardanoWalletApi.getUsedAddresses].
   external JSPromise<JSArray<JSString>> getUsedAddresses([
-    JSPaginate? paginate,
+    JSAny? paginate,
   ]);
 
   /// See [CardanoWalletApi.getUtxos].
   external JSPromise<JSArray<JSString>> getUtxos([
-    JSString? amount,
-    JSPaginate? paginate,
+    JSAny? amount,
+    JSAny? paginate,
   ]);
 
   /// See [CardanoWalletApi.signData].

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
@@ -46,7 +46,7 @@ extension type JSCardanoWalletApi(JSObject _) implements JSObject {
   external JSPromise<JSString> getBalance();
 
   /// See [CardanoWalletApi.getExtensions].
-  external JSPromise<JSArray<JSCipExtension>> getExtensions();
+  external JSPromise<JSArray<JSCipExtension>>? getExtensions();
 
   /// See [CardanoWalletApi.getNetworkId].
   external JSPromise<JSNumber> getNetworkId();

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
@@ -20,7 +20,7 @@ extension type JSCardanoWallet(JSObject _) implements JSObject {
   external JSString get icon;
 
   /// See [CardanoWallet.apiVersion].
-  external JSString? get apiVersion;
+  external JSString get apiVersion;
 
   /// See [CardanoWallet.supportedExtensions].
   external JSArray<JSCipExtension>? get supportedExtensions;
@@ -46,7 +46,7 @@ extension type JSCardanoWalletApi(JSObject _) implements JSObject {
   external JSPromise<JSString> getBalance();
 
   /// See [CardanoWalletApi.getExtensions].
-  external JSPromise<JSArray<JSCipExtension>>? getExtensions();
+  external JSPromise<JSArray<JSCipExtension>> getExtensions();
 
   /// See [CardanoWalletApi.getNetworkId].
   external JSPromise<JSNumber> getNetworkId();
@@ -67,7 +67,7 @@ extension type JSCardanoWalletApi(JSObject _) implements JSObject {
 
   /// See [CardanoWalletApi.getUtxos].
   external JSPromise<JSArray<JSString>> getUtxos([
-    JSNumber? amount,
+    JSString? amount,
     JSPaginate? paginate,
   ]);
 

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
@@ -20,7 +20,7 @@ extension type JSCardanoWallet(JSObject _) implements JSObject {
   external JSString get icon;
 
   /// See [CardanoWallet.apiVersion].
-  external JSString get apiVersion;
+  external JSString? get apiVersion;
 
   /// See [CardanoWallet.supportedExtensions].
   external JSArray<JSCipExtension> get supportedExtensions;

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
@@ -23,7 +23,7 @@ extension type JSCardanoWallet(JSObject _) implements JSObject {
   external JSString? get apiVersion;
 
   /// See [CardanoWallet.supportedExtensions].
-  external JSArray<JSCipExtension> get supportedExtensions;
+  external JSArray<JSCipExtension>? get supportedExtensions;
 
   /// See [CardanoWallet.isEnabled].
   external JSPromise<JSBoolean> isEnabled();

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
@@ -20,11 +20,12 @@ class JSCardanoWalletProxy implements CardanoWallet {
   String get icon => _delegate.icon.toDart;
 
   @override
-  String? get apiVersion => _delegate.apiVersion?.toDart;
+  String get apiVersion => _delegate.apiVersion?.toDart ?? '0.1.0';
 
   @override
   List<CipExtension> get supportedExtensions =>
-      _delegate.supportedExtensions.toDart.map((e) => e.toDart).toList();
+      _delegate.supportedExtensions?.toDart.map((e) => e.toDart).toList() ??
+      const [CipExtension(cip: 30)];
 
   @override
   Future<bool> isEnabled() async {

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
@@ -20,7 +20,7 @@ class JSCardanoWalletProxy implements CardanoWallet {
   String get icon => _delegate.icon.toDart;
 
   @override
-  String get apiVersion => _delegate.apiVersion.toDart;
+  String? get apiVersion => _delegate.apiVersion?.toDart;
 
   @override
   List<CipExtension> get supportedExtensions =>

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
@@ -156,7 +156,7 @@ class JSCardanoWalletApiProxy implements CardanoWalletApi {
   Future<List<ShelleyAddress>> getUsedAddresses({Paginate? paginate}) async {
     try {
       final jsPaginate =
-          paginate != null ? JSPaginate.fromDart(paginate) : null;
+          paginate != null ? JSPaginate.fromDart(paginate) : makeUndefined();
 
       return await _delegate.getUsedAddresses(jsPaginate).toDart.then(
             (array) => array.toDart
@@ -180,8 +180,8 @@ class JSCardanoWalletApiProxy implements CardanoWalletApi {
           .getUtxos(
             amount != null
                 ? hex.encode(cbor.encode(amount.toCbor())).toJS
-                : null,
-            paginate != null ? JSPaginate.fromDart(paginate) : null,
+                : makeUndefined(),
+            paginate != null ? JSPaginate.fromDart(paginate) : makeUndefined(),
           )
           .toDart
           .then(

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
@@ -7,12 +7,12 @@ import 'package:cbor/cbor.dart';
 import 'package:convert/convert.dart';
 
 /// Error message in exception thrown when trying
-/// to execute which doesn't exist in JS layer.
+/// to execute a method which doesn't exist in JS layer.
 ///
 /// Notably some wallet extensions decided not to implement
 /// some method even if they are required by the CIP-30 standard.
 ///
-/// We need to detect that.
+/// Checking for this error messages allows to detect unimplemented method.
 const _noSuchMethodError = 'NoSuchMethodError';
 
 /// The minimal set of wallet extensions that

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
@@ -78,10 +78,10 @@ class JSCardanoWalletApiProxy implements CardanoWalletApi {
   @override
   Future<List<CipExtension>> getExtensions() async {
     try {
-      return await _delegate
-          .getExtensions()
-          .toDart
-          .then((array) => array.toDart.map((item) => item.toDart).toList());
+      return await _delegate.getExtensions()?.toDart.then(
+                (array) => array.toDart.map((item) => item.toDart).toList(),
+              ) ??
+          const [CipExtension(cip: 30)];
     } catch (ex) {
       throw _mapApiException(ex) ?? _fallbackApiException(ex);
     }


### PR DESCRIPTION
# Description

Workarounds and various fixes to make it possible to work with [Typhoon wallet](https://typhonwallet.io/#/).

The CIP-30 implementation by that wallet distinguishes between `null` and `undefined` and behaves wrongly when it expects `undefined` but gets `null`. CIP-30 prefers using `undefined` values while dart converts `nulls` into JS `null`. Lets then make sure we send them `undefined`.

Additionally `supportedExtensions` getter and `getSupportedExtensions` method has not been implemented at all by that wallet even though it is required by CIP-30. Since the method is not critical the package will return default values.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
