### PR TITLE
feat(cat-voices): check seed phrase instructions stage

### DIFF
--- a/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/check_seed_phrase_instructions_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/stages.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
@@ -23,7 +24,8 @@ class CreateKeychainPanel extends StatelessWidget {
           isStoreSeedPhraseConfirmed: seedPhraseState.isStoredConfirmed,
           isNextEnabled: seedPhraseState.isStoredConfirmed,
         ),
-      CreateKeychainStage.checkSeedPhraseInstructions ||
+      CreateKeychainStage.checkSeedPhraseInstructions =>
+        const CheckSeedPhraseInstructionsPanel(),
       CreateKeychainStage.checkSeedPhrase ||
       CreateKeychainStage.checkSeedPhraseResult ||
       CreateKeychainStage.unlockPasswordInstructions ||

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/check_seed_phrase_instructions_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/check_seed_phrase_instructions_panel.dart
@@ -1,0 +1,57 @@
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:flutter/material.dart';
+
+class CheckSeedPhraseInstructionsPanel extends StatelessWidget {
+  const CheckSeedPhraseInstructionsPanel({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textColor = theme.colors.textOnPrimaryLevel0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          context.l10n.createKeychainSeedPhraseCheckInstructionsTitle,
+          style: theme.textTheme.titleMedium?.copyWith(color: textColor),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          context.l10n.createKeychainSeedPhraseCheckInstructionsSubtitle,
+          style: theme.textTheme.bodyMedium?.copyWith(color: textColor),
+        ),
+        const Spacer(),
+        const _Navigation(),
+      ],
+    );
+  }
+}
+
+class _Navigation extends StatelessWidget {
+  const _Navigation();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: VoicesBackButton(
+            onTap: () => RegistrationCubit.of(context).previousStep(),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: VoicesNextButton(
+            onTap: () => RegistrationCubit.of(context).nextStep(),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/lib/pages/registration/registration_info_panel.dart
@@ -59,7 +59,8 @@ class RegistrationInfoPanel extends StatelessWidget {
             subtitle: context.l10n.createKeychainSeedPhraseSubtitle,
             body: context.l10n.createKeychainSeedPhraseBody,
           ),
-        CreateKeychainStage.checkSeedPhraseInstructions ||
+        CreateKeychainStage.checkSeedPhraseInstructions =>
+          _HeaderStrings(title: context.l10n.catalystKeychain),
         CreateKeychainStage.checkSeedPhrase ||
         CreateKeychainStage.checkSeedPhraseResult ||
         CreateKeychainStage.unlockPasswordInstructions ||

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -1023,6 +1023,18 @@ abstract class VoicesLocalizations {
   /// In en, this message translates to:
   /// **'I have written down/downloaded my 12 words'**
   String get createKeychainSeedPhraseStoreConfirmation;
+
+  /// No description provided for @createKeychainSeedPhraseCheckInstructionsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your Catalyst security keys'**
+  String get createKeychainSeedPhraseCheckInstructionsTitle;
+
+  /// No description provided for @createKeychainSeedPhraseCheckInstructionsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Next, we\'re going to make sure that you\'ve written down your words correctly.     We don\'t save your seed phrase, so it\'s important  to make sure you have it right. That\'s why we do this confirmation before continuing.     It\'s also good practice to get familiar with using a seed phrase if you\'re new to crypto.'**
+  String get createKeychainSeedPhraseCheckInstructionsSubtitle;
 }
 
 class _VoicesLocalizationsDelegate extends LocalizationsDelegate<VoicesLocalizations> {

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -527,4 +527,10 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
 
   @override
   String get createKeychainSeedPhraseStoreConfirmation => 'I have written down/downloaded my 12 words';
+
+  @override
+  String get createKeychainSeedPhraseCheckInstructionsTitle => 'Check your Catalyst security keys';
+
+  @override
+  String get createKeychainSeedPhraseCheckInstructionsSubtitle => 'Next, we\'re going to make sure that you\'ve written down your words correctly.     We don\'t save your seed phrase, so it\'s important  to make sure you have it right. That\'s why we do this confirmation before continuing.     It\'s also good practice to get familiar with using a seed phrase if you\'re new to crypto.';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -527,4 +527,10 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
 
   @override
   String get createKeychainSeedPhraseStoreConfirmation => 'I have written down/downloaded my 12 words';
+
+  @override
+  String get createKeychainSeedPhraseCheckInstructionsTitle => 'Check your Catalyst security keys';
+
+  @override
+  String get createKeychainSeedPhraseCheckInstructionsSubtitle => 'Next, we\'re going to make sure that you\'ve written down your words correctly.     We don\'t save your seed phrase, so it\'s important  to make sure you have it right. That\'s why we do this confirmation before continuing.     It\'s also good practice to get familiar with using a seed phrase if you\'re new to crypto.';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -619,5 +619,7 @@
   "createKeychainSeedPhraseSubtitle": "Write down your 12 Catalyst \u2028security words",
   "createKeychainSeedPhraseBody": "Make sure you create an offline backup of your recovery phrase as well.",
   "createKeychainSeedPhraseDownload": "Download Catalyst key",
-  "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words"
+  "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words",
+  "createKeychainSeedPhraseCheckInstructionsTitle": "Check your Catalyst security keys",
+  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we're going to make sure that you've written down your words correctly.   \u2028\u2028We don't save your seed phrase, so it's important \u2028to make sure you have it right. That's why we do this confirmation before continuing.   \u2028\u2028It's also good practice to get familiar with using a seed phrase if you're new to crypto."
 }


### PR DESCRIPTION
# Description

This PR adds simple text panel for check seed phrase instructions 

## Related Issue(s)

Part of #816 

## Screenshots

<img width="935" alt="Screenshot 2024-10-01 at 09 19 36" src="https://github.com/user-attachments/assets/7a6ff645-f4ec-4555-a1fc-fd101fd012bf">


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
