### PR TITLE
fix(cat-voices): migrate apple-mobile-web-app-capable to mobile-web-app-capable

### DIFF
--- a/catalyst_voices/lib/pages/registration/finish_account/finish_account_creation_panel.dart
+++ b/catalyst_voices/lib/pages/registration/finish_account/finish_account_creation_panel.dart
@@ -24,7 +24,7 @@ class FinishAccountCreationPanel extends StatelessWidget {
               children: [
                 _TitleText(),
                 SizedBox(height: 24),
-                RegistrationProgressKeychainCompleted()
+                RegistrationProgressKeychainCompleted(),
               ],
             ),
           ),

--- a/catalyst_voices/packages/catalyst_voices_assets/example/web/index.html
+++ b/catalyst_voices/packages/catalyst_voices_assets/example/web/index.html
@@ -21,7 +21,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/catalyst_voices/uikit_example/web/index.html
+++ b/catalyst_voices/uikit_example/web/index.html
@@ -21,7 +21,7 @@
     <meta name="description" content="A new Flutter project.">
 
     <!-- iOS meta tags & icons -->
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="apple-mobile-web-app-title" content="uikit_example">
     <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/catalyst_voices/web/index.html
+++ b/catalyst_voices/web/index.html
@@ -22,7 +22,7 @@
   <meta name="description" content="Catalyst Voices">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Catalyst Voices">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/web/index.html
+++ b/catalyst_voices_packages/catalyst_cardano/catalyst_cardano/example/web/index.html
@@ -22,7 +22,7 @@
   <meta name="description" content="Demonstrates usage of catalyst_cardano plugin">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/utilities/catalyst_voices_remote_widgets/example/web/index.html
+++ b/utilities/catalyst_voices_remote_widgets/example/web/index.html
@@ -21,7 +21,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="example">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/utilities/poc_local_storage/web/index.html
+++ b/utilities/poc_local_storage/web/index.html
@@ -21,7 +21,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="poc_local_storage">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">


### PR DESCRIPTION
# Description

Migrates deprecated `migrate apple-mobile-web-app-capable` meta tag to `mobile-web-app-capable`.

## Related Issue(s)

- `https://github.com/flutter/flutter/pull/154964`

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
