### PR TITLE
fix!: X509 registration metadata encoding

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -243,3 +243,4 @@ xctestrun
 xcworkspace
 yoroi
 unchunk
+EUTXO

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_rbac_tx.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_rbac_tx.dart
@@ -125,7 +125,7 @@ Future<X509MetadataEnvelope<RegistrationData>> _buildMetadataEnvelope({
       await Ed25519KeyPair.fromSeed(Ed25519PrivateKey.seeded(0).bytes);
 
   final x509Envelope = X509MetadataEnvelope.unsigned(
-    purpose: _catalystUserRoleRegistrationPurpose,
+    purpose: UuidV4.fromString(_catalystUserRoleRegistrationPurpose),
     txInputsHash: TransactionInputsHash.fromTransactionInputs(inputs),
     previousTransactionId: _transactionHash,
     chunkedData: RegistrationData(

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/catalyst_cardano_serialization.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/catalyst_cardano_serialization.dart
@@ -11,4 +11,5 @@ export 'src/rbac/x509_metadata_envelope.dart';
 export 'src/signature.dart';
 export 'src/transaction.dart';
 export 'src/types.dart';
+export 'src/utils/uuid.dart';
 export 'src/witness.dart';

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/certificate.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/certificate.dart
@@ -73,5 +73,12 @@ final class C509Certificate extends BaseCertificate {
   C509Certificate.fromHex(super.string) : super.fromHex();
 
   /// Deserializes the type from cbor.
-  C509Certificate.fromCbor(super.value) : super.fromCbor();
+  C509Certificate.fromCbor(CborValue value)
+      : super.fromBytes(bytes: cbor.encode(value));
+
+  /// Serializes the type as cbor.
+  ///
+  /// The bytes are already cbor encoded so we override the default behavior.
+  @override
+  CborValue toCbor() => cbor.decode(bytes);
 }

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/certificate.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/certificate.dart
@@ -73,12 +73,5 @@ final class C509Certificate extends BaseCertificate {
   C509Certificate.fromHex(super.string) : super.fromHex();
 
   /// Deserializes the type from cbor.
-  C509Certificate.fromCbor(CborValue value)
-      : super.fromBytes(bytes: cbor.encode(value));
-
-  /// Serializes the type as cbor.
-  ///
-  /// The bytes are already cbor encoded so we override the default behavior.
-  @override
-  CborValue toCbor() => cbor.decode(bytes);
+  C509Certificate.fromCbor(super.value) : super.fromCbor();
 }

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/hashes.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/hashes.dart
@@ -171,7 +171,7 @@ final class CertificateHash extends BaseHash {
   CertificateHash.fromX509DerCertificate(X509DerCertificate certificate)
       : super.fromBytes(
           bytes: Hash.blake2b(
-            Uint8List.fromList(cbor.encode(certificate.toCbor())),
+            Uint8List.fromList(certificate.bytes),
             digestSize: _length,
           ),
         );
@@ -180,7 +180,7 @@ final class CertificateHash extends BaseHash {
   CertificateHash.fromC509Certificate(C509Certificate certificate)
       : super.fromBytes(
           bytes: Hash.blake2b(
-            Uint8List.fromList(cbor.encode(certificate.toCbor())),
+            Uint8List.fromList(certificate.bytes),
             digestSize: _length,
           ),
         );

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/rbac/registration_data.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/rbac/registration_data.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
+import 'package:catalyst_cardano_serialization/src/utils/cbor.dart';
 import 'package:cbor/cbor.dart';
 import 'package:equatable/equatable.dart';
 
@@ -38,7 +39,7 @@ final class RegistrationData extends Equatable {
     final cborCerts = map[const CborSmallInt(20)] as CborList?;
     final publicKeys = map[const CborSmallInt(30)] as CborList?;
     final revocationSet = map[const CborSmallInt(40)] as CborList?;
-    final roleDataSet = map[const CborSmallInt(50)] as CborList?;
+    final roleDataSet = map[const CborSmallInt(100)] as CborList?;
 
     return RegistrationData(
       derCerts: derCerts?.map(X509DerCertificate.fromCbor).toList(),
@@ -65,13 +66,13 @@ final class RegistrationData extends Equatable {
       ),
       const CborSmallInt(30): _createCborList<Ed25519PublicKey>(
         publicKeys,
-        (item) => item.toCbor(),
+        (item) => item.toCbor(tags: [CborCustomTags.ed25519Bip32PublicKey]),
       ),
       const CborSmallInt(40): _createCborList<CertificateHash>(
         revocationSet,
         (item) => item.toCbor(),
       ),
-      const CborSmallInt(50): _createCborList<RoleData>(
+      const CborSmallInt(100): _createCborList<RoleData>(
         roleDataSet?.toList(),
         (item) => item.toCbor(),
       ),

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/rbac/x509_metadata_envelope.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/rbac/x509_metadata_envelope.dart
@@ -34,7 +34,7 @@ class X509MetadataEnvelope<T> extends Equatable {
   /// must be created. Nor the purpose they are used for, that is within control
   /// of each dApp. These specifications define a universal framework
   /// to implement such systems from.
-  final String purpose;
+  final UuidV4 purpose;
 
   /// This is a hash of the transaction inputs field from the transaction this
   /// auxiliary data was originally attached to. This hash anchors the auxiliary
@@ -135,14 +135,14 @@ class X509MetadataEnvelope<T> extends Equatable {
   }) {
     final metadata = value as CborMap;
     final envelope = metadata[const CborSmallInt(509)]! as CborMap;
-    final purpose = envelope[const CborSmallInt(0)]! as CborString;
+    final purpose = envelope[const CborSmallInt(0)]! as CborBytes;
     final txInputsHash = envelope[const CborSmallInt(1)]!;
     final previousTransactionId = envelope[const CborSmallInt(2)];
     final chunkedData = _deserializeChunkedData(envelope);
     final validationSignature = envelope[const CborSmallInt(99)]!;
 
     return X509MetadataEnvelope(
-      purpose: purpose.toString(),
+      purpose: UuidV4.fromCbor(purpose),
       txInputsHash: TransactionInputsHash.fromCbor(txInputsHash),
       previousTransactionId: previousTransactionId != null
           ? TransactionHash.fromCbor(previousTransactionId)
@@ -163,7 +163,7 @@ class X509MetadataEnvelope<T> extends Equatable {
 
     return CborMap({
       const CborSmallInt(509): CborMap({
-        const CborSmallInt(0): CborString(purpose),
+        const CborSmallInt(0): purpose.toCbor(),
         const CborSmallInt(1): txInputsHash.toCbor(),
         if (previousTransactionId != null)
           const CborSmallInt(2): previousTransactionId!.toCbor(),

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/signature.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/signature.dart
@@ -70,7 +70,9 @@ extension type Ed25519PublicKey._(List<int> bytes) {
   }
 
   /// Serializes the type as cbor.
-  CborValue toCbor() => CborBytes(bytes);
+  CborValue toCbor({List<int> tags = const []}) {
+    return CborBytes(bytes, tags: tags);
+  }
 
   /// Returns a hex representation of the [Ed25519PublicKey].
   String toHex() => hex.encode(bytes);

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/transaction.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/transaction.dart
@@ -214,14 +214,43 @@ final class TransactionOutput extends Equatable {
 
   /// Deserializes the type from cbor.
   factory TransactionOutput.fromCbor(CborValue value) {
-    final list = value as CborList;
-    final address = list[0];
-    final amount = list[1];
+    return _tryFromCborMap(value) ?? _tryFromCborList(value)!;
+  }
 
-    return TransactionOutput(
-      address: ShelleyAddress.fromCbor(address),
-      amount: Balance.fromCbor(amount),
-    );
+  /// This format is simpler and does not utilize the advanced features
+  /// of the Alonzo era (e.g., datum, native assets, or smart contract scripts).
+  /// It is consistent with basic transactions that could exist in earlier eras
+  /// or basic Alonzo-era transactions.
+  static TransactionOutput? _tryFromCborMap(CborValue value) {
+    try {
+      final map = value as CborMap;
+      final address = map[const CborSmallInt(0)]!;
+      final amount = map[const CborSmallInt(1)]!;
+
+      return TransactionOutput(
+        address: ShelleyAddress.fromCbor(address),
+        amount: Balance.fromCbor(amount),
+      );
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /// This format shows the use of the EUTXO model introduced in the Alonzo era,
+  /// with support for native assets and possibly other advanced features.
+  static TransactionOutput? _tryFromCborList(CborValue value) {
+    try {
+      final list = value as CborList;
+      final address = list[0];
+      final amount = list[1];
+
+      return TransactionOutput(
+        address: ShelleyAddress.fromCbor(address),
+        amount: Balance.fromCbor(amount),
+      );
+    } catch (error) {
+      return null;
+    }
   }
 
   /// Serializes the type as cbor.

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/utils/cbor.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/utils/cbor.dart
@@ -4,6 +4,9 @@ final class CborCustomTags {
 
   /// A cbor tag describing a key-value pairs data.
   static const int map = 259;
+
+  /// A cbor tag describing a ED25519-BIP32 Public Key.
+  static const int ed25519Bip32PublicKey = 32773;
 }
 
 /// How many bytes are used in cbor encoding for a major type/length.

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/utils/uuid.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/utils/uuid.dart
@@ -1,0 +1,62 @@
+import 'dart:typed_data';
+
+import 'package:cbor/cbor.dart';
+import 'package:convert/convert.dart';
+
+/// The Uuid version 4 identifier.
+extension type UuidV4._(List<int> bytes) {
+  /// Separates groups of values in Uuid.
+  static const String separator = '-';
+
+  /// The length of the [UuidV4] in bytes.
+  static const int length = 16;
+
+  /// The default constructor for [UuidV4].
+  UuidV4.fromBytes(this.bytes) {
+    if (bytes.length != length) {
+      throw ArgumentError(
+        'UuidV4 length does not match: ${bytes.length}',
+      );
+    }
+  }
+
+  /// Builds a [UuidV4] from a [string].
+  UuidV4.fromString(String string) : this.fromBytes(_uuidToBinary(string));
+
+  /// Deserializes the type from cbor.
+  factory UuidV4.fromCbor(CborValue value) {
+    return UuidV4.fromBytes((value as CborBytes).bytes);
+  }
+
+  /// Serializes the type as cbor.
+  CborValue toCbor() => CborBytes(bytes);
+
+  /// Returns a Uuid.v4 string representation.
+  String toUuidString() {
+    // Insert dashes to format as UUID v4
+    final hexString = hex.encode(bytes);
+    final formattedUuid = '${hexString.substring(0, 8)}$separator'
+        '${hexString.substring(8, 12)}$separator'
+        '${hexString.substring(12, 16)}$separator'
+        '${hexString.substring(16, 20)}$separator'
+        '${hexString.substring(20, 32)}';
+
+    return formattedUuid;
+  }
+
+  static Uint8List _uuidToBinary(String uuid) {
+    // Remove dashes from the UUID string
+    final cleanUuid = uuid.replaceAll(separator, '');
+
+    // Convert the cleaned UUID string to a list of bytes
+    final byteList = <int>[];
+
+    for (var i = 0; i < cleanUuid.length; i += 2) {
+      final byteStr = cleanUuid.substring(i, i + 2);
+      final byteVal = int.parse(byteStr, radix: 16);
+      byteList.add(byteVal);
+    }
+
+    return Uint8List.fromList(byteList);
+  }
+}

--- a/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
@@ -124,7 +124,7 @@ void main() {
       expect(
         CertificateHash.fromC509Certificate(c509Cert),
         equals(
-          CertificateHash.fromHex('312517d13f3a63da8f487f56ded10618'),
+          CertificateHash.fromHex('431d7b744dcc4ac4359b7ee7ffa7be33'),
         ),
       );
     });

--- a/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
@@ -113,7 +113,7 @@ void main() {
       expect(
         CertificateHash.fromX509DerCertificate(derCert),
         equals(
-          CertificateHash.fromHex('c13a67ee9608dc5966aaa91fe3b1f021'),
+          CertificateHash.fromHex('667e69bd56a0fbd2d4db363e3bb017a1'),
         ),
       );
     });

--- a/catalyst_voices_packages/catalyst_cardano_serialization/test/utils/uuid_test.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/test/utils/uuid_test.dart
@@ -1,0 +1,21 @@
+import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(UuidV4, () {
+    const uuidString = '550e8400-e29b-41d4-a716-446655440000';
+    final uuid = UuidV4.fromString(uuidString);
+
+    test('Uuid fromBytes', () {
+      expect(UuidV4.fromBytes(uuid.bytes), equals(uuid));
+    });
+
+    test('UuidV4 fromString', () {
+      expect(UuidV4.fromString(uuidString).toUuidString(), equals(uuidString));
+    });
+
+    test('Uuid fromCbor', () {
+      expect(UuidV4.fromCbor(uuid.toCbor()), equals(uuid));
+    });
+  });
+}


### PR DESCRIPTION
# Description

Addresses wrong assumptions and mistakes in X509 encoding as requested by @stevenj.

### Generated X509 envelope metadata

```
a11901fda50050ca7a1457ef9f4c7f9c747f8c4a4cfa6c01582093e454212640048731a87b0f62dc16495e02eb1d3a36fe199fcd1af4c2540d5e0258204d3f576f26db29139981a69443c2325daa812cc353a31b5a4db794a5bcbb06c20b8c58401b3e030866084fcb259de07496d3197e913a39fd628a3db0a4ed6839261a00c51cb0a5b9c16194064132cc5b77ea23c75c60659400cba304d0d689c00086195d5840ff28714da02c35e7295815ba58b77f227e576fa254c464e2f9c6f9dfa900a0208250033c054a468c38e08819601d073c034a4727a524ef9c4cea77443c1fca235840839c927599b253887f50487c1caf757c0aaf79bc3fcacd42252b8f2ae1f1a8b282929ca22bb5c2885cc23a66005c0cc1ca20142b82310c3a137d44c1943e40995840a7a7ce5c3475b5887a3765ede2ff3b7bfea90f255e2edf37fd44e27f26b8e6cf408aef4b20bebf7257b3dabc7eda65fff4ed278b50219f0a52367ff5b80e46b758403875f55a394d17a5d9a6b1a1deff5b2206e9e9734e9fbefa6a1cdfeb7a104546dfb6e46c46feaeb65a7f4648c276e29e87b27bc053bffef79359300220d0c3875840f2a05cc4880317358e19c758fd9ab9917551ce3987af2e35d73b6958a0f5732784621d0c92f68a93537f16f48445424890f955d7a597c13c2eb54a82b39f0307584097507df5fef916fabb6dafdfb516fb9184783e2cb4e89d048a6c1e5c04818bdb76ffb5cbef1fbe452658d904cd152ee72a3bfc6efe1199fb3b51f1979629cd4e5840fdb7df511723d4cead3d2b2eb9c1f18cbbfcf9f5cc8eac46dc03cd55fcac3303c391437f50400923e65c5a02e981af5461b6867a47fb25ebe9b0fb4d9e41ec2158400e4b9011000206414523c0990f9ee20b5d8a745393d3febaf6413a448b994f1567eb7945df7a0ab44afd55561e0190b376d411026c5d7a4a49a19e0bd3f5addd58406c492fde46eee8d75b587286291dfeb6a78fdf59c1a6bfa2717b1f41dfa878756140ce7c77504b64b094b870ade78569566eec66369133af5aa8c8eab9f95e295840df9ec10be251547101b24c495c8ff4fa55378dbb4a5c6e89b18a12ac033343d61c3b7f5fba725b51536d92a5cb5a8f2b2ddee2d47457a125f3f9ff817539567f4eac0f8200811c822d2210b97f590818635840b71dcaafccab09da10b2a2d3e5ed36d867a3cc0ba93aef399d415f76dd40b481a88188f37113f52c1fb2c04886c37d7d14b7ac8397398afb227d2211d664f70c
```

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
