### PR TITLE
feat: VoicesButtons

### DIFF
--- a/catalyst_voices/lib/widgets/buttons/voices_button_affix_decoration.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_button_affix_decoration.dart
@@ -1,0 +1,30 @@
+import 'package:catalyst_voices/widgets/common/affix_decorator.dart';
+import 'package:flutter/material.dart';
+
+/// Adding SizedBox.shrink because we want spacing on both sites
+///
+/// See [AffixDecorator] for more context
+///
+/// Note:
+/// This widget should not be exported outside of this package
+class VoicesButtonAffixDecoration extends StatelessWidget {
+  final Widget? leading;
+  final Widget? trailing;
+  final Widget child;
+
+  const VoicesButtonAffixDecoration({
+    super.key,
+    this.leading,
+    this.trailing,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AffixDecorator(
+      prefix: leading ?? (trailing != null ? const SizedBox.shrink() : null),
+      suffix: trailing ?? (leading != null ? const SizedBox.shrink() : null),
+      child: child,
+    );
+  }
+}

--- a/catalyst_voices/lib/widgets/buttons/voices_button_affix_decoration.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_button_affix_decoration.dart
@@ -1,12 +1,12 @@
 import 'package:catalyst_voices/widgets/common/affix_decorator.dart';
 import 'package:flutter/material.dart';
 
-/// Adding SizedBox.shrink because we want spacing on both sites
+/// Adding SizedBox.shrink because we want spacing on both sites.
 ///
-/// See [AffixDecorator] for more context
+/// See [AffixDecorator] for more context.
 ///
 /// Note:
-/// This widget should not be exported outside of this package
+/// This widget should not be exported outside of this package.
 class VoicesButtonAffixDecoration extends StatelessWidget {
   final Widget? leading;
   final Widget? trailing;

--- a/catalyst_voices/lib/widgets/buttons/voices_filled_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_filled_button.dart
@@ -1,0 +1,41 @@
+import 'package:catalyst_voices/widgets/common/prefix_suffix_decorator.dart';
+import 'package:flutter/material.dart';
+
+/// A button that combines a `FilledButton` with optional leading and trailing
+/// elements.
+///
+/// This widget provides a convenient way to add icons or other widgets before
+/// or after the button's main content using a `PrefixSuffixDecorator`.
+class VoicesFilledButton extends StatelessWidget {
+  /// The callback function invoked when the button is pressed.
+  final VoidCallback? onTap;
+
+  /// The widget to be displayed before the button's main content.
+  final Widget? leading;
+
+  /// The widget to be displayed after the button's main content.
+  final Widget? trailing;
+
+  /// The main content of the button.
+  final Widget child;
+
+  const VoicesFilledButton({
+    super.key,
+    this.onTap,
+    this.leading,
+    this.trailing,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton(
+      onPressed: onTap,
+      child: PrefixSuffixDecorator(
+        prefix: leading,
+        suffix: trailing,
+        child: child,
+      ),
+    );
+  }
+}

--- a/catalyst_voices/lib/widgets/buttons/voices_icon_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_icon_button.dart
@@ -1,0 +1,97 @@
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:flutter/material.dart';
+
+enum _Variant { standard, primary, filled, tonal, outlined }
+
+class VoicesIconButton extends StatelessWidget {
+  /// The callback function invoked when the button is pressed.
+  final VoidCallback? onTap;
+
+  /// Icon widget for this button
+  final Widget child;
+
+  final _Variant _variant;
+
+  const VoicesIconButton({
+    super.key,
+    this.onTap,
+    required this.child,
+  }) : _variant = _Variant.standard;
+
+  const VoicesIconButton.primary({
+    super.key,
+    this.onTap,
+    required this.child,
+  }) : _variant = _Variant.primary;
+
+  const VoicesIconButton.filled({
+    super.key,
+    this.onTap,
+    required this.child,
+  }) : _variant = _Variant.filled;
+
+  const VoicesIconButton.tonal({
+    super.key,
+    this.onTap,
+    required this.child,
+  }) : _variant = _Variant.tonal;
+
+  const VoicesIconButton.outlined({
+    super.key,
+    this.onTap,
+    required this.child,
+  }) : _variant = _Variant.outlined;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onTap,
+      style: _buildVariantStyle(context),
+      icon: child,
+    );
+  }
+
+  /// Majority of configuration takes takes places in theme builder
+  /// so we need to override only new properties.
+  ///
+  /// See `catalyst.dart` file in `brands` package
+  ButtonStyle? _buildVariantStyle(BuildContext context) {
+    final themeData = Theme.of(context);
+    final colors = themeData.colors;
+    final colorScheme = themeData.colorScheme;
+
+    return switch (_variant) {
+      /// Default themeData configuration corresponds with this variant
+      _Variant.standard => null,
+      _Variant.primary => IconButton.styleFrom(
+          foregroundColor: colors.iconsPrimary,
+        ),
+      _Variant.filled => IconButton.styleFrom(
+          foregroundColor: colors.iconsBackground,
+          backgroundColor: colorScheme.primary,
+          disabledForegroundColor: colors.iconsDisabled,
+          disabledBackgroundColor: colors.onSurfaceNeutral012,
+        ),
+      _Variant.tonal => IconButton.styleFrom(
+          foregroundColor: colors.iconsForeground,
+          backgroundColor: colors.onSurfacePrimary012,
+          disabledForegroundColor: colors.iconsDisabled,
+          disabledBackgroundColor: colors.onSurfaceNeutral012,
+        ),
+      _Variant.outlined => IconButton.styleFrom(
+          foregroundColor: colors.iconsForeground,
+          backgroundColor: Colors.transparent,
+        ).copyWith(
+          side: WidgetStateProperty.resolveWith(
+            (states) {
+              if (states.contains(WidgetState.disabled)) {
+                return BorderSide(color: colors.onSurfaceNeutral012!);
+              }
+
+              return BorderSide(color: colors.outlineBorderVariant!);
+            },
+          ),
+        ),
+    };
+  }
+}

--- a/catalyst_voices/lib/widgets/buttons/voices_icon_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_icon_button.dart
@@ -7,7 +7,7 @@ class VoicesIconButton extends StatelessWidget {
   /// The callback function invoked when the button is pressed.
   final VoidCallback? onTap;
 
-  /// Icon widget for this button
+  /// Icon widget for this button.
   final Widget child;
 
   final _Variant _variant;
@@ -54,14 +54,14 @@ class VoicesIconButton extends StatelessWidget {
   /// Majority of configuration takes takes places in theme builder
   /// so we need to override only new properties.
   ///
-  /// See `catalyst.dart` file in `brands` package
+  /// See `catalyst.dart` file in `brands` package.
   ButtonStyle? _buildVariantStyle(BuildContext context) {
     final themeData = Theme.of(context);
     final colors = themeData.colors;
     final colorScheme = themeData.colorScheme;
 
     return switch (_variant) {
-      /// Default themeData configuration corresponds with this variant
+      /// Default themeData configuration corresponds with this variant.
       _Variant.standard => null,
       _Variant.primary => IconButton.styleFrom(
           foregroundColor: colors.iconsPrimary,

--- a/catalyst_voices/lib/widgets/buttons/voices_outlined_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_outlined_button.dart
@@ -1,11 +1,11 @@
-import 'package:catalyst_voices/widgets/common/prefix_suffix_decorator.dart';
+import 'package:catalyst_voices/widgets/buttons/voices_button_affix_decoration.dart';
 import 'package:flutter/material.dart';
 
 /// A button that combines a `OutlinedButton` with optional leading and trailing
 /// elements.
 ///
 /// This widget provides a convenient way to add icons or other widgets before
-/// or after the button's main content using a `PrefixSuffixDecorator`.
+/// or after the button's child.
 class VoicesOutlinedButton extends StatelessWidget {
   /// The callback function invoked when the button is pressed.
   final VoidCallback? onTap;
@@ -31,9 +31,9 @@ class VoicesOutlinedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return OutlinedButton(
       onPressed: onTap,
-      child: PrefixSuffixDecorator(
-        prefix: leading,
-        suffix: trailing,
+      child: VoicesButtonAffixDecoration(
+        leading: leading,
+        trailing: trailing,
         child: child,
       ),
     );

--- a/catalyst_voices/lib/widgets/buttons/voices_outlined_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_outlined_button.dart
@@ -1,0 +1,41 @@
+import 'package:catalyst_voices/widgets/common/prefix_suffix_decorator.dart';
+import 'package:flutter/material.dart';
+
+/// A button that combines a `OutlinedButton` with optional leading and trailing
+/// elements.
+///
+/// This widget provides a convenient way to add icons or other widgets before
+/// or after the button's main content using a `PrefixSuffixDecorator`.
+class VoicesOutlinedButton extends StatelessWidget {
+  /// The callback function invoked when the button is pressed.
+  final VoidCallback? onTap;
+
+  /// The widget to be displayed before the button's main content.
+  final Widget? leading;
+
+  /// The widget to be displayed after the button's main content.
+  final Widget? trailing;
+
+  /// The main content of the button.
+  final Widget child;
+
+  const VoicesOutlinedButton({
+    super.key,
+    this.onTap,
+    this.leading,
+    this.trailing,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton(
+      onPressed: onTap,
+      child: PrefixSuffixDecorator(
+        prefix: leading,
+        suffix: trailing,
+        child: child,
+      ),
+    );
+  }
+}

--- a/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
@@ -64,7 +64,7 @@ class VoicesTextButton extends StatelessWidget {
   /// Majority of configuration takes takes places in theme builder
   /// so we need to override only new properties.
   ///
-  /// See `catalyst.dart` file in `brands` package
+  /// See `catalyst.dart` file in `brands` package.
   ButtonStyle? _buildVariantStyle(BuildContext context) {
     return switch (_variant) {
       /// Default theme configuration corresponds with this variant

--- a/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
@@ -1,12 +1,14 @@
 import 'package:catalyst_voices/widgets/buttons/voices_button_affix_decoration.dart';
 import 'package:flutter/material.dart';
 
-/// A button that combines a `FilledButton` with optional leading and trailing
+enum _Type { primary, neutral, secondary }
+
+/// A button that combines a `TextButton` with optional leading and trailing
 /// elements.
 ///
 /// This widget provides a convenient way to add icons or other widgets before
 /// or after the button's child.
-class VoicesFilledButton extends StatelessWidget {
+class VoicesTextButton extends StatelessWidget {
   /// The callback function invoked when the button is pressed.
   final VoidCallback? onTap;
 
@@ -19,7 +21,7 @@ class VoicesFilledButton extends StatelessWidget {
   /// The main content of the button.
   final Widget child;
 
-  const VoicesFilledButton({
+  const VoicesTextButton({
     super.key,
     this.onTap,
     this.leading,
@@ -29,7 +31,7 @@ class VoicesFilledButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return FilledButton(
+    return TextButton(
       onPressed: onTap,
       child: VoicesButtonAffixDecoration(
         leading: leading,

--- a/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
@@ -1,7 +1,8 @@
 import 'package:catalyst_voices/widgets/buttons/voices_button_affix_decoration.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 
-enum _Type { primary, neutral, secondary }
+enum _Variant { primary, neutral, secondary }
 
 /// A button that combines a `TextButton` with optional leading and trailing
 /// elements.
@@ -21,23 +22,55 @@ class VoicesTextButton extends StatelessWidget {
   /// The main content of the button.
   final Widget child;
 
+  final _Variant _variant;
+
   const VoicesTextButton({
     super.key,
     this.onTap,
     this.leading,
     this.trailing,
     required this.child,
-  });
+  }) : _variant = _Variant.primary;
+
+  const VoicesTextButton.neutral({
+    super.key,
+    this.onTap,
+    this.leading,
+    this.trailing,
+    required this.child,
+  }) : _variant = _Variant.neutral;
+
+  const VoicesTextButton.secondary({
+    super.key,
+    this.onTap,
+    this.leading,
+    this.trailing,
+    required this.child,
+  }) : _variant = _Variant.secondary;
 
   @override
   Widget build(BuildContext context) {
     return TextButton(
       onPressed: onTap,
+      style: _buildVariantStyle(context),
       child: VoicesButtonAffixDecoration(
         leading: leading,
         trailing: trailing,
         child: child,
       ),
     );
+  }
+
+  ButtonStyle? _buildVariantStyle(BuildContext context) {
+    return switch (_variant) {
+      /// Default theme configuration corresponds with this variant
+      _Variant.primary => null,
+      _Variant.neutral => TextButton.styleFrom(
+          foregroundColor: Theme.of(context).colors.textPrimary,
+        ),
+      _Variant.secondary => TextButton.styleFrom(
+          foregroundColor: Theme.of(context).colorScheme.secondary,
+        ),
+    };
   }
 }

--- a/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
+++ b/catalyst_voices/lib/widgets/buttons/voices_text_button.dart
@@ -61,6 +61,10 @@ class VoicesTextButton extends StatelessWidget {
     );
   }
 
+  /// Majority of configuration takes takes places in theme builder
+  /// so we need to override only new properties.
+  ///
+  /// See `catalyst.dart` file in `brands` package
   ButtonStyle? _buildVariantStyle(BuildContext context) {
     return switch (_variant) {
       /// Default theme configuration corresponds with this variant

--- a/catalyst_voices/lib/widgets/chips/voices_chip.dart
+++ b/catalyst_voices/lib/widgets/chips/voices_chip.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/widgets/common/prefix_suffix_decorator.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 
@@ -81,30 +82,14 @@ class VoicesChip extends StatelessWidget {
           onTap: onTap,
           child: Padding(
             padding: padding,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (leading != null)
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(end: 8),
-                    child: IconTheme(
-                      data: iconTheme,
-                      child: leading!,
-                    ),
-                  ),
-                DefaultTextStyle(
-                  style: Theme.of(context).textTheme.labelLarge!,
-                  child: content,
-                ),
-                if (trailing != null)
-                  Padding(
-                    padding: const EdgeInsetsDirectional.only(start: 8),
-                    child: IconTheme(
-                      data: iconTheme,
-                      child: trailing!,
-                    ),
-                  ),
-              ],
+            child: PrefixSuffixDecorator(
+              affixIconTheme: iconTheme,
+              prefix: leading,
+              suffix: trailing,
+              child: DefaultTextStyle(
+                style: Theme.of(context).textTheme.labelLarge!,
+                child: content,
+              ),
             ),
           ),
         ),

--- a/catalyst_voices/lib/widgets/chips/voices_chip.dart
+++ b/catalyst_voices/lib/widgets/chips/voices_chip.dart
@@ -1,4 +1,4 @@
-import 'package:catalyst_voices/widgets/common/prefix_suffix_decorator.dart';
+import 'package:catalyst_voices/widgets/common/affix_decorator.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 
@@ -82,8 +82,8 @@ class VoicesChip extends StatelessWidget {
           onTap: onTap,
           child: Padding(
             padding: padding,
-            child: PrefixSuffixDecorator(
-              affixIconTheme: iconTheme,
+            child: AffixDecorator(
+              iconTheme: iconTheme,
               prefix: leading,
               suffix: trailing,
               child: DefaultTextStyle(

--- a/catalyst_voices/lib/widgets/common/affix_decorator.dart
+++ b/catalyst_voices/lib/widgets/common/affix_decorator.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 ///
 /// Example
 /// ```dart
-///     PrefixSuffixDecorator(
-///       affixIconTheme: IconTheme.of(context).copyWith(size: 18),
+///     AffixDecorator(
+///       iconTheme: IconTheme.of(context).copyWith(size: 18),
 ///       prefix: leading,
 ///       suffix: trailing,
 ///       child: DefaultTextStyle(
@@ -17,13 +17,13 @@ import 'package:flutter/material.dart';
 ///       ),
 ///     )
 /// ```
-class PrefixSuffixDecorator extends StatelessWidget {
+class AffixDecorator extends StatelessWidget {
   /// The spacing between the child widget and the prefix/suffix icons.
   final double gap;
 
   /// An optional theme to apply to both prefix and suffix icons.
   /// If not provided, inherits the theme from the context.
-  final IconThemeData? affixIconTheme;
+  final IconThemeData? iconTheme;
 
   /// The widget to be displayed before the child widget.
   final Widget? prefix;
@@ -38,10 +38,10 @@ class PrefixSuffixDecorator extends StatelessWidget {
   ///
   /// At least one of `prefix` or `suffix` should be non-null for the decoration
   /// to be visible.
-  const PrefixSuffixDecorator({
+  const AffixDecorator({
     super.key,
     this.gap = 8,
-    this.affixIconTheme,
+    this.iconTheme,
     this.prefix,
     this.suffix,
     required this.child,
@@ -57,7 +57,7 @@ class PrefixSuffixDecorator extends StatelessWidget {
       children: [
         if (prefix != null) ...[
           IconTheme(
-            data: affixIconTheme ?? IconTheme.of(context),
+            data: iconTheme ?? IconTheme.of(context),
             child: prefix,
           ),
           SizedBox(width: gap),
@@ -66,7 +66,7 @@ class PrefixSuffixDecorator extends StatelessWidget {
         if (suffix != null) ...[
           SizedBox(width: gap),
           IconTheme(
-            data: affixIconTheme ?? IconTheme.of(context),
+            data: iconTheme ?? IconTheme.of(context),
             child: suffix,
           ),
         ],

--- a/catalyst_voices/lib/widgets/common/prefix_suffix_decorator.dart
+++ b/catalyst_voices/lib/widgets/common/prefix_suffix_decorator.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+/// A widget that decorates a child widget with an optional prefix and/or suffix.
+///
+/// This widget allows you to add an icon or any other widget before (prefix)
+/// and/or after (suffix) the child widget, with a customizable gap in between.
+///
+/// Example
+/// ```dart
+///     PrefixSuffixDecorator(
+///       affixIconTheme: IconTheme.of(context).copyWith(size: 18),
+///       prefix: leading,
+///       suffix: trailing,
+///       child: DefaultTextStyle(
+///         style: Theme.of(context).textTheme.labelLarge!,
+///         child: child,
+///       ),
+///     )
+/// ```
+class PrefixSuffixDecorator extends StatelessWidget {
+  /// The spacing between the child widget and the prefix/suffix icons.
+  final double gap;
+
+  /// An optional theme to apply to both prefix and suffix icons.
+  /// If not provided, inherits the theme from the context.
+  final IconThemeData? affixIconTheme;
+
+  /// The widget to be displayed before the child widget.
+  final Widget? prefix;
+
+  /// The widget to be displayed after the child widget.
+  final Widget? suffix;
+
+  /// The widget to be decorated with prefix and/or suffix.
+  final Widget child;
+
+  /// Creates a new instance of PrefixSuffixDecorator.
+  ///
+  /// At least one of `prefix` or `suffix` should be non-null for the decoration
+  /// to be visible.
+  const PrefixSuffixDecorator({
+    super.key,
+    this.gap = 8,
+    this.affixIconTheme,
+    this.prefix,
+    this.suffix,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final suffix = this.suffix;
+    final prefix = this.prefix;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (prefix != null) ...[
+          IconTheme(
+            data: affixIconTheme ?? IconTheme.of(context),
+            child: prefix,
+          ),
+          SizedBox(width: gap),
+        ],
+        Flexible(child: child),
+        if (suffix != null) ...[
+          SizedBox(width: gap),
+          IconTheme(
+            data: affixIconTheme ?? IconTheme.of(context),
+            child: suffix,
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/lib/widgets/widgets.dart
@@ -1,4 +1,5 @@
 export 'buttons/voices_filled_button.dart';
+export 'buttons/voices_outlined_button.dart';
 export 'buttons/voices_segmented_button.dart';
 export 'text_field/voices_email_text_field.dart';
 export 'text_field/voices_password_text_field.dart';

--- a/catalyst_voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/lib/widgets/widgets.dart
@@ -1,6 +1,7 @@
 export 'buttons/voices_filled_button.dart';
 export 'buttons/voices_outlined_button.dart';
 export 'buttons/voices_segmented_button.dart';
+export 'buttons/voices_text_button.dart';
 export 'text_field/voices_email_text_field.dart';
 export 'text_field/voices_password_text_field.dart';
 export 'text_field/voices_text_field.dart';

--- a/catalyst_voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/lib/widgets/widgets.dart
@@ -1,3 +1,4 @@
+export 'buttons/voices_filled_button.dart';
 export 'buttons/voices_segmented_button.dart';
 export 'text_field/voices_email_text_field.dart';
 export 'text_field/voices_password_text_field.dart';

--- a/catalyst_voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/lib/widgets/widgets.dart
@@ -1,4 +1,5 @@
 export 'buttons/voices_filled_button.dart';
+export 'buttons/voices_icon_button.dart';
 export 'buttons/voices_outlined_button.dart';
 export 'buttons/voices_segmented_button.dart';
 export 'buttons/voices_text_button.dart';

--- a/catalyst_voices/packages/catalyst_voices_blocs/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_blocs/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
      path: ../catalyst_voices_services
     catalyst_voices_view_models:
      path: ../catalyst_voices_view_models
-    collection: ^1.17.1
+    collection: ^1.18.0
     equatable: ^2.0.5
     flutter:
       sdk: flutter

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -350,7 +350,12 @@ ThemeData _buildThemeData(
     ),
     textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
+        foregroundColor: colorScheme.primary,
+        backgroundColor: Colors.transparent,
+        disabledForegroundColor: voicesColorScheme.textDisabled,
+        disabledBackgroundColor: Colors.transparent,
         minimumSize: const Size(60, 40),
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
       ).merge(_buildBaseButtonStyle(textTheme)),
     ),
     iconButtonTheme: IconButtonThemeData(

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -314,7 +314,6 @@ ThemeData _buildThemeData(
     ),
 
     //#region Buttons Themes
-    // TODO(damian): Delete buttonBarTheme. ButtonBar is replaced by OverflowBar
     buttonBarTheme: const ButtonBarThemeData(
       buttonHeight: 40,
     ),

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -272,7 +272,7 @@ TextTheme _buildTextTheme(VoicesColorScheme voicesColorScheme) {
 /// few properties that's why we're extracting what's shared.
 ///
 /// ButtonStyle returned by this function is not final and is meant to
-/// be served as further adjustment via .copyWith or .merge
+/// be served as further adjustment via .copyWith or `.merge`.
 ButtonStyle _buildBaseButtonStyle(TextTheme textTheme) {
   return ButtonStyle(
     textStyle: WidgetStatePropertyAll(textTheme.labelLarge),
@@ -288,7 +288,7 @@ ButtonStyle _buildBaseButtonStyle(TextTheme textTheme) {
 /// Note:
 ///
 /// If we're going to introduce other themes then catalyst this method
-/// should be extracted
+/// should be extracted.
 ThemeData _buildThemeData(
   ColorScheme colorScheme,
   VoicesColorScheme voicesColorScheme,

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -1,6 +1,7 @@
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/src/theme_extensions/brand_assets.dart';
 import 'package:catalyst_voices_brands/src/theme_extensions/voices_color_scheme.dart';
+import 'package:catalyst_voices_brands/src/themes/widgets/buttons_theme.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -268,23 +269,6 @@ TextTheme _buildTextTheme(VoicesColorScheme voicesColorScheme) {
   );
 }
 
-/// Most of buttons share same configuration and differ in just a
-/// few properties that's why we're extracting what's shared.
-///
-/// ButtonStyle returned by this function is not final and is meant to
-/// be served as further adjustment via .copyWith or `.merge`.
-ButtonStyle _buildBaseButtonStyle(TextTheme textTheme) {
-  return ButtonStyle(
-    textStyle: WidgetStatePropertyAll(textTheme.labelLarge),
-    minimumSize: const WidgetStatePropertyAll(Size(85, 40)),
-    iconSize: const WidgetStatePropertyAll(16),
-    shape: const WidgetStatePropertyAll(StadiumBorder()),
-    padding: const WidgetStatePropertyAll(
-      EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-    ),
-  );
-}
-
 /// Note:
 ///
 /// If we're going to introduce other themes then catalyst this method
@@ -312,92 +296,11 @@ ThemeData _buildThemeData(
     dividerTheme: DividerThemeData(
       color: colorScheme.outlineVariant,
     ),
-
-    //#region Buttons Themes
-    buttonBarTheme: const ButtonBarThemeData(
-      buttonHeight: 40,
-    ),
-    filledButtonTheme: FilledButtonThemeData(
-      style: FilledButton.styleFrom(
-        foregroundColor: colorScheme.onPrimary,
-        backgroundColor: colorScheme.primary,
-        disabledForegroundColor: voicesColorScheme.textDisabled,
-        disabledBackgroundColor: voicesColorScheme.onSurfaceNeutral012,
-      ).merge(_buildBaseButtonStyle(textTheme)),
-    ),
-    outlinedButtonTheme: OutlinedButtonThemeData(
-      style: OutlinedButton.styleFrom(
-        foregroundColor: colorScheme.primary,
-        backgroundColor: Colors.transparent,
-        disabledForegroundColor: voicesColorScheme.textDisabled,
-        disabledBackgroundColor: Colors.transparent,
-      ).copyWith(
-        side: WidgetStateProperty.resolveWith(
-          (states) {
-            if (states.contains(WidgetState.disabled)) {
-              return BorderSide(color: voicesColorScheme.onSurfaceNeutral012!);
-            }
-
-            if (states.contains(WidgetState.focused)) {
-              return BorderSide(color: colorScheme.primary);
-            }
-
-            return BorderSide(color: voicesColorScheme.outlineBorder!);
-          },
-        ),
-      ).merge(_buildBaseButtonStyle(textTheme)),
-    ),
-    textButtonTheme: TextButtonThemeData(
-      style: TextButton.styleFrom(
-        foregroundColor: colorScheme.primary,
-        backgroundColor: Colors.transparent,
-        disabledForegroundColor: voicesColorScheme.textDisabled,
-        disabledBackgroundColor: Colors.transparent,
-        minimumSize: const Size(60, 40),
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
-      ).merge(_buildBaseButtonStyle(textTheme)),
-    ),
-    iconButtonTheme: IconButtonThemeData(
-      style: IconButton.styleFrom(
-        foregroundColor: voicesColorScheme.iconsForeground,
-        backgroundColor: Colors.transparent,
-        disabledForegroundColor: voicesColorScheme.iconsDisabled,
-        disabledBackgroundColor: Colors.transparent,
-        minimumSize: const Size.square(40),
-        iconSize: 24,
-        shape: const CircleBorder(),
-      ).merge(_buildBaseButtonStyle(textTheme)),
-    ),
-    segmentedButtonTheme: SegmentedButtonThemeData(
-      style: SegmentedButton.styleFrom(
-        foregroundColor: voicesColorScheme.textOnPrimary,
-        backgroundColor: Colors.transparent,
-        selectedForegroundColor: voicesColorScheme.textOnPrimary,
-        selectedBackgroundColor: voicesColorScheme.onSurfacePrimary012,
-        disabledForegroundColor: voicesColorScheme.iconsDisabled,
-        disabledBackgroundColor: Colors.transparent,
-        textStyle: textTheme.labelLarge,
-      ).copyWith(
-        side: WidgetStateProperty.resolveWith(
-          (states) {
-            if (states.contains(WidgetState.disabled)) {
-              return BorderSide(color: voicesColorScheme.iconsDisabled!);
-            }
-
-            return BorderSide(color: voicesColorScheme.outlineBorder!);
-          },
-        ),
-        iconSize: const WidgetStatePropertyAll(18),
-      ),
-      selectedIcon: const Icon(Icons.check),
-    ),
-    //#endregion
-
     textTheme: textTheme,
     colorScheme: colorScheme,
     extensions: <ThemeExtension<dynamic>>[
       voicesColorScheme,
       brandAssets,
     ],
-  );
+  ).copyWithButtonsTheme();
 }

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -327,7 +327,26 @@ ThemeData _buildThemeData(
       ).merge(_buildBaseButtonStyle(textTheme)),
     ),
     outlinedButtonTheme: OutlinedButtonThemeData(
-      style: OutlinedButton.styleFrom().merge(_buildBaseButtonStyle(textTheme)),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: colorScheme.primary,
+        backgroundColor: Colors.transparent,
+        disabledForegroundColor: voicesColorScheme.textDisabled,
+        disabledBackgroundColor: Colors.transparent,
+      ).copyWith(
+        side: WidgetStateProperty.resolveWith(
+          (states) {
+            if (states.contains(WidgetState.disabled)) {
+              return BorderSide(color: voicesColorScheme.onSurfaceNeutral012!);
+            }
+
+            if (states.contains(WidgetState.focused)) {
+              return BorderSide(color: colorScheme.primary);
+            }
+
+            return BorderSide(color: voicesColorScheme.outlineBorder!);
+          },
+        ),
+      ).merge(_buildBaseButtonStyle(textTheme)),
     ),
     textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 const ColorScheme darkColorScheme = ColorScheme.dark(
   primary: VoicesColors.darkPrimary,
+  onPrimary: VoicesColors.darkOnPrimary,
   primaryContainer: VoicesColors.darkPrimaryContainer,
   onPrimaryContainer: VoicesColors.darkOnPrimaryContainer,
   secondary: VoicesColors.darkSecondary,
@@ -72,6 +73,8 @@ const VoicesColorScheme darkVoicesColorScheme = VoicesColorScheme(
 
 const ColorScheme lightColorScheme = ColorScheme.light(
   primary: VoicesColors.lightPrimary,
+  // ignore: avoid_redundant_argument_values
+  onPrimary: VoicesColors.lightOnPrimary,
   primaryContainer: VoicesColors.lightPrimaryContainer,
   onPrimaryContainer: VoicesColors.lightOnPrimaryContainer,
   secondary: VoicesColors.lightSecondary,
@@ -265,6 +268,27 @@ TextTheme _buildTextTheme(VoicesColorScheme voicesColorScheme) {
   );
 }
 
+/// Most of buttons share same configuration and differ in just a
+/// few properties that's why we're extracting what's shared.
+///
+/// ButtonStyle returned by this function is not final and is meant to
+/// be served as further adjustment via .copyWith or .merge
+ButtonStyle _buildBaseButtonStyle(TextTheme textTheme) {
+  return ButtonStyle(
+    textStyle: WidgetStatePropertyAll(textTheme.labelLarge),
+    minimumSize: const WidgetStatePropertyAll(Size(85, 40)),
+    iconSize: const WidgetStatePropertyAll(16),
+    shape: const WidgetStatePropertyAll(StadiumBorder()),
+    padding: const WidgetStatePropertyAll(
+      EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+    ),
+  );
+}
+
+/// Note:
+///
+/// If we're going to introduce other themes then catalyst this method
+/// should be extracted
 ThemeData _buildThemeData(
   ColorScheme colorScheme,
   VoicesColorScheme voicesColorScheme,
@@ -275,25 +299,6 @@ ThemeData _buildThemeData(
   return ThemeData(
     appBarTheme: AppBarTheme(
       backgroundColor: voicesColorScheme.onSurfaceNeutralOpaqueLv1,
-    ),
-    filledButtonTheme: FilledButtonThemeData(
-      style: FilledButton.styleFrom(
-        minimumSize: const Size(48, 48),
-      ),
-    ),
-    outlinedButtonTheme: OutlinedButtonThemeData(
-      style: OutlinedButton.styleFrom(
-        minimumSize: const Size(48, 48),
-      ),
-    ),
-    buttonBarTheme: const ButtonBarThemeData(
-      buttonHeight: 40,
-    ),
-    iconButtonTheme: IconButtonThemeData(
-      style: IconButton.styleFrom(
-        foregroundColor: voicesColorScheme.iconsForeground,
-        iconSize: 24,
-      ),
     ),
     drawerTheme: DrawerThemeData(
       backgroundColor: voicesColorScheme.elevationsOnSurfaceNeutralLv0,
@@ -306,6 +311,35 @@ ThemeData _buildThemeData(
     ),
     dividerTheme: DividerThemeData(
       color: colorScheme.outlineVariant,
+    ),
+
+    //#region Buttons Themes
+    // TODO(damian): Delete buttonBarTheme. ButtonBar is replaced by OverflowBar
+    buttonBarTheme: const ButtonBarThemeData(
+      buttonHeight: 40,
+    ),
+    filledButtonTheme: FilledButtonThemeData(
+      style: FilledButton.styleFrom(
+        foregroundColor: colorScheme.onPrimary,
+        backgroundColor: colorScheme.primary,
+        disabledForegroundColor: voicesColorScheme.textDisabled,
+        disabledBackgroundColor: voicesColorScheme.onSurfaceNeutral012,
+      ).merge(_buildBaseButtonStyle(textTheme)),
+    ),
+    outlinedButtonTheme: OutlinedButtonThemeData(
+      style: OutlinedButton.styleFrom().merge(_buildBaseButtonStyle(textTheme)),
+    ),
+    textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+        minimumSize: const Size(60, 40),
+      ).merge(_buildBaseButtonStyle(textTheme)),
+    ),
+    iconButtonTheme: IconButtonThemeData(
+      style: IconButton.styleFrom(
+        foregroundColor: voicesColorScheme.iconsForeground,
+        minimumSize: const Size.square(48),
+        iconSize: 24,
+      ).merge(_buildBaseButtonStyle(textTheme)),
     ),
     segmentedButtonTheme: SegmentedButtonThemeData(
       style: SegmentedButton.styleFrom(
@@ -330,6 +364,8 @@ ThemeData _buildThemeData(
       ),
       selectedIcon: const Icon(Icons.check),
     ),
+    //#endregion
+
     textTheme: textTheme,
     colorScheme: colorScheme,
     extensions: <ThemeExtension<dynamic>>[

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -361,8 +361,12 @@ ThemeData _buildThemeData(
     iconButtonTheme: IconButtonThemeData(
       style: IconButton.styleFrom(
         foregroundColor: voicesColorScheme.iconsForeground,
-        minimumSize: const Size.square(48),
+        backgroundColor: Colors.transparent,
+        disabledForegroundColor: voicesColorScheme.iconsDisabled,
+        disabledBackgroundColor: Colors.transparent,
+        minimumSize: const Size.square(40),
         iconSize: 24,
+        shape: const CircleBorder(),
       ).merge(_buildBaseButtonStyle(textTheme)),
     ),
     segmentedButtonTheme: SegmentedButtonThemeData(

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/widgets/buttons_theme.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/widgets/buttons_theme.dart
@@ -1,0 +1,107 @@
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:flutter/material.dart';
+
+extension ButtonsThemeExt on ThemeData {
+  /// Applies Buttons themes configuration.
+  ///
+  /// Reasoning behind having it as extension is readability mostly and
+  /// reusability if we're going to have more brands.
+  ThemeData copyWithButtonsTheme() {
+    return copyWith(
+      buttonBarTheme: const ButtonBarThemeData(
+        buttonHeight: 40,
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          foregroundColor: colorScheme.onPrimary,
+          backgroundColor: colorScheme.primary,
+          disabledForegroundColor: colors.textDisabled,
+          disabledBackgroundColor: colors.onSurfaceNeutral012,
+        ).merge(_buildBaseButtonStyle(textTheme)),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: colorScheme.primary,
+          backgroundColor: Colors.transparent,
+          disabledForegroundColor: colors.textDisabled,
+          disabledBackgroundColor: Colors.transparent,
+        ).copyWith(
+          side: WidgetStateProperty.resolveWith(
+            (states) {
+              if (states.contains(WidgetState.disabled)) {
+                return BorderSide(color: colors.onSurfaceNeutral012!);
+              }
+
+              if (states.contains(WidgetState.focused)) {
+                return BorderSide(color: colorScheme.primary);
+              }
+
+              return BorderSide(color: colors.outlineBorder!);
+            },
+          ),
+        ).merge(_buildBaseButtonStyle(textTheme)),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: colorScheme.primary,
+          backgroundColor: Colors.transparent,
+          disabledForegroundColor: colors.textDisabled,
+          disabledBackgroundColor: Colors.transparent,
+          minimumSize: const Size(60, 40),
+          padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 12),
+        ).merge(_buildBaseButtonStyle(textTheme)),
+      ),
+      iconButtonTheme: IconButtonThemeData(
+        style: IconButton.styleFrom(
+          foregroundColor: colors.iconsForeground,
+          backgroundColor: Colors.transparent,
+          disabledForegroundColor: colors.iconsDisabled,
+          disabledBackgroundColor: Colors.transparent,
+          minimumSize: const Size.square(40),
+          iconSize: 24,
+          shape: const CircleBorder(),
+        ).merge(_buildBaseButtonStyle(textTheme)),
+      ),
+      segmentedButtonTheme: SegmentedButtonThemeData(
+        style: SegmentedButton.styleFrom(
+          foregroundColor: colors.textOnPrimary,
+          backgroundColor: Colors.transparent,
+          selectedForegroundColor: colors.textOnPrimary,
+          selectedBackgroundColor: colors.onSurfacePrimary012,
+          disabledForegroundColor: colors.iconsDisabled,
+          disabledBackgroundColor: Colors.transparent,
+          textStyle: textTheme.labelLarge,
+        ).copyWith(
+          side: WidgetStateProperty.resolveWith(
+            (states) {
+              if (states.contains(WidgetState.disabled)) {
+                return BorderSide(color: colors.iconsDisabled!);
+              }
+
+              return BorderSide(color: colors.outlineBorder!);
+            },
+          ),
+          iconSize: const WidgetStatePropertyAll(18),
+        ),
+        selectedIcon: const Icon(Icons.check),
+      ),
+    );
+  }
+}
+
+/// Most of buttons share same configuration and differ in just a
+/// few properties that's why we're extracting what's shared.
+///
+/// ButtonStyle returned by this function is not final and is meant to
+/// be served as further adjustment via .copyWith or `.merge`.
+ButtonStyle _buildBaseButtonStyle(TextTheme textTheme) {
+  return ButtonStyle(
+    textStyle: WidgetStatePropertyAll(textTheme.labelLarge),
+    minimumSize: const WidgetStatePropertyAll(Size(85, 40)),
+    iconSize: const WidgetStatePropertyAll(16),
+    shape: const WidgetStatePropertyAll(StadiumBorder()),
+    padding: const WidgetStatePropertyAll(
+      EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+    ),
+  );
+}

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
@@ -28,31 +29,48 @@ class VoicesButtonsExample extends StatelessWidget {
       appBar: AppBar(title: const Text('Voices Buttons')),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: _ButtonType.values
-              .map(
-                (type) {
-                  return [
-                    Text(
-                      type.name,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                    _ButtonRow(type: type),
-                    _ButtonRow(type: type, addLeadingIcon: true),
-                    _ButtonRow(type: type, addTrailingIcon: true),
-                  ];
-                },
-              )
-              .flattened
-              .expandIndexed(
-                (index, element) => [
-                  if (index != 0) const SizedBox(height: 16),
-                  element,
-                ],
-              )
-              .toList(),
+        child: ListView.separated(
+          itemBuilder: (context, index) {
+            final type = _ButtonType.values[index];
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _SectionText(type.name, key: ObjectKey(type)),
+                const SizedBox(height: 16),
+                _ButtonRow(type: type),
+                const SizedBox(height: 16),
+                _ButtonRow(type: type, addLeadingIcon: true),
+                const SizedBox(height: 16),
+                _ButtonRow(type: type, addTrailingIcon: true),
+              ],
+            );
+          },
+          separatorBuilder: (_, __) => const SizedBox(height: 16),
+          itemCount: _ButtonType.values.length,
         ),
       ),
+    );
+  }
+}
+
+class _SectionText extends StatelessWidget {
+  const _SectionText(
+    this.data, {
+    super.key,
+  });
+
+  final String data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      data,
+      style: theme.textTheme.titleMedium?.copyWith(
+        color: theme.colors.textPrimary,
+      ),
+      textAlign: TextAlign.start,
     );
   }
 }

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -6,8 +6,8 @@ enum _ButtonType {
   filled,
   outlined,
   text,
-  // textNeutral,
-  // textSecondary,
+  textNeutral,
+  textSecondary,
   // icon,
   // iconPrimary,
   // iconFilled,
@@ -28,11 +28,15 @@ class VoicesButtonsExample extends StatelessWidget {
       appBar: AppBar(title: const Text('Buttons')),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: Column(
+        child: ListView(
           children: _ButtonType.values
               .map(
                 (type) {
                   return [
+                    Text(
+                      type.name,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
                     _ButtonRow(type: type),
                     _ButtonRow(type: type, addLeadingIcon: true),
                     _ButtonRow(type: type, addTrailingIcon: true),
@@ -106,6 +110,18 @@ class _ButtonRow extends StatelessWidget {
           child: const Text('Label'),
         ),
       _ButtonType.text => VoicesTextButton(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          leading: addLeadingIcon ? const Icon(Icons.add) : null,
+          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          child: const Text('Label'),
+        ),
+      _ButtonType.textNeutral => VoicesTextButton.neutral(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          leading: addLeadingIcon ? const Icon(Icons.add) : null,
+          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          child: const Text('Label'),
+        ),
+      _ButtonType.textSecondary => VoicesTextButton.secondary(
           onTap: state == _ButtonState.disabled ? null : () {},
           leading: addLeadingIcon ? const Icon(Icons.add) : null,
           trailing: addTrailingIcon ? const Icon(Icons.add) : null,

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 enum _ButtonType {
   filled,
   outlined,
-  // text,
+  text,
   // textNeutral,
   // textSecondary,
   // icon,
@@ -100,6 +100,12 @@ class _ButtonRow extends StatelessWidget {
           child: const Text('Label'),
         ),
       _ButtonType.outlined => VoicesOutlinedButton(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          leading: addLeadingIcon ? const Icon(Icons.add) : null,
+          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          child: const Text('Label'),
+        ),
+      _ButtonType.text => VoicesTextButton(
           onTap: state == _ButtonState.disabled ? null : () {},
           leading: addLeadingIcon ? const Icon(Icons.add) : null,
           trailing: addTrailingIcon ? const Icon(Icons.add) : null,

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -1,0 +1,104 @@
+import 'package:catalyst_voices/widgets/buttons/voices_filled_button.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+enum _ButtonType {
+  filled,
+  // outlined,
+  // text,
+  // textNeutral,
+  // textSecondary,
+  // icon,
+  // iconPrimary,
+  // iconFilled,
+  // iconTonal,
+  // iconOutlined;
+}
+
+enum _ButtonState { normal, disabled }
+
+class VoicesButtonsExample extends StatelessWidget {
+  static const String route = '/buttons-example';
+
+  const VoicesButtonsExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Buttons')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: _ButtonType.values
+              .map(
+                (type) {
+                  return [
+                    _ButtonRow(type: type),
+                    _ButtonRow(type: type, addLeadingIcon: true),
+                    _ButtonRow(type: type, addTrailingIcon: true),
+                  ];
+                },
+              )
+              .flattened
+              .expandIndexed(
+                (index, element) => [
+                  if (index != 0) const SizedBox(height: 16),
+                  element,
+                ],
+              )
+              .toList(),
+        ),
+      ),
+    );
+  }
+}
+
+class _ButtonRow extends StatelessWidget {
+  const _ButtonRow({
+    required this.type,
+    this.addLeadingIcon = false,
+    this.addTrailingIcon = false,
+  });
+
+  final _ButtonType type;
+  final bool addLeadingIcon;
+  final bool addTrailingIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: _ButtonState.values
+          .map((state) {
+            return _buildButton(
+              type,
+              state,
+              addLeadingIcon: addLeadingIcon,
+              addTrailingIcon: addTrailingIcon,
+            );
+          })
+          .expandIndexed(
+            (index, element) => [
+              if (index != 0) const SizedBox(width: 16),
+              element,
+            ],
+          )
+          .toList(),
+    );
+  }
+
+  Widget _buildButton(
+    _ButtonType type,
+    _ButtonState state, {
+    bool addLeadingIcon = false,
+    bool addTrailingIcon = false,
+  }) {
+    return switch (type) {
+      _ButtonType.filled => VoicesFilledButton(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          leading: addLeadingIcon ? const Icon(Icons.add) : null,
+          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          child: const Text('Label'),
+        )
+    };
+  }
+}

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -39,10 +39,18 @@ class VoicesButtonsExample extends StatelessWidget {
                 _SectionText(type.name, key: ObjectKey(type)),
                 const SizedBox(height: 16),
                 _ButtonRow(type: type),
-                const SizedBox(height: 16),
-                _ButtonRow(type: type, addLeadingIcon: true),
-                const SizedBox(height: 16),
-                _ButtonRow(type: type, addTrailingIcon: true),
+                if (!type.name.startsWith('icon')) ...[
+                  const SizedBox(height: 16),
+                  _ButtonRow(type: type, addLeadingIcon: true),
+                  const SizedBox(height: 16),
+                  _ButtonRow(type: type, addTrailingIcon: true),
+                  const SizedBox(height: 16),
+                  _ButtonRow(
+                    type: type,
+                    addLeadingIcon: true,
+                    addTrailingText: true,
+                  ),
+                ],
               ],
             );
           },
@@ -80,22 +88,28 @@ class _ButtonRow extends StatelessWidget {
     required this.type,
     this.addLeadingIcon = false,
     this.addTrailingIcon = false,
+    this.addTrailingText = false,
   });
 
   final _ButtonType type;
   final bool addLeadingIcon;
   final bool addTrailingIcon;
+  final bool addTrailingText;
 
   @override
   Widget build(BuildContext context) {
     return Row(
       children: _ButtonState.values
-          .map((state) {
+          .map<Widget>((state) {
             return _buildButton(
               type,
               state,
-              addLeadingIcon: addLeadingIcon,
-              addTrailingIcon: addTrailingIcon,
+              leading: addLeadingIcon ? const Icon(Icons.add) : null,
+              trailing: addTrailingIcon
+                  ? const Icon(Icons.add)
+                  : addTrailingText
+                      ? const Text(r'$4.44')
+                      : null,
             );
           })
           .expandIndexed(
@@ -111,38 +125,38 @@ class _ButtonRow extends StatelessWidget {
   Widget _buildButton(
     _ButtonType type,
     _ButtonState state, {
-    bool addLeadingIcon = false,
-    bool addTrailingIcon = false,
+    Widget? leading,
+    Widget? trailing,
   }) {
     return switch (type) {
       _ButtonType.filled => VoicesFilledButton(
           onTap: state == _ButtonState.disabled ? null : () {},
-          leading: addLeadingIcon ? const Icon(Icons.add) : null,
-          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          leading: leading,
+          trailing: trailing,
           child: const Text('Label'),
         ),
       _ButtonType.outlined => VoicesOutlinedButton(
           onTap: state == _ButtonState.disabled ? null : () {},
-          leading: addLeadingIcon ? const Icon(Icons.add) : null,
-          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          leading: leading,
+          trailing: trailing,
           child: const Text('Label'),
         ),
       _ButtonType.text => VoicesTextButton(
           onTap: state == _ButtonState.disabled ? null : () {},
-          leading: addLeadingIcon ? const Icon(Icons.add) : null,
-          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          leading: leading,
+          trailing: trailing,
           child: const Text('Label'),
         ),
       _ButtonType.textNeutral => VoicesTextButton.neutral(
           onTap: state == _ButtonState.disabled ? null : () {},
-          leading: addLeadingIcon ? const Icon(Icons.add) : null,
-          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          leading: leading,
+          trailing: trailing,
           child: const Text('Label'),
         ),
       _ButtonType.textSecondary => VoicesTextButton.secondary(
           onTap: state == _ButtonState.disabled ? null : () {},
-          leading: addLeadingIcon ? const Icon(Icons.add) : null,
-          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          leading: leading,
+          trailing: trailing,
           child: const Text('Label'),
         ),
       _ButtonType.icon => VoicesIconButton(

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -25,7 +25,7 @@ class VoicesButtonsExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Buttons')),
+      appBar: AppBar(title: const Text('Voices Buttons')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: ListView(

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -1,10 +1,10 @@
-import 'package:catalyst_voices/widgets/buttons/voices_filled_button.dart';
+import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 enum _ButtonType {
   filled,
-  // outlined,
+  outlined,
   // text,
   // textNeutral,
   // textSecondary,
@@ -98,7 +98,13 @@ class _ButtonRow extends StatelessWidget {
           leading: addLeadingIcon ? const Icon(Icons.add) : null,
           trailing: addTrailingIcon ? const Icon(Icons.add) : null,
           child: const Text('Label'),
-        )
+        ),
+      _ButtonType.outlined => VoicesOutlinedButton(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          leading: addLeadingIcon ? const Icon(Icons.add) : null,
+          trailing: addTrailingIcon ? const Icon(Icons.add) : null,
+          child: const Text('Label'),
+        ),
     };
   }
 }

--- a/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_buttons_example.dart
@@ -8,11 +8,11 @@ enum _ButtonType {
   text,
   textNeutral,
   textSecondary,
-  // icon,
-  // iconPrimary,
-  // iconFilled,
-  // iconTonal,
-  // iconOutlined;
+  icon,
+  iconPrimary,
+  iconFilled,
+  iconTonal,
+  iconOutlined;
 }
 
 enum _ButtonState { normal, disabled }
@@ -126,6 +126,26 @@ class _ButtonRow extends StatelessWidget {
           leading: addLeadingIcon ? const Icon(Icons.add) : null,
           trailing: addTrailingIcon ? const Icon(Icons.add) : null,
           child: const Text('Label'),
+        ),
+      _ButtonType.icon => VoicesIconButton(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          child: const Icon(Icons.close),
+        ),
+      _ButtonType.iconPrimary => VoicesIconButton.primary(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          child: const Icon(Icons.close),
+        ),
+      _ButtonType.iconFilled => VoicesIconButton.filled(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          child: const Icon(Icons.close),
+        ),
+      _ButtonType.iconTonal => VoicesIconButton.tonal(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          child: const Icon(Icons.close),
+        ),
+      _ButtonType.iconOutlined => VoicesIconButton.outlined(
+          onTap: state == _ButtonState.disabled ? null : () {},
+          child: const Icon(Icons.close),
         ),
     };
   }

--- a/catalyst_voices/uikit_example/lib/examples_list.dart
+++ b/catalyst_voices/uikit_example/lib/examples_list.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:catalyst_voices/widgets/menu/voices_list_tile.dart';
 import 'package:flutter/material.dart';
+import 'package:uikit_example/examples/voices_buttons_example.dart';
 import 'package:uikit_example/examples/voices_chip_example.dart';
 import 'package:uikit_example/examples/voices_navigation_example.dart';
 import 'package:uikit_example/examples/voices_segmented_button_example.dart';
@@ -29,6 +30,11 @@ class ExamplesListPage extends StatelessWidget {
         title: 'Voices SegmentedButton',
         route: VoicesSegmentedButtonExample.route,
         page: VoicesSegmentedButtonExample(),
+      ),
+      ExampleTile(
+        title: 'Voices Buttons',
+        route: VoicesButtonsExample.route,
+        page: VoicesButtonsExample(),
       ),
     ];
   }

--- a/catalyst_voices/uikit_example/pubspec.yaml
+++ b/catalyst_voices/uikit_example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     path: ../packages/catalyst_voices_brands
   catalyst_voices_localization:
     path: ../packages/catalyst_voices_localization
+  collection: ^1.18.0
   cupertino_icons: ^1.0.6
   flutter:
     sdk: flutter

--- a/melos.yaml
+++ b/melos.yaml
@@ -20,7 +20,7 @@ command:
     dependencies:
       bloc_concurrency: ^0.2.2
       bloc: ^8.1.2
-      collection: ^1.17.1
+      collection: ^1.18.0
       cryptography: ^2.7.0
       equatable: ^2.0.5
       flutter_localized_locales: ^2.0.5


### PR DESCRIPTION
# Description

- Add all variants of `VoicesButtons*` for Catalyst Voice frontend

## Demo


https://github.com/user-attachments/assets/526e8689-41cd-41a5-a744-3ac89db10154


## Related Issue(s)

Closes #651 

## Description of Changes

- Introduce `AffixDecorator` widget which encapsulates repeatable logic in all buttons as well as in  `VoicesChip`
