### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,76 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-09-03
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`catalyst_analysis` - `v2.0.0`](#catalyst_analysis---v200)
+ - [`catalyst_cardano` - `v0.3.0`](#catalyst_cardano---v030)
+ - [`catalyst_cardano_platform_interface` - `v0.3.0`](#catalyst_cardano_platform_interface---v030)
+ - [`catalyst_cardano_serialization` - `v0.4.0`](#catalyst_cardano_serialization---v040)
+ - [`catalyst_cardano_web` - `v0.3.0`](#catalyst_cardano_web---v030)
+ - [`catalyst_compression` - `v0.3.0`](#catalyst_compression---v030)
+ - [`catalyst_compression_platform_interface` - `v0.2.0`](#catalyst_compression_platform_interface---v020)
+ - [`catalyst_compression_web` - `v0.3.0`](#catalyst_compression_web---v030)
+ - [`catalyst_cose` - `v0.3.0`](#catalyst_cose---v030)
+
+Packages with other changes:
+
+ - There are no other changes in this release.
+
+---
+
+#### `catalyst_analysis` - `v2.0.0`
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_cardano` - `v0.3.0`
+
+ - **FIX**: catalyst cardano null utxos ([#746](https://github.com/input-output-hk/catalyst-voices/issues/746)). ([3f2f5925](https://github.com/input-output-hk/catalyst-voices/commit/3f2f592593efe306f85fb0e81ce07aa1ea90b7b6))
+ - **FIX**: rbac txn inputs hash ([#688](https://github.com/input-output-hk/catalyst-voices/issues/688)). ([b644026f](https://github.com/input-output-hk/catalyst-voices/commit/b644026fa3b675591d071819eda185365257f0d1))
+ - **BREAKING** **FEAT**: add initial support for Cardano Native scripts, Plutus scripts, advanced transaction outputs, and additional transaction body fields and witnesses ([#713](https://github.com/input-output-hk/catalyst-voices/issues/713)). ([74fcb725](https://github.com/input-output-hk/catalyst-voices/commit/74fcb725f221bb3acf3824a3dd18a073d0a321e0))
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_cardano_platform_interface` - `v0.3.0`
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_cardano_serialization` - `v0.4.0`
+
+ - **FIX**: to be signed message should be a plain cbor sequence ([#701](https://github.com/input-output-hk/catalyst-voices/issues/701)). ([7c2dec6e](https://github.com/input-output-hk/catalyst-voices/commit/7c2dec6e2f91c1f18a39e7646ee3a5ca6a6e7249))
+ - **FIX**: rbac txn inputs hash ([#688](https://github.com/input-output-hk/catalyst-voices/issues/688)). ([b644026f](https://github.com/input-output-hk/catalyst-voices/commit/b644026fa3b675591d071819eda185365257f0d1))
+ - **FEAT**(catalyst_cardano_serialization): add CborEncodable interface for standardized CBOR handling ([#696](https://github.com/input-output-hk/catalyst-voices/issues/696)). ([4222926f](https://github.com/input-output-hk/catalyst-voices/commit/4222926f028460ddb100008806fe39a38ac3511c))
+ - **BREAKING** **FIX**: required signers are the hash of the public key, not the public key itself ([#703](https://github.com/input-output-hk/catalyst-voices/issues/703)). ([a63c4686](https://github.com/input-output-hk/catalyst-voices/commit/a63c4686ee6e79aa65ace0cb4ed9b0c91e994320))
+ - **BREAKING** **FEAT**: add initial support for Cardano Native scripts, Plutus scripts, advanced transaction outputs, and additional transaction body fields and witnesses ([#713](https://github.com/input-output-hk/catalyst-voices/issues/713)). ([74fcb725](https://github.com/input-output-hk/catalyst-voices/commit/74fcb725f221bb3acf3824a3dd18a073d0a321e0))
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_cardano_web` - `v0.3.0`
+
+ - **FIX**: catalyst cardano null utxos ([#746](https://github.com/input-output-hk/catalyst-voices/issues/746)). ([3f2f5925](https://github.com/input-output-hk/catalyst-voices/commit/3f2f592593efe306f85fb0e81ce07aa1ea90b7b6))
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_compression` - `v0.3.0`
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_compression_platform_interface` - `v0.2.0`
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_compression_web` - `v0.3.0`
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+#### `catalyst_cose` - `v0.3.0`
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
+
 ## 2024-08-13
 
 ### Changes

--- a/catalyst_voices/packages/catalyst_voices_assets/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_assets/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.12
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_gen_runner: ^5.3.2
 
 flutter:

--- a/catalyst_voices/packages/catalyst_voices_blocs/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_blocs/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
 
 dev_dependencies:
    bloc_test: ^9.1.4
-   catalyst_analysis: ^1.2.0
+   catalyst_analysis: ^2.0.0
    flutter_bloc: ^8.1.5
    flutter_test:
       sdk: flutter

--- a/catalyst_voices/packages/catalyst_voices_brands/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_brands/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   google_fonts: ^6.2.1
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   catalyst_voices_blocs:
     path: ../catalyst_voices_blocs
   flutter_bloc: ^8.1.5

--- a/catalyst_voices/packages/catalyst_voices_localization/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_localization/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   intl: ^0.19.0
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter
 

--- a/catalyst_voices/packages/catalyst_voices_models/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_models/pubspec.yaml
@@ -11,5 +11,5 @@ dependencies:
   meta: ^1.10.0
 
 dev_dependencies:
-   catalyst_analysis: ^1.2.0
+   catalyst_analysis: ^2.0.0
    test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_repositories/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_repositories/pubspec.yaml
@@ -21,6 +21,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.12
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   mockito: ^5.4.4
   test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_services/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_services/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.12
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   chopper_generator: ^7.2.0
   json_serializable: ^6.7.1
   swagger_dart_code_generator: ^2.15.2

--- a/catalyst_voices/packages/catalyst_voices_shared/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_shared/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   web: ^0.5.0
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter
   test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_view_models/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_view_models/pubspec.yaml
@@ -14,5 +14,5 @@ dependencies:
   formz: ^0.7.0
 
 dev_dependencies:
-   catalyst_analysis: ^1.2.0
+   catalyst_analysis: ^2.0.0
    test: ^1.24.9

--- a/catalyst_voices/pubspec.yaml
+++ b/catalyst_voices/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   animated_text_kit: ^4.2.2
   animations: ^2.0.11
-  catalyst_cardano: ^0.2.0+1
-  catalyst_cardano_serialization: ^0.3.0
-  catalyst_cardano_web: ^0.2.0+1
+  catalyst_cardano: ^0.3.0
+  catalyst_cardano_serialization: ^0.4.0
+  catalyst_cardano_web: ^0.3.0
   catalyst_voices_assets:
     path: ./packages/catalyst_voices_assets
   catalyst_voices_blocs:
@@ -54,7 +54,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.12
   build_verify: ^3.1.0
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter
   go_router_builder: ^2.4.1

--- a/catalyst_voices/uikit_example/pubspec.yaml
+++ b/catalyst_voices/uikit_example/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.12
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_gen_runner: ^5.3.2
   flutter_test:
     sdk: flutter

--- a/catalyst_voices_packages/catalyst_analysis/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_analysis/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 1.2.0
 
  - **FIX**: readme versioning for catalyst packages ([#585](https://github.com/input-output-hk/catalyst-voices/issues/585)). ([e433b2db](https://github.com/input-output-hk/catalyst-voices/commit/e433b2dbba7a43c50f4411ea5279a623c221b66b))

--- a/catalyst_voices_packages/catalyst_analysis/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_analysis/pubspec.yaml
@@ -1,5 +1,5 @@
 name: catalyst_analysis
-version: 1.2.0
+version: 2.0.0
 description: Lint rules for Dart and Flutter used internally at Catalyst.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_analysis
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**: catalyst cardano null utxos ([#746](https://github.com/input-output-hk/catalyst-voices/issues/746)). ([3f2f5925](https://github.com/input-output-hk/catalyst-voices/commit/3f2f592593efe306f85fb0e81ce07aa1ea90b7b6))
+ - **FIX**: rbac txn inputs hash ([#688](https://github.com/input-output-hk/catalyst-voices/issues/688)). ([b644026f](https://github.com/input-output-hk/catalyst-voices/commit/b644026fa3b675591d071819eda185365257f0d1))
+ - **BREAKING** **FEAT**: add initial support for Cardano Native scripts, Plutus scripts, advanced transaction outputs, and additional transaction body fields and witnesses ([#713](https://github.com/input-output-hk/catalyst-voices/issues/713)). ([74fcb725](https://github.com/input-output-hk/catalyst-voices/commit/74fcb725f221bb3acf3824a3dd18a073d0a321e0))
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.2.0+1
 
  - Update a dependency to the latest release.

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano: ^0.2.0+1
-  catalyst_cardano_serialization: ^0.3.0
-  catalyst_cardano_web: ^0.2.0+1
-  catalyst_compression: ^0.2.0
-  catalyst_compression_web: ^0.2.0
+  catalyst_cardano: ^0.3.0
+  catalyst_cardano_serialization: ^0.4.0
+  catalyst_cardano_web: ^0.3.0
+  catalyst_compression: ^0.3.0
+  catalyst_compression_web: ^0.3.0
   cbor: ^6.2.0
   convert: ^3.1.1
   cupertino_icons: ^1.0.6
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter
 

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter plugin exposing the CIP-30 and CIP-95 APIs. Allows to com
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cardano/catalyst_cardano
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.2.0+1
+version: 0.3.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -16,14 +16,14 @@ flutter:
         default_package: catalyst_cardano_web
 
 dependencies:
-  catalyst_cardano_platform_interface: ^0.2.0+1
-  catalyst_cardano_serialization: ^0.3.0
-  catalyst_cardano_web: ^0.2.0+1
+  catalyst_cardano_platform_interface: ^0.3.0
+  catalyst_cardano_serialization: ^0.4.0
+  catalyst_cardano_web: ^0.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter
   plugin_platform_interface: ^2.1.7

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.2.0+1
 
  - Update a dependency to the latest release.

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
@@ -3,20 +3,20 @@ description: A common platform interface for the catalyst_cardano plugin.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_platform_interface
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.2.0+1
+version: 0.3.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano_serialization: ^0.3.0
+  catalyst_cardano_serialization: ^0.4.0
   equatable: ^2.0.5
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.7
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.3.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**: catalyst cardano null utxos ([#746](https://github.com/input-output-hk/catalyst-voices/issues/746)). ([3f2f5925](https://github.com/input-output-hk/catalyst-voices/commit/3f2f592593efe306f85fb0e81ce07aa1ea90b7b6))
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.2.0+1
 
  - Update a dependency to the latest release.

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Web platform implementation of catalyst_cardano. Allows to communic
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cardano/catalyst_cardano_web
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.2.0+1
+version: 0.3.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -21,8 +21,8 @@ flutter:
     - assets/js/
 
 dependencies:
-  catalyst_cardano_platform_interface: ^0.2.0+1
-  catalyst_cardano_serialization: ^0.3.0
+  catalyst_cardano_platform_interface: ^0.3.0
+  catalyst_cardano_serialization: ^0.4.0
   cbor: ^6.2.0
   convert: ^3.1.1
   flutter:
@@ -32,6 +32,6 @@ dependencies:
   web: ^0.5.0
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices_packages/catalyst_cardano_serialization/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.0
+
+> Note: This release has breaking changes.
+
+ - **FIX**: to be signed message should be a plain cbor sequence ([#701](https://github.com/input-output-hk/catalyst-voices/issues/701)). ([7c2dec6e](https://github.com/input-output-hk/catalyst-voices/commit/7c2dec6e2f91c1f18a39e7646ee3a5ca6a6e7249))
+ - **FIX**: rbac txn inputs hash ([#688](https://github.com/input-output-hk/catalyst-voices/issues/688)). ([b644026f](https://github.com/input-output-hk/catalyst-voices/commit/b644026fa3b675591d071819eda185365257f0d1))
+ - **FEAT**(catalyst_cardano_serialization): add CborEncodable interface for standardized CBOR handling ([#696](https://github.com/input-output-hk/catalyst-voices/issues/696)). ([4222926f](https://github.com/input-output-hk/catalyst-voices/commit/4222926f028460ddb100008806fe39a38ac3511c))
+ - **BREAKING** **FIX**: required signers are the hash of the public key, not the public key itself ([#703](https://github.com/input-output-hk/catalyst-voices/issues/703)). ([a63c4686](https://github.com/input-output-hk/catalyst-voices/commit/a63c4686ee6e79aa65ace0cb4ed9b0c91e994320))
+ - **BREAKING** **FEAT**: add initial support for Cardano Native scripts, Plutus scripts, advanced transaction outputs, and additional transaction body fields and witnesses ([#713](https://github.com/input-output-hk/catalyst-voices/issues/713)). ([74fcb725](https://github.com/input-output-hk/catalyst-voices/commit/74fcb725f221bb3acf3824a3dd18a073d0a321e0))
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.3.0
 
 > Note: This release has breaking changes.

--- a/catalyst_voices_packages/catalyst_cardano_serialization/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cardano_serialization/pubspec.yaml
@@ -3,7 +3,7 @@ description: Dart package providing serialization/deserialization for common str
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cardano_serialization
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.3.0
+version: 0.4.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -12,8 +12,8 @@ environment:
 dependencies:
   bech32: ^0.2.2
   bip32_ed25519: ^0.6.0
-  catalyst_compression: ^0.2.0
-  catalyst_compression_web: ^0.2.0
+  catalyst_compression: ^0.3.0
+  catalyst_compression_web: ^0.3.0
   cbor: ^6.2.0
   convert: ^3.1.1
   cryptography: ^2.7.0
@@ -22,5 +22,5 @@ dependencies:
   ulid: ^2.0.0
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   test: ^1.24.9

--- a/catalyst_voices_packages/catalyst_compression/catalyst_compression/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_compression/catalyst_compression/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.2.0
 
 > Note: This release has breaking changes.

--- a/catalyst_voices_packages/catalyst_compression/catalyst_compression/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_compression/catalyst_compression/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter plugin exposing Brotli and zstd compression algorithms.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_compression/catalyst_compression
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [compression, codec]
-version: 0.2.0
+version: 0.3.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -16,14 +16,14 @@ flutter:
         default_package: catalyst_compression_web
 
 dependencies:
-  catalyst_compression_platform_interface: ^0.1.1
-  catalyst_compression_web: ^0.2.0
+  catalyst_compression_platform_interface: ^0.2.0
+  catalyst_compression_web: ^0.3.0
   convert: ^3.1.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter
   plugin_platform_interface: ^2.1.7

--- a/catalyst_voices_packages/catalyst_compression/catalyst_compression_platform_interface/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_compression/catalyst_compression_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.1.1
 
  - **FEAT**: catalyst compression - brotli/zstd ([#626](https://github.com/input-output-hk/catalyst-voices/issues/626)). ([2b8e7d72](https://github.com/input-output-hk/catalyst-voices/commit/2b8e7d7239f9982aa7144a676a86d21b97f912fb))

--- a/catalyst_voices_packages/catalyst_compression/catalyst_compression_platform_interface/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_compression/catalyst_compression_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the catalyst_compression plugin.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_compression/catalyst_compression_platform_interface
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [compression, codec]
-version: 0.1.1
+version: 0.2.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -16,6 +16,6 @@ dependencies:
   plugin_platform_interface: ^2.1.7
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices_packages/catalyst_compression/catalyst_compression_web/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_compression/catalyst_compression_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.2.0
 
 > Note: This release has breaking changes.

--- a/catalyst_voices_packages/catalyst_compression/catalyst_compression_web/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_compression/catalyst_compression_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Web platform implementation of catalyst_compression. Exposes a JS w
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_compression/catalyst_compression_web
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [compression, codec]
-version: 0.2.0
+version: 0.3.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -21,7 +21,7 @@ flutter:
     - assets/js/
 
 dependencies:
-  catalyst_compression_platform_interface: ^0.1.1
+  catalyst_compression_platform_interface: ^0.2.0
   convert: ^3.1.1
   flutter:
     sdk: flutter
@@ -30,6 +30,6 @@ dependencies:
   web: ^0.5.0
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices_packages/catalyst_cose/CHANGELOG.md
+++ b/catalyst_voices_packages/catalyst_cose/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **CHORE**: upgrade flutter to 3.24.1 and dart to 3.5.0 ([#725](https://github.com/input-output-hk/catalyst-voices/issues/725)). ([eb8a516e](https://github.com/input-output-hk/catalyst-voices/commit/eb8a516edbd25386c0fbe41501285870abf82543))
+
 ## 0.2.0
 
 > Note: This release has breaking changes.

--- a/catalyst_voices_packages/catalyst_cose/pubspec.yaml
+++ b/catalyst_voices_packages/catalyst_cose/pubspec.yaml
@@ -3,7 +3,7 @@ description: A dart plugin implementing CBOR Object Signing and Encryption (RFC 
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices_packages/catalyst_cose
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [cryptography, encryption, codec]
-version: 0.2.0
+version: 0.3.0
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -14,5 +14,5 @@ dependencies:
   cryptography: ^2.7.0
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
   test: ^1.24.9

--- a/utilities/catalyst_voices_remote_widgets/example/pubspec.yaml
+++ b/utilities/catalyst_voices_remote_widgets/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   rfw: ^1.0.26
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/utilities/catalyst_voices_remote_widgets/pubspec.yaml
+++ b/utilities/catalyst_voices_remote_widgets/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   rfw: ^1.0.26
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/utilities/poc_local_storage/pubspec.yaml
+++ b/utilities/poc_local_storage/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   pointycastle: ^3.9.1
 
 dev_dependencies:
-  catalyst_analysis: ^1.2.0
+  catalyst_analysis: ^2.0.0
 
 dependency_overrides:
   flutter_secure_storage_web: ^2.0.0-beta.1


### PR DESCRIPTION
 - catalyst_analysis@2.0.0
 - catalyst_cardano@0.3.0
 - catalyst_cardano_platform_interface@0.3.0
 - catalyst_cardano_serialization@0.4.0
 - catalyst_cardano_web@0.3.0
 - catalyst_compression@0.3.0
 - catalyst_compression_platform_interface@0.2.0
 - catalyst_compression_web@0.3.0
 - catalyst_cose@0.3.0

# Description

Release dart/flutter packages to pub.dev. The changelogs are automatically generated by melos from commit history.
