### PR TITLE
fix(cat-voices): center avatar letter

### DIFF
--- a/catalyst_voices/lib/widgets/avatars/voices_avatar.dart
+++ b/catalyst_voices/lib/widgets/avatars/voices_avatar.dart
@@ -58,6 +58,7 @@ class VoicesAvatar extends StatelessWidget {
                 child: DefaultTextStyle(
                   style: Theme.of(context).textTheme.bodyLarge!.copyWith(
                         fontSize: 18,
+                        height: 1,
                         color: foregroundColor ??
                             Theme.of(context).colorScheme.primary,
                       ),


### PR DESCRIPTION
# Description

Fixes avatar letter center 

## Screenshots

Before:
<img width="120" alt="before" src="https://github.com/user-attachments/assets/0b41c48a-89e4-47dc-a179-0f08de1cfe45">

After:
<img width="139" alt="after" src="https://github.com/user-attachments/assets/ead26578-3a1a-474a-b9b9-bc28bf35cf23">
