### PR TITLE
fix(cat-voices): align colors with designs

### DIFF
--- a/catalyst_voices/lib/widgets/indicators/voices_no_internet_connection_banner.dart
+++ b/catalyst_voices/lib/widgets/indicators/voices_no_internet_connection_banner.dart
@@ -35,12 +35,13 @@ class NoInternetConnectionBanner extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final shouldButtonDisplay = constraints.maxWidth > 744;
+        final foregroundColor = Theme.of(context).colorScheme.errorContainer;
 
         return Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           margin: const EdgeInsets.all(16),
           decoration: BoxDecoration(
-            color: Theme.of(context).colors.avatarsError,
+            color: Theme.of(context).colorScheme.error,
             borderRadius: BorderRadius.circular(8),
           ),
           child: Row(
@@ -56,20 +57,26 @@ class NoInternetConnectionBanner extends StatelessWidget {
                       children: [
                         CatalystSvgIcon.asset(
                           VoicesAssets.icons.wifi.path,
-                          color: Theme.of(context).colors.iconsForeground,
+                          color: foregroundColor,
                         ),
                         const SizedBox(width: 8),
                         Expanded(
                           child: Text(
                             context.l10n.noConnectionBannerTitle,
-                            style: Theme.of(context).textTheme.titleLarge,
+                            style: Theme.of(context)
+                                .textTheme
+                                .titleLarge
+                                ?.copyWith(color: foregroundColor),
                           ),
                         ),
                       ],
                     ),
                     Text(
                       context.l10n.noConnectionBannerDescription,
-                      style: Theme.of(context).textTheme.bodySmall,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: foregroundColor),
                       softWrap: true,
                     ),
                   ],
@@ -81,7 +88,9 @@ class NoInternetConnectionBanner extends StatelessWidget {
                   onTap: onRefresh,
                   child: Text(
                     context.l10n.noConnectionBannerRefreshButtonText,
-                    style: Theme.of(context).textTheme.labelLarge,
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          color: Theme.of(context).colors.onErrorVariant,
+                        ),
                   ),
                 ),
               ],

--- a/catalyst_voices/lib/widgets/indicators/voices_status_indicator.dart
+++ b/catalyst_voices/lib/widgets/indicators/voices_status_indicator.dart
@@ -79,6 +79,11 @@ class _StatusContainer extends StatelessWidget {
     final theme = Theme.of(context);
 
     final backgroundColor = switch (type) {
+      VoicesStatusIndicatorType.success => theme.colors.success,
+      VoicesStatusIndicatorType.error => theme.colorScheme.error,
+    };
+
+    final foregroundColor = switch (type) {
       VoicesStatusIndicatorType.success => theme.colors.successContainer,
       VoicesStatusIndicatorType.error => theme.colors.errorContainer,
     };
@@ -92,11 +97,11 @@ class _StatusContainer extends StatelessWidget {
       alignment: Alignment.center,
       child: DefaultTextStyle(
         style: (theme.textTheme.titleLarge ?? const TextStyle())
-            .copyWith(color: theme.colors.textPrimary),
+            .copyWith(color: foregroundColor),
         child: IconTheme(
           data: IconThemeData(
             size: 24,
-            color: theme.colors.textPrimary,
+            color: foregroundColor,
           ),
           child: child,
         ),

--- a/catalyst_voices/packages/catalyst_voices_assets/assets/colors/colors.xml
+++ b/catalyst_voices/packages/catalyst_voices_assets/assets/colors/colors.xml
@@ -20,6 +20,7 @@
     <color name="light_outline_variant">#61BFC8D9</color>
     <color name="light_error">#CC0000</color>
     <color name="light_on_error">#FFFFFF</color>
+    <color name="light_on_error_variant">#FFFFFF</color>
     <color name="light_error_container">#FFD1D1</color>
     <color name="light_on_error_container">#700000</color>
     <color name="light_success">#218230</color>
@@ -87,6 +88,7 @@
     <color name="dark_outline_variant">#364463</color>
     <color name="dark_error">#FF9999</color>
     <color name="dark_on_error">#380000</color>
+    <color name="dark_on_error_variant">#FFFFFF</color>
     <color name="dark_error_container">#AD0000</color>
     <color name="dark_on_error_container">#FFD1D1</color>
     <color name="dark_success">#BAEDC2</color>

--- a/catalyst_voices/packages/catalyst_voices_assets/lib/generated/colors.gen.dart
+++ b/catalyst_voices/packages/catalyst_voices_assets/lib/generated/colors.gen.dart
@@ -82,6 +82,9 @@ class VoicesColors {
   /// Color: #FFD1D1
   static const Color darkOnErrorContainer = Color(0xFFFFD1D1);
 
+  /// Color: #FFFFFF
+  static const Color darkOnErrorVariant = Color(0xFFFFFFFF);
+
   /// Color: #0C288D
   static const Color darkOnPrimary = Color(0xFF0C288D);
 
@@ -283,6 +286,9 @@ class VoicesColors {
 
   /// Color: #700000
   static const Color lightOnErrorContainer = Color(0xFF700000);
+
+  /// Color: #FFFFFF
+  static const Color lightOnErrorVariant = Color(0xFFFFFFFF);
 
   /// Color: #FFFFFF
   static const Color lightOnPrimary = Color(0xFFFFFFFF);

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/theme_extensions/voices_color_scheme.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/theme_extensions/voices_color_scheme.dart
@@ -62,6 +62,7 @@ class VoicesColorScheme extends ThemeExtension<VoicesColorScheme> {
   final Color? primary98;
   final Color? primaryContainer;
   final Color? onPrimaryContainer;
+  final Color? onErrorVariant;
   final Color? errorContainer;
   final Color? onErrorContainer;
 
@@ -121,6 +122,7 @@ class VoicesColorScheme extends ThemeExtension<VoicesColorScheme> {
     required this.primary98,
     required this.primaryContainer,
     required this.onPrimaryContainer,
+    required this.onErrorVariant,
     required this.errorContainer,
     required this.onErrorContainer,
   });
@@ -182,6 +184,7 @@ class VoicesColorScheme extends ThemeExtension<VoicesColorScheme> {
     this.primary98,
     this.primaryContainer,
     this.onPrimaryContainer,
+    this.onErrorVariant,
     this.errorContainer,
     this.onErrorContainer,
   });
@@ -243,6 +246,7 @@ class VoicesColorScheme extends ThemeExtension<VoicesColorScheme> {
     Color? primary98,
     Color? primaryContainer,
     Color? onPrimaryContainer,
+    Color? onErrorVariant,
     Color? errorContainer,
     Color? onErrorContainer,
   }) {
@@ -314,6 +318,7 @@ class VoicesColorScheme extends ThemeExtension<VoicesColorScheme> {
       primary98: primary98 ?? this.primary98,
       primaryContainer: primaryContainer ?? this.primaryContainer,
       onPrimaryContainer: onPrimaryContainer ?? this.onPrimaryContainer,
+      onErrorVariant: onErrorVariant ?? this.onErrorVariant,
       errorContainer: errorContainer ?? this.errorContainer,
       onErrorContainer: onErrorContainer ?? this.onErrorContainer,
     );
@@ -447,6 +452,7 @@ class VoicesColorScheme extends ThemeExtension<VoicesColorScheme> {
       primaryContainer: Color.lerp(primaryContainer, other.primaryContainer, t),
       onPrimaryContainer:
           Color.lerp(onPrimaryContainer, other.onPrimaryContainer, t),
+      onErrorVariant: Color.lerp(onErrorVariant, other.onErrorVariant, t),
       errorContainer: Color.lerp(errorContainer, other.errorContainer, t),
       onErrorContainer: Color.lerp(onErrorContainer, other.onErrorContainer, t),
     );

--- a/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
+++ b/catalyst_voices/packages/catalyst_voices_brands/lib/src/themes/catalyst.dart
@@ -81,6 +81,7 @@ const VoicesColorScheme darkVoicesColorScheme = VoicesColorScheme(
   primary98: VoicesColors.darkPrimary98,
   primaryContainer: VoicesColors.darkPrimaryContainer,
   onPrimaryContainer: VoicesColors.darkOnPrimaryContainer,
+  onErrorVariant: VoicesColors.darkOnErrorVariant,
   errorContainer: VoicesColors.darkErrorContainer,
   onErrorContainer: VoicesColors.darkOnErrorContainer,
 );
@@ -162,6 +163,7 @@ const VoicesColorScheme lightVoicesColorScheme = VoicesColorScheme(
   primary98: VoicesColors.lightPrimary98,
   primaryContainer: VoicesColors.lightPrimaryContainer,
   onPrimaryContainer: VoicesColors.lightOnPrimaryContainer,
+  onErrorVariant: VoicesColors.lightOnErrorVariant,
   errorContainer: VoicesColors.lightErrorContainer,
   onErrorContainer: VoicesColors.lightOnErrorContainer,
 );


### PR DESCRIPTION
# Description

Aligns colors with designs.

## Related Issue(s)

Closes #938

## Screenshots

Light theme:
![Screenshot 2024-10-03 at 16 53 10](https://github.com/user-attachments/assets/eaf21bd1-9e41-4403-8a8b-47e41df29309)
![Screenshot 2024-10-03 at 16 53 13](https://github.com/user-attachments/assets/44e92eaf-4077-4b98-938b-eb311056ed4d)

Dark theme:
![Screenshot 2024-10-03 at 16 53 17](https://github.com/user-attachments/assets/9fff5a89-1be5-4562-a2de-6b807acf121e)
![Screenshot 2024-10-03 at 16 53 20](https://github.com/user-attachments/assets/646ac479-4d98-41af-b07e-06fc5cef8ffd)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
