### PR TITLE
feat(cat-voices): seed phrase error result and unlock password instructions

### DIFF
--- a/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
@@ -1,5 +1,5 @@
-import 'package:catalyst_voices/pages/registration/create_keychain/stage/check_seed_phrase_instructions_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/instructions_panel.dart';
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_instructions_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_panel.dart';
@@ -30,7 +30,7 @@ class CreateKeychainPanel extends StatelessWidget {
           isNextEnabled: seedPhraseState.isStoredConfirmed,
         ),
       CreateKeychainStage.checkSeedPhraseInstructions =>
-        const CheckSeedPhraseInstructionsPanel(),
+        const SeedPhraseCheckInstructionsPanel(),
       CreateKeychainStage.checkSeedPhrase => SeedPhraseCheckPanel(
           seedPhrase: seedPhraseState.seedPhrase,
         ),

--- a/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/create_keychain_panel.dart
@@ -4,6 +4,7 @@ import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_ph
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/seed_phrase_panel.dart';
 import 'package:catalyst_voices/pages/registration/create_keychain/stage/splash_panel.dart';
+import 'package:catalyst_voices/pages/registration/create_keychain/stage/unlock_password_instructions_panel.dart';
 import 'package:catalyst_voices/pages/registration/placeholder_panel.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
@@ -37,9 +38,9 @@ class CreateKeychainPanel extends StatelessWidget {
       CreateKeychainStage.checkSeedPhraseResult => SeedPhraseCheckResultPanel(
           isCheckConfirmed: seedPhraseState.isCheckConfirmed,
         ),
-      CreateKeychainStage.unlockPasswordInstructions ||
-      CreateKeychainStage.unlockPasswordCreate =>
-        const PlaceholderPanel(),
+      CreateKeychainStage.unlockPasswordInstructions =>
+        const UnlockPasswordInstructionsPanel(),
+      CreateKeychainStage.unlockPasswordCreate => const PlaceholderPanel(),
     };
   }
 }

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/instructions_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/instructions_panel.dart
@@ -8,15 +8,21 @@ class InstructionsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SizedBox(height: 24),
-        RegistrationStageMessage(
-          title: context.l10n.accountInstructionsTitle,
-          subtitle: context.l10n.accountInstructionsMessage,
+        Expanded(
+          child: SingleChildScrollView(
+            child: RegistrationStageMessage(
+              title: l10n.accountInstructionsTitle,
+              subtitle: l10n.accountInstructionsMessage,
+            ),
+          ),
         ),
-        const Spacer(),
+        const SizedBox(height: 10),
         const RegistrationBackNextNavigation(),
       ],
     );

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_instructions_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_instructions_panel.dart
@@ -10,16 +10,21 @@ class SeedPhraseCheckInstructionsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SizedBox(height: 24),
-        RegistrationStageMessage(
-          title: context.l10n.createKeychainSeedPhraseCheckInstructionsTitle,
-          subtitle:
-              context.l10n.createKeychainSeedPhraseCheckInstructionsSubtitle,
+        Expanded(
+          child: SingleChildScrollView(
+            child: RegistrationStageMessage(
+              title: l10n.createKeychainSeedPhraseCheckInstructionsTitle,
+              subtitle: l10n.createKeychainSeedPhraseCheckInstructionsSubtitle,
+            ),
+          ),
         ),
-        const Spacer(),
+        const SizedBox(height: 10),
         const RegistrationBackNextNavigation(),
       ],
     );

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_instructions_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_instructions_panel.dart
@@ -4,8 +4,8 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 
-class CheckSeedPhraseInstructionsPanel extends StatelessWidget {
-  const CheckSeedPhraseInstructionsPanel({
+class SeedPhraseCheckInstructionsPanel extends StatelessWidget {
+  const SeedPhraseCheckInstructionsPanel({
     super.key,
   });
 

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -22,12 +22,14 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
   final _shuffledSeedPhraseWords = <String>[];
   final _userWords = <String>[];
 
-  bool get _isStageValid {
-    if (_seedPhraseWords.isEmpty) {
-      return false;
-    }
+  bool get _hasSeedPhraseWords => _seedPhraseWords.isNotEmpty;
 
-    return listEquals(_seedPhraseWords, _userWords);
+  bool get _completedWordsSequence {
+    return _hasSeedPhraseWords && _userWords.length == _seedPhraseWords.length;
+  }
+
+  bool get _completedCorrectlyWordsSequence {
+    return _hasSeedPhraseWords && listEquals(_userWords, _seedPhraseWords);
   }
 
   @override
@@ -68,7 +70,9 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
           ),
         ),
         const SizedBox(height: 10),
-        _Navigation(isNextEnabled: _isStageValid),
+        _Navigation(
+          isNextEnabled: _completedWordsSequence,
+        ),
       ],
     );
   }
@@ -108,9 +112,10 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
       ..clear()
       ..addAll(words);
 
-    RegistrationCubit.of(context).setSeedPhraseCheckConfirmed(
-      isConfirmed: _isStageValid,
-    );
+    final isConfirmed = _completedCorrectlyWordsSequence;
+
+    RegistrationCubit.of(context)
+        .setSeedPhraseCheckConfirmed(isConfirmed: isConfirmed);
   }
 }
 

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -38,7 +38,7 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
     super.initState();
 
     _updateSeedPhraseWords();
-    _updateUserWords(_seedPhraseWords);
+    _updateUserWords();
   }
 
   @override

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart
@@ -14,26 +14,28 @@ class SeedPhraseCheckResultPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SizedBox(height: 24),
         // TODO(damian-molinski): use correct strings when available.
-        RegistrationStageMessage(
-          title: isCheckConfirmed
-              ? context.l10n.createKeychainSeedPhraseCheckSuccessTitle
-              : 'Seed phrase words does not match!',
-          subtitle: isCheckConfirmed
-              ? context.l10n.createKeychainSeedPhraseCheckSuccessSubtitle
-              : 'Go back ana make sure order is correct',
-        ),
-        const Spacer(),
-        if (isCheckConfirmed) ...[
-          NextStep(
-            context.l10n.createKeychainSeedPhraseCheckSuccessNextStep,
+        Expanded(
+          child: SingleChildScrollView(
+            child: RegistrationStageMessage(
+              title: isCheckConfirmed
+                  ? l10n.createKeychainSeedPhraseCheckSuccessTitle
+                  : 'Seed phrase words does not match!',
+              subtitle: isCheckConfirmed
+                  ? l10n.createKeychainSeedPhraseCheckSuccessSubtitle
+                  : 'Go back ana make sure order is correct',
+            ),
           ),
-          const SizedBox(height: 10),
-        ],
+        ),
+        if (isCheckConfirmed)
+          NextStep(l10n.createKeychainSeedPhraseCheckSuccessNextStep),
+        const SizedBox(height: 10),
         RegistrationBackNextNavigation(isNextEnabled: isCheckConfirmed),
       ],
     );

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_result_panel.dart
@@ -18,15 +18,22 @@ class SeedPhraseCheckResultPanel extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SizedBox(height: 24),
+        // TODO(damian-molinski): use correct strings when available.
         RegistrationStageMessage(
-          title: context.l10n.createKeychainSeedPhraseCheckSuccessTitle,
-          subtitle: context.l10n.createKeychainSeedPhraseCheckSuccessSubtitle,
+          title: isCheckConfirmed
+              ? context.l10n.createKeychainSeedPhraseCheckSuccessTitle
+              : 'Seed phrase words does not match!',
+          subtitle: isCheckConfirmed
+              ? context.l10n.createKeychainSeedPhraseCheckSuccessSubtitle
+              : 'Go back ana make sure order is correct',
         ),
         const Spacer(),
-        NextStep(
-          context.l10n.createKeychainSeedPhraseCheckSuccessNextStep,
-        ),
-        const SizedBox(height: 10),
+        if (isCheckConfirmed) ...[
+          NextStep(
+            context.l10n.createKeychainSeedPhraseCheckSuccessNextStep,
+          ),
+          const SizedBox(height: 10),
+        ],
         RegistrationBackNextNavigation(isNextEnabled: isCheckConfirmed),
       ],
     );

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/unlock_password_instructions_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/unlock_password_instructions_panel.dart
@@ -1,0 +1,27 @@
+import 'package:catalyst_voices/pages/registration/registration_stage_message.dart';
+import 'package:catalyst_voices/pages/registration/registration_stage_navigation.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:flutter/material.dart';
+
+class UnlockPasswordInstructionsPanel extends StatelessWidget {
+  const UnlockPasswordInstructionsPanel({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 24),
+        RegistrationStageMessage(
+          title: context.l10n.createKeychainSeedPhraseCheckInstructionsTitle,
+          subtitle:
+              context.l10n.createKeychainSeedPhraseCheckInstructionsSubtitle,
+        ),
+        const Spacer(),
+        const RegistrationBackNextNavigation(),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/unlock_password_instructions_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/unlock_password_instructions_panel.dart
@@ -10,16 +10,21 @@ class UnlockPasswordInstructionsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const SizedBox(height: 24),
-        RegistrationStageMessage(
-          title: context.l10n.createKeychainSeedPhraseCheckInstructionsTitle,
-          subtitle:
-              context.l10n.createKeychainSeedPhraseCheckInstructionsSubtitle,
+        Expanded(
+          child: SingleChildScrollView(
+            child: RegistrationStageMessage(
+              title: l10n.createKeychainUnlockPasswordInstructionsTitle,
+              subtitle: l10n.createKeychainUnlockPasswordInstructionsSubtitle,
+            ),
+          ),
         ),
-        const Spacer(),
+        const SizedBox(height: 10),
         const RegistrationBackNextNavigation(),
       ],
     );

--- a/catalyst_voices/lib/pages/registration/pictures/password_picture.dart
+++ b/catalyst_voices/lib/pages/registration/pictures/password_picture.dart
@@ -1,0 +1,17 @@
+import 'package:catalyst_voices/pages/registration/pictures/task_picture.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:flutter/material.dart';
+
+class PasswordPicture extends StatelessWidget {
+  const PasswordPicture({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TaskPicture(
+      child: TaskPictureIconBox(
+        type: TaskPictureType.error,
+        child: VoicesAssets.icons.lockClosed.buildIcon(size: 48),
+      ),
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/lib/pages/registration/registration_info_panel.dart
@@ -1,5 +1,6 @@
 import 'package:catalyst_voices/pages/registration/information_panel.dart';
 import 'package:catalyst_voices/pages/registration/pictures/keychain_picture.dart';
+import 'package:catalyst_voices/pages/registration/pictures/password_picture.dart';
 import 'package:catalyst_voices/pages/registration/pictures/seed_phrase_picture.dart';
 import 'package:catalyst_voices/pages/registration/pictures/task_picture.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
@@ -66,9 +67,9 @@ class RegistrationInfoPanel extends StatelessWidget {
             subtitle: context.l10n.createKeychainSeedPhraseCheckSubtitle,
             body: context.l10n.createKeychainSeedPhraseCheckBody,
           ),
-        CreateKeychainStage.checkSeedPhraseResult =>
+        CreateKeychainStage.checkSeedPhraseResult ||
+        CreateKeychainStage.unlockPasswordInstructions =>
           _HeaderStrings(title: context.l10n.catalystKeychain),
-        CreateKeychainStage.unlockPasswordInstructions ||
         CreateKeychainStage.unlockPasswordCreate =>
           _HeaderStrings(title: 'TODO'),
       };
@@ -138,7 +139,7 @@ class _RegistrationPicture extends StatelessWidget {
           ),
         CreateKeychainStage.unlockPasswordInstructions ||
         CreateKeychainStage.unlockPasswordCreate =>
-          const KeychainPicture(),
+          const PasswordPicture(),
       };
     }
 

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -1113,6 +1113,18 @@ abstract class VoicesLocalizations {
   /// In en, this message translates to:
   /// **'Now let’s set your Unlock password for this device!'**
   String get createKeychainSeedPhraseCheckSuccessNextStep;
+
+  /// No description provided for @createKeychainUnlockPasswordInstructionsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set your Catalyst unlock password  for this device'**
+  String get createKeychainUnlockPasswordInstructionsTitle;
+
+  /// No description provided for @createKeychainUnlockPasswordInstructionsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
+  String get createKeychainUnlockPasswordInstructionsSubtitle;
 }
 
 class _VoicesLocalizationsDelegate extends LocalizationsDelegate<VoicesLocalizations> {

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -572,4 +572,10 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
 
   @override
   String get createKeychainSeedPhraseCheckSuccessNextStep => 'Now let’s set your Unlock password for this device!';
+
+  @override
+  String get createKeychainUnlockPasswordInstructionsTitle => 'Set your Catalyst unlock password  for this device';
+
+  @override
+  String get createKeychainUnlockPasswordInstructionsSubtitle => 'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -572,4 +572,10 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
 
   @override
   String get createKeychainSeedPhraseCheckSuccessNextStep => 'Now let’s set your Unlock password for this device!';
+
+  @override
+  String get createKeychainUnlockPasswordInstructionsTitle => 'Set your Catalyst unlock password  for this device';
+
+  @override
+  String get createKeychainUnlockPasswordInstructionsSubtitle => 'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -649,5 +649,7 @@
   "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You've successfully verified the seed phrase for your keychain.",
   "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It's kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
   "yourNextStep": "Your next step",
-  "createKeychainSeedPhraseCheckSuccessNextStep": "Now let’s set your Unlock password for this device!"
+  "createKeychainSeedPhraseCheckSuccessNextStep": "Now let’s set your Unlock password for this device!",
+  "createKeychainUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password \u2028for this device",
+  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access."
 }


### PR DESCRIPTION
# Description

- Adds Unlock password instructions panel
- Allows user see result seed phrase stage when incorrect order

## Related Issue(s)

Part of #816 

## Screenshots

<img width="1320" alt="Screenshot 2024-10-02 at 10 37 38" src="https://github.com/user-attachments/assets/af718dac-91ab-4a62-807b-aeced142abf8">


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
