### PR TITLE
fix(cat-voices): use dart test in models package

### DIFF
--- a/catalyst_voices/packages/catalyst_voices_models/pubspec.yaml
+++ b/catalyst_voices/packages/catalyst_voices_models/pubspec.yaml
@@ -20,5 +20,4 @@ dependencies:
 
 dev_dependencies:
   catalyst_analysis: ^2.0.0
-  flutter_test:
-    sdk: flutter
+  test: ^1.24.9

--- a/catalyst_voices/packages/catalyst_voices_models/test/auth/password_strength_test.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/test/auth/password_strength_test.dart
@@ -1,5 +1,5 @@
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group(PasswordStrength, () {

--- a/catalyst_voices/packages/catalyst_voices_models/test/optional_test.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/test/optional_test.dart
@@ -1,5 +1,5 @@
 import 'package:catalyst_voices_models/src/optional.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group(Optional, () {

--- a/catalyst_voices/packages/catalyst_voices_models/test/seed_phrase_test.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/test/seed_phrase_test.dart
@@ -1,7 +1,7 @@
 import 'package:bip39/bip39.dart' as bip39;
 import 'package:catalyst_voices_models/src/seed_phrase.dart';
 import 'package:collection/collection.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group(SeedPhrase, () {


### PR DESCRIPTION
# Description

Use `test` package in `catalyst_voices_models` package as it does not depend on flutter.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
