### PR TITLE
feat!: update transactions inputs hash size

### DIFF
--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/hashes.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/hashes.dart
@@ -92,11 +92,11 @@ final class TransactionHash extends BaseHash {
   int get length => _length;
 }
 
-/// Describes the Blake2b-256 hash of the transaction inputs (UTXOs)
+/// Describes the Blake2b-128 hash of the transaction inputs (UTXOs)
 /// which can be used as a link to a certain transaction
 /// (as UTXOs can only be spent once).
 final class TransactionInputsHash extends BaseHash {
-  static const int _length = 32;
+  static const int _length = 16;
 
   /// Constructs the [TransactionInputsHash] from raw [bytes].
   TransactionInputsHash.fromBytes({required super.bytes}) : super.fromBytes();

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/rbac/x509_metadata_envelope.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/rbac/x509_metadata_envelope.dart
@@ -23,7 +23,7 @@ typedef ChunkedDataDeserializer<T> = T Function(CborValue value);
 /// between those references being altered and closes a potential attack vector
 /// where an unrelated registration update is attached to a different
 /// transaction.
-class X509MetadataEnvelope<T> extends Equatable {
+final class X509MetadataEnvelope<T> extends Equatable {
   /// The size of a chunk of data that is used to overcome
   /// the field size limitation.
   static const int metadataChunkSize = 64;

--- a/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
@@ -51,6 +51,39 @@ void main() {
     });
   });
 
+  group(TransactionInputsHash, () {
+    const hexString = '4d3f576f26db29139981a69443c2325d';
+    final bytes = hex.decode(hexString);
+
+    test('from and to hex', () {
+      final hash = TransactionInputsHash.fromHex(hexString);
+      expect(hash.toHex(), equals(hexString));
+    });
+
+    test('from and to bytes', () {
+      final hash = TransactionInputsHash.fromBytes(bytes: bytes);
+      expect(hash.bytes, equals(bytes));
+    });
+
+    test('from transaction inputs', () {
+      final hash = TransactionInputsHash.fromTransactionInputs([testUtxo()]);
+      expect(
+        hash,
+        equals(
+          TransactionInputsHash.fromHex('26497de5e0c8fe2e4b0c85651f96b3c9'),
+        ),
+      );
+    });
+
+    test('toCbor returns bytes', () {
+      final hash = TransactionInputsHash.fromBytes(bytes: bytes);
+      final encodedCbor = cbor.encode(hash.toCbor());
+      final decodedCbor = cbor.decode(encodedCbor);
+      expect(decodedCbor, isA<CborBytes>());
+      expect((decodedCbor as CborBytes).bytes, equals(bytes));
+    });
+  });
+
   group(AuxiliaryDataHash, () {
     const hexString =
         '4d3f576f26db29139981a69443c2325daa812cc353a31b5a4db794a5bcbb06c2';


### PR DESCRIPTION
# Description

Updates transaction inputs hash size from 32 to 16 bytes. Adds missing tests.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
