### PR TITLE
feat: allow m4 subpages in voices

### DIFF
--- a/catalyst_voices/nginx.conf
+++ b/catalyst_voices/nginx.conf
@@ -22,6 +22,11 @@ http {
       index  index.html;
       try_files $uri $uri/ /index.html;
     }
+    # Ensure that /m4 (and any other SPA path) serves index.html
+    location /m4 {
+      root /app;
+      try_files $uri $uri/ /index.html;
+    }
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
       root   /usr/share/nginx/html;


### PR DESCRIPTION
# Description

We're deploying `m4` related pages to https://voices.projectcatalyst.io/ as we're waiting for **dev** env. This change should let us see those pages.

Example pages that we want to be able to see

- /m4/treasury
- /m4/discovery
- /m4/workspace
- /m4/voting
- /m4/funded_projects 

As per spaces routing [here](https://github.com/input-output-hk/catalyst-voices/blob/main/catalyst_voices/lib/routes/routing/spaces_route.dart#L15)

## Related Issue(s)

Part of #762 
Relates to #765 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
