### PR TITLE
feat(cat-voices): debug pre fill seed phrase words

### DIFF
--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/seed_phrase_check_panel.dart
@@ -38,7 +38,9 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
     super.initState();
 
     _updateSeedPhraseWords();
-    _updateUserWords();
+    // Note. In debug mode we're prefilling correct seed phrase words
+    // so its faster to test screens
+    _updateUserWords(kDebugMode ? _seedPhraseWords : const []);
   }
 
   @override
@@ -47,7 +49,9 @@ class _SeedPhraseCheckPanelState extends State<SeedPhraseCheckPanel> {
 
     if (widget.seedPhrase != oldWidget.seedPhrase) {
       _updateSeedPhraseWords();
-      _updateUserWords();
+      // Note. In debug mode we're prefilling correct seed phrase words
+      // so its faster to test screens
+      _updateUserWords(kDebugMode ? _seedPhraseWords : const []);
     }
   }
 


### PR DESCRIPTION
# Description

In debug mode seed phrase words are filled in correct order by default.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
