### PR TITLE
Set cat-gateway as the container entrypoint

### DIFF
--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -93,7 +93,7 @@ package:
     # COPY ./scripts/entry.sh .
 
     # ENTRYPOINT ./entry.sh
-    ENTRYPOINT ./cat-gateway
+    ENTRYPOINT [ "./cat-gateway", "run" ]
 
 # Publish cat-gateway
 publish:

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -90,9 +90,10 @@ package:
     # RUN apk add gcc bash
 
     COPY +build/cat-gateway .
-    COPY ./scripts/entry.sh .
+    # COPY ./scripts/entry.sh .
 
-    ENTRYPOINT ./entry.sh
+    # ENTRYPOINT ./entry.sh
+    ENTRYPOINT ./cat-gateway
 
 # Publish cat-gateway
 publish:

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -84,15 +84,8 @@ all-hosts-build:
 # package-cat-gateway : Create a deployable container for catalyst-gateway
 package:
     FROM debian:12.7-slim
-
     WORKDIR /cat-gateway
-
-    # RUN apk add gcc bash
-
     COPY +build/cat-gateway .
-    # COPY ./scripts/entry.sh .
-
-    # ENTRYPOINT ./entry.sh
     ENTRYPOINT [ "./cat-gateway", "run" ]
 
 # Publish cat-gateway


### PR DESCRIPTION
# Description

Set the container entrypoint to cat-gateway binary.

## Related Issue(s)

#50 


## Description of Changes

Remove entry.sh from the container and set the entrypoint as the cat-gateway binary.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
