### PR TITLE
fix(cat-voices): flutter_inappwebview's web_support.js not found error

### DIFF
--- a/catalyst_voices/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/catalyst_voices/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,7 +7,6 @@ import Foundation
 
 import device_info_plus
 import file_selector_macos
-import flutter_inappwebview_macos
 import flutter_secure_storage_macos
 import gal
 import irondash_engine_context
@@ -21,7 +20,6 @@ import video_player_avfoundation
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   IrondashEngineContextPlugin.register(with: registry.registrar(forPlugin: "IrondashEngineContextPlugin"))

--- a/catalyst_voices/pubspec.yaml
+++ b/catalyst_voices/pubspec.yaml
@@ -38,8 +38,8 @@ dependencies:
   flutter_adaptive_scaffold: ^0.2.4
   flutter_bloc: ^8.1.5
   flutter_localized_locales: ^2.0.5
-  flutter_quill: ^10.5.13
-  flutter_quill_extensions: ^10.5.13
+  flutter_quill: ^10.8.2
+  flutter_quill_extensions: ^10.8.2
   flutter_web_plugins:
     sdk: flutter
   formz: ^0.7.0

--- a/catalyst_voices/uikit_example/pubspec.yaml
+++ b/catalyst_voices/uikit_example/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^8.1.5
   flutter_localized_locales: ^2.0.5
-  flutter_quill: ^10.5.13
+  flutter_quill: ^10.8.2
 
 dev_dependencies:
   build_runner: ^2.4.12

--- a/catalyst_voices/uikit_example/web/index.html
+++ b/catalyst_voices/uikit_example/web/index.html
@@ -31,9 +31,6 @@
 
     <title>uikit_example</title>
     <link rel="manifest" href="manifest.json">
-    <script type="application/javascript"
-            src="/assets/packages/flutter_inappwebview_web/assets/web/web_support.js"
-            defer></script>
 </head>
 <body>
 <script src="flutter_bootstrap.js" async></script>

--- a/catalyst_voices/web/index.html
+++ b/catalyst_voices/web/index.html
@@ -2,42 +2,41 @@
 <html>
 
 <head>
-    <!--
-      If you are serving your web app in a path other than the root, change the
-      href value below to reflect the base path you are serving from.
+  <!--
+    If you are serving your web app in a path other than the root, change the
+    href value below to reflect the base path you are serving from.
 
-      The path provided below has to start and end with a slash "/" in order for
-      it to work correctly.
+    The path provided below has to start and end with a slash "/" in order for
+    it to work correctly.
 
-      For more details:
-      * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+    For more details:
+    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
-      This is a placeholder for base href that will be replaced by the value of
-      the `--base-href` argument provided to `flutter build`.
-    -->
-    <base href="$FLUTTER_BASE_HREF">
+    This is a placeholder for base href that will be replaced by the value of
+    the `--base-href` argument provided to `flutter build`.
+  -->
+  <base href="$FLUTTER_BASE_HREF">
 
-    <meta charset="UTF-8">
-    <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-    <meta name="description" content="Catalyst Voices">
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+  <meta name="description" content="Catalyst Voices">
 
-    <!-- iOS meta tags & icons -->
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <meta name="apple-mobile-web-app-title" content="Catalyst Voices">
-    <link rel="apple-touch-icon" href="icons/Icon-192.png">
+  <!-- iOS meta tags & icons -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Catalyst Voices">
+  <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
-    <!-- Favicon -->
-    <link rel="icon" type="image/png" href="favicon.png"/>
+  <!-- Favicon -->
+  <link rel="icon" type="image/png" href="favicon.png" />
 
-    <title>Catalyst Voices</title>
-    <link rel="manifest" href="manifest.json">
-    <script type="module"
-            src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"></script>
+  <title>Catalyst Voices</title>
+  <link rel="manifest" href="manifest.json">
+  <script type="module" src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"></script>
 </head>
 
 <body>
-<script src="flutter_bootstrap.js" async></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 
 </html>

--- a/catalyst_voices/web/index.html
+++ b/catalyst_voices/web/index.html
@@ -33,8 +33,6 @@
   <title>Catalyst Voices</title>
   <link rel="manifest" href="manifest.json">
   <script type="module" src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"></script>
-  <script type="application/javascript" src="/assets/packages/flutter_inappwebview_web/assets/web/web_support.js"
-    defer></script>
 </head>
 
 <body>

--- a/catalyst_voices/web/index.html
+++ b/catalyst_voices/web/index.html
@@ -2,41 +2,42 @@
 <html>
 
 <head>
-  <!--
-    If you are serving your web app in a path other than the root, change the
-    href value below to reflect the base path you are serving from.
+    <!--
+      If you are serving your web app in a path other than the root, change the
+      href value below to reflect the base path you are serving from.
 
-    The path provided below has to start and end with a slash "/" in order for
-    it to work correctly.
+      The path provided below has to start and end with a slash "/" in order for
+      it to work correctly.
 
-    For more details:
-    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+      For more details:
+      * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 
-    This is a placeholder for base href that will be replaced by the value of
-    the `--base-href` argument provided to `flutter build`.
-  -->
-  <base href="$FLUTTER_BASE_HREF">
+      This is a placeholder for base href that will be replaced by the value of
+      the `--base-href` argument provided to `flutter build`.
+    -->
+    <base href="$FLUTTER_BASE_HREF">
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="Catalyst Voices">
+    <meta charset="UTF-8">
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+    <meta name="description" content="Catalyst Voices">
 
-  <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="Catalyst Voices">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <meta name="apple-mobile-web-app-title" content="Catalyst Voices">
+    <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png" />
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>Catalyst Voices</title>
-  <link rel="manifest" href="manifest.json">
-  <script type="module" src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"></script>
+    <title>Catalyst Voices</title>
+    <link rel="manifest" href="manifest.json">
+    <script type="module"
+            src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"></script>
 </head>
 
 <body>
-  <script src="flutter_bootstrap.js" async></script>
+<script src="flutter_bootstrap.js" async></script>
 </body>
 
 </html>

--- a/melos.yaml
+++ b/melos.yaml
@@ -88,8 +88,8 @@ command:
       equatable: ^2.0.5
       flutter_bloc: ^8.1.5
       flutter_localized_locales: ^2.0.5
-      flutter_quill: ^10.5.13
-      flutter_quill_extensions: ^10.5.13
+      flutter_quill: ^10.8.2
+      flutter_quill_extensions: ^10.8.2
       flutter_secure_storage: ^9.2.2
       formz: ^0.7.0
       intl: ^0.19.0


### PR DESCRIPTION
# Description

There was an issue with  flutter_inappwebview's web_support.js not found 

![Screenshot 2024-10-03 at 14 18 22 (1)](https://github.com/user-attachments/assets/4dc8b926-e6ac-4701-acee-991ec5be62b2)


## Description of Changes

Newer version of `flutter_quill_extensions` doesn't use `flutter_inappwebview` and we explicitly added reference to `web_support.js` to index.html before, so now it needed to be removed.
Also I upgraded here `flutter_quill_extensions ` explicitly and cleaned related files.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
