### PR TITLE
feat(cat-voices): check seed phrase and result panel

### DIFF
--- a/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/stages.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
@@ -23,8 +24,10 @@ class CreateKeychainPanel extends StatelessWidget {
           isStoreSeedPhraseConfirmed: seedPhraseState.isStoredConfirmed,
           isNextEnabled: seedPhraseState.isStoredConfirmed,
         ),
-      CreateKeychainStage.checkSeedPhraseInstructions ||
-      CreateKeychainStage.checkSeedPhrase ||
+      CreateKeychainStage.checkSeedPhraseInstructions => const Placeholder(),
+      CreateKeychainStage.checkSeedPhrase => SeedPhraseCheckPanel(
+          seedPhrase: seedPhraseState.seedPhrase,
+        ),
       CreateKeychainStage.checkSeedPhraseResult ||
       CreateKeychainStage.unlockPasswordInstructions ||
       CreateKeychainStage.unlockPasswordCreate ||

--- a/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
@@ -1,6 +1,9 @@
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/check_seed_phrase_instructions_panel.dart';
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/instructions_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart';
-import 'package:catalyst_voices/pages/registration/create_keychain/stage/stages.dart';
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart';
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_panel.dart';
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/splash_panel.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
@@ -30,7 +33,9 @@ class CreateKeychainPanel extends StatelessWidget {
       CreateKeychainStage.checkSeedPhrase => SeedPhraseCheckPanel(
           seedPhrase: seedPhraseState.seedPhrase,
         ),
-      CreateKeychainStage.checkSeedPhraseResult ||
+      CreateKeychainStage.checkSeedPhraseResult => SeedPhraseCheckResultPanel(
+          isCheckConfirmed: seedPhraseState.isCheckConfirmed,
+        ),
       CreateKeychainStage.unlockPasswordInstructions ||
       CreateKeychainStage.unlockPasswordCreate ||
       CreateKeychainStage.created =>

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -35,7 +35,7 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
     super.initState();
 
     _updateSeedPhraseWords();
-    _updateUserWords(_seedPhraseWords);
+    _updateUserWords();
   }
 
   @override
@@ -44,7 +44,7 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
 
     if (widget.seedPhrase != oldWidget.seedPhrase) {
       _updateSeedPhraseWords();
-      _updateUserWords(_seedPhraseWords);
+      _updateUserWords();
     }
   }
 

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -35,7 +35,7 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
     super.initState();
 
     _updateSeedPhraseWords();
-    _updateUserWords();
+    _updateUserWords(_seedPhraseWords);
   }
 
   @override
@@ -44,7 +44,7 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
 
     if (widget.seedPhrase != oldWidget.seedPhrase) {
       _updateSeedPhraseWords();
-      _updateUserWords();
+      _updateUserWords(_seedPhraseWords);
     }
   }
 
@@ -110,7 +110,9 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
       ..clear()
       ..addAll(words);
 
-    RegistrationCubit.of(context).setSeedPhraseCheck(isChecked: _isStageValid);
+    RegistrationCubit.of(context).setSeedPhraseCheckConfirmed(
+      isConfirmed: _isStageValid,
+    );
   }
 }
 

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -1,0 +1,207 @@
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class SeedPhraseCheckPanel extends StatefulWidget {
+  final SeedPhrase? seedPhrase;
+
+  const SeedPhraseCheckPanel({
+    super.key,
+    this.seedPhrase,
+  });
+
+  @override
+  State<SeedPhraseCheckPanel> createState() => _SeedPhraseCheckPanelState();
+}
+
+class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
+  final _seedPhraseWords = <String>[];
+  final _shuffledSeedPhraseWords = <String>[];
+  final _userWords = <String>[];
+
+  bool get _isStageValid {
+    if (_seedPhraseWords.isEmpty) {
+      return false;
+    }
+
+    return listEquals(_seedPhraseWords, _userWords);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _updateWords();
+  }
+
+  @override
+  void didUpdateWidget(covariant SeedPhraseCheckPanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.seedPhrase != oldWidget.seedPhrase) {
+      _updateWords();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: VoicesLoadable(
+            isLoading: _seedPhraseWords.isEmpty,
+            builder: (context) {
+              return _SeedPhraseWords(
+                words: _shuffledSeedPhraseWords,
+                userWords: _userWords,
+                onUserWordsChanged: _onWordsSequenceChanged,
+                onUploadTap: _uploadSeedPhrase,
+                onResetTap: _clearUserWords,
+                isResetEnabled: _userWords.isNotEmpty,
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 10),
+        _Navigation(isNextEnabled: _isStageValid),
+      ],
+    );
+  }
+
+  Future<void> _uploadSeedPhrase() async {
+    //
+  }
+
+  void _clearUserWords() {
+    setState(_userWords.clear);
+  }
+
+  void _onWordsSequenceChanged(List<String> words) {
+    setState(() {
+      _userWords
+        ..clear()
+        ..addAll(words);
+    });
+  }
+
+  void _updateWords() {
+    final seedPhrase = widget.seedPhrase;
+    final words = seedPhrase?.mnemonicWords ?? <String>[];
+    final shuffledWords = seedPhrase?.shuffledMnemonicWords ?? <String>[];
+
+    _seedPhraseWords
+      ..clear()
+      ..addAll(words);
+
+    _shuffledSeedPhraseWords
+      ..clear()
+      ..addAll(shuffledWords);
+
+    _userWords.clear();
+
+    debugPrint('seedPhraseWords: $_seedPhraseWords');
+  }
+}
+
+class _SeedPhraseWords extends StatelessWidget {
+  final List<String> words;
+  final List<String> userWords;
+  final ValueChanged<List<String>> onUserWordsChanged;
+  final VoidCallback? onUploadTap;
+  final VoidCallback? onResetTap;
+  final bool isResetEnabled;
+
+  const _SeedPhraseWords({
+    required this.words,
+    required this.userWords,
+    required this.onUserWordsChanged,
+    required this.onUploadTap,
+    required this.onResetTap,
+    required this.isResetEnabled,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        children: [
+          const SizedBox(height: 20),
+          SeedPhrasesSequencer(
+            words: words,
+            selectedWords: userWords,
+            onChanged: onUserWordsChanged,
+          ),
+          _WordsActions(
+            onUploadKeyTap: onUploadTap,
+            onResetTap: onResetTap,
+            isResetOffstage: !isResetEnabled,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WordsActions extends StatelessWidget {
+  final VoidCallback? onUploadKeyTap;
+  final VoidCallback? onResetTap;
+  final bool isResetOffstage;
+
+  const _WordsActions({
+    this.onUploadKeyTap,
+    this.onResetTap,
+    this.isResetOffstage = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        VoicesTextButton(
+          onTap: onUploadKeyTap,
+          child: Text(context.l10n.uploadCatalystKey),
+        ),
+        const Spacer(),
+        Offstage(
+          offstage: isResetOffstage,
+          child: VoicesTextButton(
+            onTap: onResetTap,
+            child: Text(context.l10n.reset),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Navigation extends StatelessWidget {
+  final bool isNextEnabled;
+
+  const _Navigation({
+    this.isNextEnabled = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: VoicesBackButton(
+            onTap: () => RegistrationCubit.of(context).previousStep(),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: VoicesNextButton(
+            onTap: isNextEnabled
+                ? () => RegistrationCubit.of(context).nextStep()
+                : null,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -134,6 +134,7 @@ class _SeedPhraseWords extends StatelessWidget {
             selectedWords: userWords,
             onChanged: onUserWordsChanged,
           ),
+          const SizedBox(height: 10),
           _WordsActions(
             onUploadKeyTap: onUploadTap,
             onResetTap: onResetTap,

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -74,7 +74,7 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
   }
 
   Future<void> _uploadSeedPhrase() async {
-    //
+    // TODO(damian-molinski): open upload dialog
   }
 
   void _clearUserWords() {

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -99,8 +99,6 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
     _shuffledSeedPhraseWords
       ..clear()
       ..addAll(shuffledWords);
-
-    debugPrint('seedPhraseWords: $_seedPhraseWords');
   }
 
   void _updateUserWords([

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -34,7 +34,8 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
   void initState() {
     super.initState();
 
-    _updateWords();
+    _updateSeedPhraseWords();
+    _updateUserWords();
   }
 
   @override
@@ -42,7 +43,8 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
     super.didUpdateWidget(oldWidget);
 
     if (widget.seedPhrase != oldWidget.seedPhrase) {
-      _updateWords();
+      _updateSeedPhraseWords();
+      _updateUserWords();
     }
   }
 
@@ -76,18 +78,16 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
   }
 
   void _clearUserWords() {
-    setState(_userWords.clear);
+    setState(_updateUserWords);
   }
 
   void _onWordsSequenceChanged(List<String> words) {
     setState(() {
-      _userWords
-        ..clear()
-        ..addAll(words);
+      _updateUserWords(words);
     });
   }
 
-  void _updateWords() {
+  void _updateSeedPhraseWords() {
     final seedPhrase = widget.seedPhrase;
     final words = seedPhrase?.mnemonicWords ?? <String>[];
     final shuffledWords = seedPhrase?.shuffledMnemonicWords ?? <String>[];
@@ -100,9 +100,17 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
       ..clear()
       ..addAll(shuffledWords);
 
-    _userWords.clear();
-
     debugPrint('seedPhraseWords: $_seedPhraseWords');
+  }
+
+  void _updateUserWords([
+    List<String> words = const [],
+  ]) {
+    _userWords
+      ..clear()
+      ..addAll(words);
+
+    RegistrationCubit.of(context).setSeedPhraseCheck(isChecked: _isStageValid);
   }
 }
 

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart
@@ -1,0 +1,73 @@
+import 'package:catalyst_voices/pages/registration/next_step.dart';
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:flutter/material.dart';
+
+class SeedPhraseCheckResultPanel extends StatelessWidget {
+  final bool isCheckConfirmed;
+
+  const SeedPhraseCheckResultPanel({
+    super.key,
+    required this.isCheckConfirmed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textColor = theme.colors.textOnPrimaryLevel0;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          context.l10n.createKeychainSeedPhraseCheckSuccessTitle,
+          style: theme.textTheme.titleMedium?.copyWith(color: textColor),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          context.l10n.createKeychainSeedPhraseCheckSuccessSubtitle,
+          style: theme.textTheme.bodyMedium?.copyWith(color: textColor),
+        ),
+        const Spacer(),
+        NextStep(
+          context.l10n.createKeychainSeedPhraseCheckSuccessNextStep,
+        ),
+        const SizedBox(height: 10),
+        _Navigation(
+          isNextEnabled: isCheckConfirmed,
+        ),
+      ],
+    );
+  }
+}
+
+class _Navigation extends StatelessWidget {
+  final bool isNextEnabled;
+
+  const _Navigation({
+    this.isNextEnabled = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: VoicesBackButton(
+            onTap: () => RegistrationCubit.of(context).previousStep(),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: VoicesNextButton(
+            onTap: isNextEnabled
+                ? () => RegistrationCubit.of(context).nextStep()
+                : null,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_panel.dart
@@ -21,10 +21,23 @@ class SeedPhrasePanel extends StatefulWidget {
 }
 
 class _SeedPhrasePanelState extends State<SeedPhrasePanel> {
+  final _seedPhraseWords = <String>[];
+
   @override
   void initState() {
     super.initState();
     RegistrationCubit.of(context).buildSeedPhrase();
+
+    _updateWords();
+  }
+
+  @override
+  void didUpdateWidget(covariant SeedPhrasePanel oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.seedPhrase != oldWidget.seedPhrase) {
+      _updateWords();
+    }
   }
 
   @override
@@ -32,9 +45,14 @@ class _SeedPhrasePanelState extends State<SeedPhrasePanel> {
     return Column(
       children: [
         Expanded(
-          child: _Body(
-            words: widget.seedPhrase?.mnemonicWords,
-            onDownloadTap: _downloadSeedPhrase,
+          child: VoicesLoadable(
+            isLoading: _seedPhraseWords.isEmpty,
+            builder: (context) {
+              return _SeedPhraseWords(
+                words: _seedPhraseWords,
+                onDownloadTap: _downloadSeedPhrase,
+              );
+            },
           ),
         ),
         const SizedBox(height: 10),
@@ -50,29 +68,11 @@ class _SeedPhrasePanelState extends State<SeedPhrasePanel> {
   Future<void> _downloadSeedPhrase() async {
     await RegistrationCubit.of(context).downloadSeedPhrase();
   }
-}
 
-class _Body extends StatelessWidget {
-  final List<String>? words;
-  final VoidCallback? onDownloadTap;
-
-  const _Body({
-    this.words,
-    this.onDownloadTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final words = this.words;
-
-    if (words == null || words.isEmpty) {
-      return const Center(child: VoicesCircularProgressIndicator());
-    } else {
-      return _SeedPhraseWords(
-        words: words,
-        onDownloadTap: onDownloadTap,
-      );
-    }
+  void _updateWords() {
+    _seedPhraseWords
+      ..clear()
+      ..addAll(widget.seedPhrase?.mnemonicWords ?? []);
   }
 }
 

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/stages.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/stages.dart
@@ -1,3 +1,0 @@
-export 'instructions_panel.dart';
-export 'seed_phrase_panel.dart';
-export 'splash_panel.dart';

--- a/catalyst_voices/lib/pages/registration/next_step.dart
+++ b/catalyst_voices/lib/pages/registration/next_step.dart
@@ -1,0 +1,34 @@
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:flutter/material.dart';
+
+class NextStep extends StatelessWidget {
+  final String data;
+
+  const NextStep(
+    this.data, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textColor = theme.colors.textOnPrimaryLevel0;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(height: 8),
+        VoicesTextDivider(child: Text(context.l10n.yourNextStep)),
+        const SizedBox(height: 12),
+        Text(
+          data,
+          style: theme.textTheme.bodySmall?.copyWith(color: textColor),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 12),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/lib/pages/registration/registration_info_panel.dart
@@ -1,6 +1,7 @@
 import 'package:catalyst_voices/pages/registration/information_panel.dart';
 import 'package:catalyst_voices/pages/registration/pictures/keychain_picture.dart';
 import 'package:catalyst_voices/pages/registration/pictures/seed_phrase_picture.dart';
+import 'package:catalyst_voices/pages/registration/pictures/task_picture.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
@@ -37,11 +38,10 @@ class RegistrationInfoPanel extends StatelessWidget {
           title: headerStrings.title,
           subtitle: headerStrings.subtitle,
           body: headerStrings.body,
-          picture: _RegistrationPicture(step: state.step),
+          picture: _RegistrationPicture(state: state),
           progress: state.progress,
         );
       },
-      buildWhen: (previous, current) => previous.step != current.step,
     );
   }
 
@@ -66,7 +66,8 @@ class RegistrationInfoPanel extends StatelessWidget {
             subtitle: context.l10n.createKeychainSeedPhraseCheckSubtitle,
             body: context.l10n.createKeychainSeedPhraseCheckBody,
           ),
-        CreateKeychainStage.checkSeedPhraseResult ||
+        CreateKeychainStage.checkSeedPhraseResult =>
+          _HeaderStrings(title: context.l10n.catalystKeychain),
         CreateKeychainStage.unlockPasswordInstructions ||
         CreateKeychainStage.unlockPasswordCreate ||
         CreateKeychainStage.created =>
@@ -108,15 +109,18 @@ class RegistrationInfoPanel extends StatelessWidget {
 }
 
 class _RegistrationPicture extends StatelessWidget {
-  final RegistrationStep step;
+  final RegistrationState state;
 
   const _RegistrationPicture({
-    required this.step,
+    required this.state,
   });
 
   @override
   Widget build(BuildContext context) {
-    Widget buildKeychainStagePicture(CreateKeychainStage stage) {
+    Widget buildKeychainStagePicture(
+      CreateKeychainStage stage, {
+      required bool isSeedPhraseCheckConfirmed,
+    }) {
       return switch (stage) {
         CreateKeychainStage.splash ||
         CreateKeychainStage.instructions =>
@@ -127,7 +131,12 @@ class _RegistrationPicture extends StatelessWidget {
           const SeedPhrasePicture(
             indicateSelection: true,
           ),
-        CreateKeychainStage.checkSeedPhraseResult => const SeedPhrasePicture(),
+        CreateKeychainStage.checkSeedPhraseResult => SeedPhrasePicture(
+            type: isSeedPhraseCheckConfirmed
+                ? TaskPictureType.success
+                : TaskPictureType.error,
+            indicateSelection: true,
+          ),
         CreateKeychainStage.unlockPasswordInstructions ||
         CreateKeychainStage.unlockPasswordCreate ||
         CreateKeychainStage.created =>
@@ -147,13 +156,17 @@ class _RegistrationPicture extends StatelessWidget {
       };
     }
 
-    return switch (step) {
-      GetStartedStep() => const KeychainPicture(),
-      FinishAccountCreationStep() => const KeychainPicture(),
-      RecoverStep() => const KeychainPicture(),
-      CreateKeychainStep(:final stage) => buildKeychainStagePicture(stage),
-      WalletLinkStep(:final stage) => buildWalletLinkStagePicture(stage),
-      AccountCompletedStep() => const KeychainPicture(),
+    return switch (state) {
+      GetStarted() => const KeychainPicture(),
+      FinishAccountCreation() => const KeychainPicture(),
+      Recover() => const KeychainPicture(),
+      CreateKeychain(:final stage, :final seedPhraseState) =>
+        buildKeychainStagePicture(
+          stage,
+          isSeedPhraseCheckConfirmed: seedPhraseState.isCheckConfirmed,
+        ),
+      WalletLink(:final stage) => buildWalletLinkStagePicture(stage),
+      AccountCompleted() => const KeychainPicture(),
     };
   }
 }

--- a/catalyst_voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/lib/pages/registration/registration_info_panel.dart
@@ -59,8 +59,13 @@ class RegistrationInfoPanel extends StatelessWidget {
             subtitle: context.l10n.createKeychainSeedPhraseSubtitle,
             body: context.l10n.createKeychainSeedPhraseBody,
           ),
-        CreateKeychainStage.checkSeedPhraseInstructions ||
-        CreateKeychainStage.checkSeedPhrase ||
+        CreateKeychainStage.checkSeedPhraseInstructions =>
+          _HeaderStrings(title: 'TODO'),
+        CreateKeychainStage.checkSeedPhrase => _HeaderStrings(
+            title: context.l10n.catalystKeychain,
+            subtitle: context.l10n.createKeychainSeedPhraseCheckSubtitle,
+            body: context.l10n.createKeychainSeedPhraseCheckBody,
+          ),
         CreateKeychainStage.checkSeedPhraseResult ||
         CreateKeychainStage.unlockPasswordInstructions ||
         CreateKeychainStage.unlockPasswordCreate ||

--- a/catalyst_voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/lib/pages/registration/registration_info_panel.dart
@@ -121,11 +121,13 @@ class _RegistrationPicture extends StatelessWidget {
         CreateKeychainStage.splash ||
         CreateKeychainStage.instructions =>
           const KeychainPicture(),
-        CreateKeychainStage.seedPhrase ||
+        CreateKeychainStage.seedPhrase => const SeedPhrasePicture(),
         CreateKeychainStage.checkSeedPhraseInstructions ||
-        CreateKeychainStage.checkSeedPhrase ||
-        CreateKeychainStage.checkSeedPhraseResult =>
-          const SeedPhrasePicture(),
+        CreateKeychainStage.checkSeedPhrase =>
+          const SeedPhrasePicture(
+            indicateSelection: true,
+          ),
+        CreateKeychainStage.checkSeedPhraseResult => const SeedPhrasePicture(),
         CreateKeychainStage.unlockPasswordInstructions ||
         CreateKeychainStage.unlockPasswordCreate ||
         CreateKeychainStage.created =>

--- a/catalyst_voices/lib/widgets/common/infrastructure/voices_loadable.dart
+++ b/catalyst_voices/lib/widgets/common/infrastructure/voices_loadable.dart
@@ -1,0 +1,28 @@
+import 'package:catalyst_voices/widgets/indicators/voices_circular_progress_indicator.dart';
+import 'package:flutter/material.dart';
+
+class VoicesLoadable extends StatelessWidget {
+  final bool isLoading;
+  final WidgetBuilder loaderBuilder;
+  final WidgetBuilder builder;
+
+  const VoicesLoadable({
+    super.key,
+    this.isLoading = true,
+    this.loaderBuilder = _defaultLoaderBuilder,
+    required this.builder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (isLoading) {
+      return loaderBuilder(context);
+    } else {
+      return builder(context);
+    }
+  }
+}
+
+Widget _defaultLoaderBuilder(BuildContext context) {
+  return const Center(child: VoicesCircularProgressIndicator());
+}

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_completer.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_completer.dart
@@ -18,19 +18,27 @@ class SeedPhrasesCompleter extends StatelessWidget {
   final int slotsCount;
 
   /// A set of currently selected seed phrases. Defaults to an empty set.
-  final Set<String> words;
+  final List<String> words;
 
   /// A callback function triggered when a non-filled slot or a filled but only
   /// for previous selection.
   final ValueChanged<String>? onWordTap;
+
+  /// See [ColumnsRow.mainAxisSpacing].
+  final double mainAxisSpacing;
+
+  /// See [ColumnsRow.crossAxisSpacing].
+  final double crossAxisSpacing;
 
   /// Creates a [SeedPhrasesCompleter] widget.
   const SeedPhrasesCompleter({
     super.key,
     this.columnsCount = 2,
     required this.slotsCount,
-    this.words = const <String>{},
+    this.words = const <String>[],
     this.onWordTap,
+    this.mainAxisSpacing = 10,
+    this.crossAxisSpacing = 4,
   });
 
   @override
@@ -45,8 +53,8 @@ class SeedPhrasesCompleter extends StatelessWidget {
     return MediaQuery.withNoTextScaling(
       child: ColumnsRow(
         columnsCount: 2,
-        mainAxisSpacing: 10,
-        crossAxisSpacing: 6,
+        mainAxisSpacing: mainAxisSpacing,
+        crossAxisSpacing: crossAxisSpacing,
         children: slots.mapIndexed((index, element) {
           final isCurrent = index == currentIndex;
           final isPrevious = currentIndex != null

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_picker.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_picker.dart
@@ -14,17 +14,25 @@ class SeedPhrasesPicker extends StatelessWidget {
   final List<String> words;
 
   /// A set of currently selected seed phrases. Defaults to an empty set.
-  final Set<String> selectedWords;
+  final List<String> selectedWords;
 
   /// A callback function triggered when a non-selected seed phrase is tapped.
   final ValueChanged<String>? onWordTap;
+
+  /// See [ColumnsRow.mainAxisSpacing].
+  final double mainAxisSpacing;
+
+  /// See [ColumnsRow.crossAxisSpacing].
+  final double crossAxisSpacing;
 
   const SeedPhrasesPicker({
     super.key,
     this.columnsCount = 2,
     required this.words,
-    this.selectedWords = const <String>{},
+    this.selectedWords = const <String>[],
     this.onWordTap,
+    this.mainAxisSpacing = 10,
+    this.crossAxisSpacing = 4,
   });
 
   @override
@@ -34,8 +42,8 @@ class SeedPhrasesPicker extends StatelessWidget {
     return MediaQuery.withNoTextScaling(
       child: ColumnsRow(
         columnsCount: 2,
-        mainAxisSpacing: 10,
-        crossAxisSpacing: 6,
+        mainAxisSpacing: mainAxisSpacing,
+        crossAxisSpacing: crossAxisSpacing,
         children: words.map((word) {
           final isSelected = selectedWords.contains(word);
 

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_picker.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_picker.dart
@@ -14,7 +14,7 @@ class SeedPhrasesPicker extends StatelessWidget {
   /// The list of seed phrases to be displayed.
   final List<String> words;
 
-  /// A set of currently selected seed phrases. Defaults to an empty set.
+  /// A list of currently selected seed phrases. Defaults to empty list.
   final List<String> selectedWords;
 
   /// A callback function triggered when a non-selected seed phrase is tapped.

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_picker.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_picker.dart
@@ -1,5 +1,6 @@
 import 'package:catalyst_voices/widgets/common/columns_row.dart';
 import 'package:catalyst_voices/widgets/seed_phrase/seed_phrases_completer.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 /// A widget that displays a grid of seed phrases with selection functionality.
@@ -44,12 +45,12 @@ class SeedPhrasesPicker extends StatelessWidget {
         columnsCount: 2,
         mainAxisSpacing: mainAxisSpacing,
         crossAxisSpacing: crossAxisSpacing,
-        children: words.map((word) {
+        children: words.mapIndexed((index, word) {
           final isSelected = selectedWords.contains(word);
 
           return _WordCell(
             word,
-            key: ValueKey('PickerSeedPhrase${word}CellKey'),
+            key: ValueKey('PickerSeedPhrase${index}CellKey'),
             isSelected: isSelected,
             onTap: isSelected || onWordTap == null
                 ? null

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_sequencer.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_sequencer.dart
@@ -1,7 +1,5 @@
 import 'package:catalyst_voices/widgets/seed_phrase/seed_phrases_completer.dart';
 import 'package:catalyst_voices/widgets/seed_phrase/seed_phrases_picker.dart';
-import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// A widget that allows users to sequence a set of seed phrases.
@@ -12,97 +10,53 @@ import 'package:flutter/material.dart';
 ///
 /// The selected phrases are managed internally and updated through the
 /// [onChanged] callback.
-class SeedPhrasesSequencer extends StatefulWidget {
+class SeedPhrasesSequencer extends StatelessWidget {
   /// The list of available seed phrases.
   final List<String> words;
 
+  /// The list of words selected by user.
+  final List<String> selectedWords;
+
   /// A callback function triggered when the set of selected phrases changes.
-  final ValueChanged<Set<String>> onChanged;
+  final ValueChanged<List<String>> onChanged;
 
   /// Creates a [SeedPhrasesSequencer] widget.
   const SeedPhrasesSequencer({
     super.key,
     required this.words,
+    this.selectedWords = const [],
     required this.onChanged,
   });
-
-  @override
-  State<SeedPhrasesSequencer> createState() => _SeedPhrasesSequencerState();
-}
-
-class _SeedPhrasesSequencerState extends State<SeedPhrasesSequencer> {
-  final _selected = <String>{};
-
-  @override
-  void didUpdateWidget(covariant SeedPhrasesSequencer oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    if (!listEquals(widget.words, oldWidget.words)) {
-      _selected.clear();
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        _BorderDecorator(
-          child: SeedPhrasesCompleter(
-            slotsCount: widget.words.length,
-            words: _selected,
-            onWordTap: _removeWord,
-          ),
+        SeedPhrasesCompleter(
+          slotsCount: words.length,
+          words: selectedWords,
+          onWordTap: _removeWord,
         ),
-        const SizedBox(height: 12),
-        _BorderDecorator(
-          child: SeedPhrasesPicker(
-            words: widget.words,
-            selectedWords: _selected,
-            onWordTap: _selectWord,
-          ),
+        const SizedBox(height: 10),
+        SeedPhrasesPicker(
+          words: words,
+          selectedWords: selectedWords,
+          onWordTap: _selectWord,
         ),
       ],
     );
   }
 
   void _removeWord(String word) {
-    setState(() {
-      _selected.remove(word);
-      widget.onChanged(Set.of(_selected));
-    });
+    final words = [...selectedWords]..remove(word);
+
+    onChanged(words);
   }
 
   void _selectWord(String word) {
-    setState(() {
-      _selected.add(word);
-      widget.onChanged(Set.of(_selected));
-    });
-  }
-}
+    final words = [...selectedWords]..add(word);
 
-class _BorderDecorator extends StatelessWidget {
-  final Widget child;
-
-  const _BorderDecorator({
-    required this.child,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        border: Border.all(
-          color: Theme.of(context).colors.outlineBorderVariant ??
-              Theme.of(context).colorScheme.outlineVariant,
-          width: 1.5,
-        ),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(10),
-        child: child,
-      ),
-    );
+    onChanged(words);
   }
 }

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_sequencer.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_sequencer.dart
@@ -55,7 +55,7 @@ class SeedPhrasesSequencer extends StatelessWidget {
   }
 
   void _selectWord(String word) {
-    final words = [...selectedWords]..add(word);
+    final words = [...selectedWords, word];
 
     onChanged(words);
   }

--- a/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_viewer.dart
+++ b/catalyst_voices/lib/widgets/seed_phrase/seed_phrases_viewer.dart
@@ -29,7 +29,7 @@ class SeedPhrasesViewer extends StatelessWidget {
         children: words.mapIndexed((index, word) {
           return _WordCell(
             word,
-            key: ValueKey('SeedPhrase${word}CellKey'),
+            key: ValueKey('SeedPhrase${index}CellKey'),
             number: index + 1,
           );
         }).toList(),

--- a/catalyst_voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/lib/widgets/widgets.dart
@@ -13,6 +13,7 @@ export 'buttons/voices_segmented_button.dart';
 export 'buttons/voices_text_button.dart';
 export 'cards/funded_proposal_card.dart';
 export 'chips/voices_chip.dart';
+export 'common/infrastructure/voices_loadable.dart';
 export 'common/link_text.dart';
 export 'common/navigation_location.dart';
 export 'common/shortcut_activator_view.dart';

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
@@ -82,6 +82,10 @@ final class KeychainCreationCubit extends Cubit<CreateKeychain> {
   }
 
   CreateKeychainStep? nextStep() {
+    if (state.stage == CreateKeychainStage.seedPhrase) {
+      return CreateKeychainStep(stage: CreateKeychainStage.checkSeedPhrase);
+    }
+
     final currentStageIndex = CreateKeychainStage.values.indexOf(state.stage);
     final isLast = currentStageIndex == CreateKeychainStage.values.length - 1;
     if (isLast) {
@@ -93,6 +97,10 @@ final class KeychainCreationCubit extends Cubit<CreateKeychain> {
   }
 
   CreateKeychainStep? previousStep() {
+    if (state.stage == CreateKeychainStage.checkSeedPhrase) {
+      return CreateKeychainStep(stage: CreateKeychainStage.seedPhrase);
+    }
+
     final currentStageIndex = CreateKeychainStage.values.indexOf(state.stage);
     final isFirst = currentStageIndex == 0;
     if (isFirst) {

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
@@ -49,6 +49,15 @@ final class KeychainCreationCubit extends Cubit<CreateKeychain> {
     }
   }
 
+  void setSeedPhraseCheck({
+    required bool isChecked,
+  }) {
+    if (_seedPhraseState.isSeedPhraseChecked != isChecked) {
+      _seedPhraseState =
+          _seedPhraseState.copyWith(isSeedPhraseChecked: isChecked);
+    }
+  }
+
   Future<void> downloadSeedPhrase() async {
     final mnemonic = _seedPhraseState.seedPhrase?.mnemonic;
     if (mnemonic == null) {

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
@@ -82,10 +82,6 @@ final class KeychainCreationCubit extends Cubit<CreateKeychain> {
   }
 
   CreateKeychainStep? nextStep() {
-    if (state.stage == CreateKeychainStage.seedPhrase) {
-      return CreateKeychainStep(stage: CreateKeychainStage.checkSeedPhrase);
-    }
-
     final currentStageIndex = CreateKeychainStage.values.indexOf(state.stage);
     final isLast = currentStageIndex == CreateKeychainStage.values.length - 1;
     if (isLast) {
@@ -97,10 +93,6 @@ final class KeychainCreationCubit extends Cubit<CreateKeychain> {
   }
 
   CreateKeychainStep? previousStep() {
-    if (state.stage == CreateKeychainStage.checkSeedPhrase) {
-      return CreateKeychainStep(stage: CreateKeychainStage.seedPhrase);
-    }
-
     final currentStageIndex = CreateKeychainStage.values.indexOf(state.stage);
     final isFirst = currentStageIndex == 0;
     if (isFirst) {

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
@@ -49,12 +49,12 @@ final class KeychainCreationCubit extends Cubit<CreateKeychain> {
     }
   }
 
-  void setSeedPhraseCheck({
-    required bool isChecked,
+  void setSeedPhraseCheckConfirmed({
+    required bool isConfirmed,
   }) {
-    if (_seedPhraseState.isSeedPhraseChecked != isChecked) {
+    if (_seedPhraseState.isCheckConfirmed != isConfirmed) {
       _seedPhraseState =
-          _seedPhraseState.copyWith(isSeedPhraseChecked: isChecked);
+          _seedPhraseState.copyWith(isCheckConfirmed: isConfirmed);
     }
   }
 

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -100,10 +100,12 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
     return _keychainCreationCubit.downloadSeedPhrase();
   }
 
-  void setSeedPhraseCheck({
-    required bool isChecked,
+  void setSeedPhraseCheckConfirmed({
+    required bool isConfirmed,
   }) {
-    _keychainCreationCubit.setSeedPhraseCheck(isChecked: isChecked);
+    _keychainCreationCubit.setSeedPhraseCheckConfirmed(
+      isConfirmed: isConfirmed,
+    );
   }
 
   RegistrationStep? _nextStep({RegistrationStep? from}) {

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -100,6 +100,12 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
     return _keychainCreationCubit.downloadSeedPhrase();
   }
 
+  void setSeedPhraseCheck({
+    required bool isChecked,
+  }) {
+    _keychainCreationCubit.setSeedPhraseCheck(isChecked: isChecked);
+  }
+
   RegistrationStep? _nextStep({RegistrationStep? from}) {
     final step = from ?? state.step;
 

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/seed_phrase_state.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/seed_phrase_state.dart
@@ -4,23 +4,23 @@ import 'package:equatable/equatable.dart';
 final class SeedPhraseState extends Equatable {
   final SeedPhrase? seedPhrase;
   final bool isStoredConfirmed;
-  final bool isSeedPhraseChecked;
+  final bool isCheckConfirmed;
 
   const SeedPhraseState({
     this.seedPhrase,
     this.isStoredConfirmed = false,
-    this.isSeedPhraseChecked = false,
+    this.isCheckConfirmed = false,
   });
 
   SeedPhraseState copyWith({
     Optional<SeedPhrase>? seedPhrase,
     bool? isStoredConfirmed,
-    bool? isSeedPhraseChecked,
+    bool? isCheckConfirmed,
   }) {
     return SeedPhraseState(
       seedPhrase: seedPhrase != null ? seedPhrase.data : this.seedPhrase,
       isStoredConfirmed: isStoredConfirmed ?? this.isStoredConfirmed,
-      isSeedPhraseChecked: isSeedPhraseChecked ?? this.isSeedPhraseChecked,
+      isCheckConfirmed: isCheckConfirmed ?? this.isCheckConfirmed,
     );
   }
 
@@ -28,6 +28,6 @@ final class SeedPhraseState extends Equatable {
   List<Object?> get props => [
         seedPhrase,
         isStoredConfirmed,
-        isSeedPhraseChecked,
+        isCheckConfirmed,
       ];
 }

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/seed_phrase_state.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/seed_phrase_state.dart
@@ -4,19 +4,23 @@ import 'package:equatable/equatable.dart';
 final class SeedPhraseState extends Equatable {
   final SeedPhrase? seedPhrase;
   final bool isStoredConfirmed;
+  final bool isSeedPhraseChecked;
 
   const SeedPhraseState({
     this.seedPhrase,
     this.isStoredConfirmed = false,
+    this.isSeedPhraseChecked = false,
   });
 
   SeedPhraseState copyWith({
     Optional<SeedPhrase>? seedPhrase,
     bool? isStoredConfirmed,
+    bool? isSeedPhraseChecked,
   }) {
     return SeedPhraseState(
       seedPhrase: seedPhrase != null ? seedPhrase.data : this.seedPhrase,
       isStoredConfirmed: isStoredConfirmed ?? this.isStoredConfirmed,
+      isSeedPhraseChecked: isSeedPhraseChecked ?? this.isSeedPhraseChecked,
     );
   }
 
@@ -24,5 +28,6 @@ final class SeedPhraseState extends Equatable {
   List<Object?> get props => [
         seedPhrase,
         isStoredConfirmed,
+        isSeedPhraseChecked,
       ];
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -1053,6 +1053,30 @@ abstract class VoicesLocalizations {
   /// In en, this message translates to:
   /// **'I have written down/downloaded my 12 words'**
   String get createKeychainSeedPhraseStoreConfirmation;
+
+  /// No description provided for @createKeychainSeedPhraseCheckSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Input your Catalyst security keys'**
+  String get createKeychainSeedPhraseCheckSubtitle;
+
+  /// No description provided for @createKeychainSeedPhraseCheckBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Select your 12 written down words in  the correct order.'**
+  String get createKeychainSeedPhraseCheckBody;
+
+  /// When user checks correct seed phrase words order he can upload it too
+  ///
+  /// In en, this message translates to:
+  /// **'Upload Catalyst Key'**
+  String get uploadCatalystKey;
+
+  /// No description provided for @reset.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset'**
+  String get reset;
 }
 
 class _VoicesLocalizationsDelegate extends LocalizationsDelegate<VoicesLocalizations> {

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -1089,6 +1089,30 @@ abstract class VoicesLocalizations {
   /// In en, this message translates to:
   /// **'Reset'**
   String get reset;
+
+  /// No description provided for @createKeychainSeedPhraseCheckSuccessTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Nice job! You\'ve successfully verified the seed phrase for your keychain.'**
+  String get createKeychainSeedPhraseCheckSuccessTitle;
+
+  /// No description provided for @createKeychainSeedPhraseCheckSuccessSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.'**
+  String get createKeychainSeedPhraseCheckSuccessSubtitle;
+
+  /// No description provided for @yourNextStep.
+  ///
+  /// In en, this message translates to:
+  /// **'Your next step'**
+  String get yourNextStep;
+
+  /// No description provided for @createKeychainSeedPhraseCheckSuccessNextStep.
+  ///
+  /// In en, this message translates to:
+  /// **'Now let’s set your Unlock password for this device!'**
+  String get createKeychainSeedPhraseCheckSuccessNextStep;
 }
 
 class _VoicesLocalizationsDelegate extends LocalizationsDelegate<VoicesLocalizations> {

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -560,4 +560,16 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
 
   @override
   String get reset => 'Reset';
+
+  @override
+  String get createKeychainSeedPhraseCheckSuccessTitle => 'Nice job! You\'ve successfully verified the seed phrase for your keychain.';
+
+  @override
+  String get createKeychainSeedPhraseCheckSuccessSubtitle => 'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.';
+
+  @override
+  String get yourNextStep => 'Your next step';
+
+  @override
+  String get createKeychainSeedPhraseCheckSuccessNextStep => 'Now let’s set your Unlock password for this device!';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -542,4 +542,16 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
 
   @override
   String get createKeychainSeedPhraseStoreConfirmation => 'I have written down/downloaded my 12 words';
+
+  @override
+  String get createKeychainSeedPhraseCheckSubtitle => 'Input your Catalyst security keys';
+
+  @override
+  String get createKeychainSeedPhraseCheckBody => 'Select your 12 written down words in  the correct order.';
+
+  @override
+  String get uploadCatalystKey => 'Upload Catalyst Key';
+
+  @override
+  String get reset => 'Reset';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -542,4 +542,16 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
 
   @override
   String get createKeychainSeedPhraseStoreConfirmation => 'I have written down/downloaded my 12 words';
+
+  @override
+  String get createKeychainSeedPhraseCheckSubtitle => 'Input your Catalyst security keys';
+
+  @override
+  String get createKeychainSeedPhraseCheckBody => 'Select your 12 written down words in  the correct order.';
+
+  @override
+  String get uploadCatalystKey => 'Upload Catalyst Key';
+
+  @override
+  String get reset => 'Reset';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -560,4 +560,16 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
 
   @override
   String get reset => 'Reset';
+
+  @override
+  String get createKeychainSeedPhraseCheckSuccessTitle => 'Nice job! You\'ve successfully verified the seed phrase for your keychain.';
+
+  @override
+  String get createKeychainSeedPhraseCheckSuccessSubtitle => 'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.';
+
+  @override
+  String get yourNextStep => 'Your next step';
+
+  @override
+  String get createKeychainSeedPhraseCheckSuccessNextStep => 'Now let’s set your Unlock password for this device!';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -636,5 +636,12 @@
   "createKeychainSeedPhraseSubtitle": "Write down your 12 Catalyst \u2028security words",
   "createKeychainSeedPhraseBody": "Make sure you create an offline backup of your recovery phrase as well.",
   "createKeychainSeedPhraseDownload": "Download Catalyst key",
-  "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words"
+  "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words",
+  "createKeychainSeedPhraseCheckSubtitle": "Input your Catalyst security keys",
+  "createKeychainSeedPhraseCheckBody": "Select your 12 written down words in \u2028the correct order.",
+  "uploadCatalystKey": "Upload Catalyst Key",
+  "@uploadCatalystKey": {
+    "description": "When user checks correct seed phrase words order he can upload it too"
+  },
+  "reset": "Reset"
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -645,5 +645,9 @@
   "@uploadCatalystKey": {
     "description": "When user checks correct seed phrase words order he can upload it too"
   },
-  "reset": "Reset"
+  "reset": "Reset",
+  "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You've successfully verified the seed phrase for your keychain.",
+  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It's kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
+  "yourNextStep": "Your next step",
+  "createKeychainSeedPhraseCheckSuccessNextStep": "Now let’s set your Unlock password for this device!"
 }

--- a/catalyst_voices/packages/catalyst_voices_models/lib/src/seed_phrase.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/lib/src/seed_phrase.dart
@@ -85,6 +85,10 @@ final class SeedPhrase extends Equatable {
   /// The mnemonic phrase as a list of individual words.
   List<String> get mnemonicWords => mnemonic.split(' ');
 
+  /// Version of [mnemonicWords] but in random order. Each call will generate
+  /// new random order.
+  List<String> get shuffledMnemonicWords => [...mnemonicWords]..shuffle();
+
   /// Derives an Ed25519 key pair from a seed.
   ///
   /// Throws a [RangeError] If the provided [offset] is negative or exceeds

--- a/catalyst_voices/test/widgets/seed_phrase/seed_phrases_sequencer_test.dart
+++ b/catalyst_voices/test/widgets/seed_phrase/seed_phrases_sequencer_test.dart
@@ -24,7 +24,7 @@ void main() {
               ..addAll(value);
           },
         );
-        final wordPickerKey = ValueKey('PickerSeedPhrase${word}CellKey');
+        const wordPickerKey = ValueKey('PickerSeedPhrase${0}CellKey');
 
         // When
         await tester.pumpApp(sequencer);
@@ -40,11 +40,15 @@ void main() {
       'clicking last word in completer removes word from list',
       (tester) async {
         // Given
-        final selectedWords = <String>{};
+        final selectedWords = <String>[
+          words[0],
+          words[1],
+        ];
         final expectedWords = {words[0]};
 
         final sequencer = SeedPhrasesSequencer(
           words: words,
+          selectedWords: selectedWords,
           onChanged: (value) {
             selectedWords
               ..clear()
@@ -52,23 +56,12 @@ void main() {
           },
         );
 
-        final pickerKeys = <ValueKey<String>>[
-          ValueKey('PickerSeedPhrase${words[0]}CellKey'),
-          ValueKey('PickerSeedPhrase${words[1]}CellKey'),
-        ];
         final completerKeys = <ValueKey<String>>[
           const ValueKey('CompleterSeedPhrase${1}CellKey'),
         ];
 
         // When
         await tester.pumpApp(sequencer);
-        await tester.pumpAndSettle();
-
-        // Adds items to selectedWords
-        for (final key in pickerKeys) {
-          await tester.tap(find.byKey(key));
-        }
-
         await tester.pumpAndSettle();
 
         // Removes from selectedWords

--- a/catalyst_voices/uikit_example/lib/examples/voices_seed_phrase_example.dart
+++ b/catalyst_voices/uikit_example/lib/examples/voices_seed_phrase_example.dart
@@ -1,7 +1,7 @@
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 
-class VoicesSeedPhraseExample extends StatelessWidget {
+class VoicesSeedPhraseExample extends StatefulWidget {
   static const String route = '/seed-phrase-example';
 
   static const _words = [
@@ -24,6 +24,14 @@ class VoicesSeedPhraseExample extends StatelessWidget {
   });
 
   @override
+  State<VoicesSeedPhraseExample> createState() =>
+      _VoicesSeedPhraseExampleState();
+}
+
+class _VoicesSeedPhraseExampleState extends State<VoicesSeedPhraseExample> {
+  final _selectedWords = <String>[];
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Seed Phrase')),
@@ -32,13 +40,20 @@ class VoicesSeedPhraseExample extends StatelessWidget {
         children: [
           const Text('SeedPhrasesViewer'),
           const SizedBox(height: 12),
-          const SeedPhrasesViewer(words: _words),
+          const SeedPhrasesViewer(words: VoicesSeedPhraseExample._words),
           const SizedBox(height: 24),
           const Text('SeedPhrasesSequencer'),
           const SizedBox(height: 12),
           SeedPhrasesSequencer(
-            words: _words,
-            onChanged: (value) {},
+            words: VoicesSeedPhraseExample._words,
+            selectedWords: _selectedWords,
+            onChanged: (value) {
+              setState(() {
+                _selectedWords
+                  ..clear()
+                  ..addAll(value);
+              });
+            },
           ),
         ],
       ),


### PR DESCRIPTION
# Description

This PR adds checking seed phrase order by user as well as result panel

## Related Issue(s)

Part of #816  

## Screenshots

<img width="1213" alt="Screenshot 2024-10-01 at 14 34 23" src="https://github.com/user-attachments/assets/10f0d6c9-edcd-4fc6-b51e-ade0d6af3456">
<img width="1207" alt="Screenshot 2024-10-01 at 14 34 29" src="https://github.com/user-attachments/assets/f6e0df83-442d-4baf-b0a0-9199111e99a9">


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
