### PR TITLE
chore(cat-voices): add melos scripts to generate code

### DIFF
--- a/catalyst_voices/packages/catalyst_voices_assets/lib/generated/assets.gen.dart
+++ b/catalyst_voices/packages/catalyst_voices_assets/lib/generated/assets.gen.dart
@@ -7,10 +7,10 @@
 // ignore_for_file: type=lint
 // ignore_for_file: directives_ordering,unnecessary_import,implicit_dynamic_list_literal,deprecated_member_use
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:vector_graphics/vector_graphics.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_svg/flutter_svg.dart' as _svg;
+import 'package:vector_graphics/vector_graphics.dart' as _vg;
 
 class $AssetsIconsGen {
   const $AssetsIconsGen();
@@ -1362,7 +1362,7 @@ class SvgGenImage {
   final Set<String> flavors;
   final bool _isVecFormat;
 
-  SvgPicture svg({
+  _svg.SvgPicture svg({
     Key? key,
     bool matchTextDirection = false,
     AssetBundle? bundle,
@@ -1375,29 +1375,29 @@ class SvgGenImage {
     WidgetBuilder? placeholderBuilder,
     String? semanticsLabel,
     bool excludeFromSemantics = false,
-    SvgTheme? theme,
+    _svg.SvgTheme? theme,
     ColorFilter? colorFilter,
     Clip clipBehavior = Clip.hardEdge,
     @deprecated Color? color,
     @deprecated BlendMode colorBlendMode = BlendMode.srcIn,
     @deprecated bool cacheColorFilter = false,
   }) {
-    final BytesLoader loader;
+    final _svg.BytesLoader loader;
     if (_isVecFormat) {
-      loader = AssetBytesLoader(
+      loader = _vg.AssetBytesLoader(
         _assetName,
         assetBundle: bundle,
         packageName: package,
       );
     } else {
-      loader = SvgAssetLoader(
+      loader = _svg.SvgAssetLoader(
         _assetName,
         assetBundle: bundle,
         packageName: package,
         theme: theme,
       );
     }
-    return SvgPicture(
+    return _svg.SvgPicture(
       loader,
       key: key,
       matchTextDirection: matchTextDirection,

--- a/melos.yaml
+++ b/melos.yaml
@@ -115,6 +115,23 @@ command:
       mocktail: ^1.0.1
 
 scripts:
+  l10n:
+    run: |
+      melos exec -c 1 --scope="catalyst_voices_localization" -- flutter gen-l10n
+    description: |
+      Run `flutter gen-l10n` in catalyst_voices_localization package to generate l10n bindings.
+
+  build_runner:
+    run: |
+      melos exec -c 1 \
+      --depends-on="build_runner" \
+      --ignore="catalyst_voices_services" -- \
+          dart run build_runner build --delete-conflicting-outputs
+    description: |
+      Run `build_runner` in every package which contains the build_runner dependency.
+      The catalyst_voices_services is skipped because to run a build_runner there you
+      must generate first swagger docs (see related Earthfile).
+
   metrics:
     run: |
       melos exec -c 1 -- \


### PR DESCRIPTION
# Description

Currently running code generation requires going in cmd to a specific subfolder and entering a command, the PR introduced melos scripts which can be run from any directory inside the repository:

- melos l10n
- melos build_runner

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
