### PR TITLE
fix!: signData return type should be DataSignature, not VkeyWitness

### DIFF
--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_data.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_data.dart
@@ -7,13 +7,13 @@ Future<void> _signData({
   var result = '';
 
   try {
-    final rewardAddress = await api.getRewardAddresses();
-    final signer = await api.signData(
-      address: rewardAddress.first,
-      payload: [1, 2, 3],
+    final addresses = await api.getUsedAddresses();
+    final signature = await api.signData(
+      address: addresses.first,
+      payload: 'hello world!'.codeUnits,
     );
 
-    result = 'Signature: ${hex.encode(cbor.encode(signer.toCbor()))}';
+    result = 'Signature: $signature';
   } catch (error) {
     result = error.toString();
   }

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/lib/src/cardano_wallet.dart
@@ -130,7 +130,7 @@ abstract interface class CardanoWalletApi {
   /// reward addresses.
   ///
   /// Throws [WalletDataSignException].
-  Future<VkeyWitness> signData({
+  Future<DataSignature> signData({
     required ShelleyAddress address,
     required List<int> payload,
   });
@@ -242,4 +242,22 @@ final class Paginate extends Equatable {
 
   @override
   List<Object?> get props => [page, limit];
+}
+
+/// The data signature as returned by CIP-30 signData.
+final class DataSignature extends Equatable {
+  /// The public key.
+  final String key;
+
+  /// The signature.
+  final String signature;
+
+  /// The default constructor for [DataSignature].
+  const DataSignature({
+    required this.key,
+    required this.signature,
+  });
+
+  @override
+  List<Object?> get props => [key, signature];
 }

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_interop.dart
@@ -79,7 +79,7 @@ extension type JSCardanoWalletApi(JSObject _) implements JSObject {
   ]);
 
   /// See [CardanoWalletApi.signData].
-  external JSPromise<JSString> signData(
+  external JSPromise<JSDataSignature> signData(
     JSString address,
     JSString payload,
   );
@@ -173,4 +173,22 @@ extension type JSPaginate._(JSObject _) implements JSObject {
 
   /// See [JSPaginate.limit].
   external JSNumber get limit;
+}
+
+/// The JS representation of the [DataSignature].
+extension type JSDataSignature._(JSObject _) implements JSObject {
+  /// The default constructor for [JSDataSignature].
+  external factory JSDataSignature({JSString key, JSString signature});
+
+  /// See [DataSignature.key].
+  external JSString get key;
+
+  /// See [DataSignature.signature].
+  external JSString get signature;
+
+  /// Converts JS representation to pure dart representation.
+  DataSignature get toDart => DataSignature(
+        key: key.toDart,
+        signature: signature.toDart,
+      );
 }

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/lib/src/interop/catalyst_cardano_wallet_proxy.dart
@@ -201,18 +201,18 @@ class JSCardanoWalletApiProxy implements CardanoWalletApi {
   }
 
   @override
-  Future<VkeyWitness> signData({
+  Future<DataSignature> signData({
     required ShelleyAddress address,
     required List<int> payload,
   }) async {
     try {
       return await _delegate
           .signData(
-            hex.encode(cbor.encode(address.toCbor())).toJS,
+            address.toBech32().toJS,
             hex.encode(payload).toJS,
           )
           .toDart
-          .then((e) => VkeyWitness.fromCbor(cbor.decode(hex.decode(e.toDart))));
+          .then((e) => e.toDart);
     } catch (ex) {
       throw _mapApiException(ex) ??
           _mapDataSignException(ex) ??


### PR DESCRIPTION
# Description

Fixes wrong return type from CIP-30 signData method. The data is encoded as JSON, not as CBOR.

Expected result in example app after calling signData:
![Screenshot 2024-07-31 at 10 25 34](https://github.com/user-attachments/assets/29f5f22a-89c3-4e99-9efd-156cccae4c25)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
