### PR TITLE
feat(cat-voices): not dismissible registration dialog

### DIFF
--- a/catalyst_voices/lib/pages/registration/registration_dialog.dart
+++ b/catalyst_voices/lib/pages/registration/registration_dialog.dart
@@ -17,6 +17,7 @@ class RegistrationDialog extends StatelessWidget {
       context: context,
       routeSettings: const RouteSettings(name: '/registration'),
       builder: (context) => const RegistrationDialog._(),
+      barrierDismissible: false,
     );
   }
 


### PR DESCRIPTION
# Description

Makes `RegistrationDialog` not dismissible when clicking outside. Now user have to make conscious decision by clicking "X" button to exit. 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
