### PR TITLE
fix: rbac txn inputs hash

### DIFF
--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_rbac_tx.dart
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/lib/sign_and_submit_rbac_tx.dart
@@ -81,7 +81,7 @@ Future<void> _signAndSubmitRbacTx({
     );
 
     final x509Envelope = await _buildMetadataEnvelope(
-      inputs: utxos,
+      utxos: utxos,
     );
 
     final auxiliaryData = AuxiliaryData.fromCbor(
@@ -119,14 +119,14 @@ Future<void> _signAndSubmitRbacTx({
 }
 
 Future<X509MetadataEnvelope<RegistrationData>> _buildMetadataEnvelope({
-  required List<TransactionUnspentOutput> inputs,
+  required List<TransactionUnspentOutput> utxos,
 }) async {
   final keyPair =
       await Ed25519KeyPair.fromSeed(Ed25519PrivateKey.seeded(0).bytes);
 
   final x509Envelope = X509MetadataEnvelope.unsigned(
     purpose: UuidV4.fromString(_catalystUserRoleRegistrationPurpose),
-    txInputsHash: TransactionInputsHash.fromTransactionInputs(inputs),
+    txInputsHash: TransactionInputsHash.fromTransactionInputs(utxos),
     previousTransactionId: _transactionHash,
     chunkedData: RegistrationData(
       derCerts: [_derCert],

--- a/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/hashes.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/lib/src/hashes.dart
@@ -107,13 +107,13 @@ final class TransactionInputsHash extends BaseHash {
 
   /// Constructs the [TransactionInputsHash] from a [TransactionBody].
   TransactionInputsHash.fromTransactionInputs(
-    List<TransactionUnspentOutput> inputs,
+    List<TransactionUnspentOutput> utxos,
   ) : super.fromBytes(
           bytes: Hash.blake2b(
             Uint8List.fromList(
               cbor.encode(
                 CborList([
-                  for (final input in inputs) input.toCbor(),
+                  for (final utxo in utxos) utxo.input.toCbor(),
                 ]),
               ),
             ),

--- a/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/test/hashes_test.dart
@@ -70,7 +70,7 @@ void main() {
       expect(
         hash,
         equals(
-          TransactionInputsHash.fromHex('26497de5e0c8fe2e4b0c85651f96b3c9'),
+          TransactionInputsHash.fromHex('7336167445e63489f9c477367fd7a529'),
         ),
       );
     });


### PR DESCRIPTION
# Description

Transaction inputs hash should be generated only from the UTXO inputs, not from the whole UTXO that contains outputs too.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
