### PR TITLE
feat(cat-voices): recover wallet 954

### DIFF
--- a/catalyst_voices/lib/pages/registration/recover/recover_seed_phrase_panel.dart
+++ b/catalyst_voices/lib/pages/registration/recover/recover_seed_phrase_panel.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/pages/registration/recover/seed_phrase/account_details_panel.dart';
 import 'package:catalyst_voices/pages/registration/recover/seed_phrase/seed_phrase_input_panel.dart';
 import 'package:catalyst_voices/pages/registration/recover/seed_phrase/seed_phrase_instructions_panel.dart';
 import 'package:catalyst_voices/pages/registration/widgets/placeholder_panel.dart';
@@ -18,7 +19,7 @@ class RecoverSeedPhrasePanel extends StatelessWidget {
       RecoverSeedPhraseStage.seedPhraseInstructions =>
         const SeedPhraseInstructionsPanel(),
       RecoverSeedPhraseStage.seedPhrase => const SeedPhraseInputPanel(),
-      RecoverSeedPhraseStage.linkedWallet => const PlaceholderPanel(),
+      RecoverSeedPhraseStage.accountDetails => const AccountDetailsPanel(),
       RecoverSeedPhraseStage.unlockPasswordInstructions =>
         const PlaceholderPanel(),
       RecoverSeedPhraseStage.unlockPassword => const PlaceholderPanel(),

--- a/catalyst_voices/lib/pages/registration/recover/seed_phrase/account_details_panel.dart
+++ b/catalyst_voices/lib/pages/registration/recover/seed_phrase/account_details_panel.dart
@@ -1,0 +1,32 @@
+import 'package:catalyst_voices/widgets/buttons/voices_filled_button.dart';
+import 'package:catalyst_voices/widgets/buttons/voices_text_button.dart';
+import 'package:flutter/material.dart';
+
+class AccountDetailsPanel extends StatelessWidget {
+  const AccountDetailsPanel({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(height: 24),
+        Text('Catalyst account recovery'),
+        SizedBox(height: 24),
+        SizedBox(height: 24),
+        Spacer(),
+        SizedBox(height: 24),
+        VoicesFilledButton(
+          onTap: () {},
+          child: Text('Set unlock password for this device'),
+        ),
+        SizedBox(height: 10),
+        VoicesTextButton(
+          onTap: () {},
+          child: Text('Back'),
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/recover/seed_phrase/account_details_panel.dart
+++ b/catalyst_voices/lib/pages/registration/recover/seed_phrase/account_details_panel.dart
@@ -61,20 +61,18 @@ class _BlocAccountSummery extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocRecoverBuilder<Result<AccountSummaryData, Exception>?>(
+    return BlocRecoverBuilder<Result<AccountSummaryData, LocalizedException>?>(
       selector: (state) => state.accountDetails,
       builder: (context, state) {
-        print('state: $state');
         return switch (state) {
-          Success<AccountSummaryData, Exception>(:final value) =>
+          Success<AccountSummaryData, LocalizedException>(:final value) =>
             _RecoveredAccountSummary(
               walletConnection: value.walletConnection,
               walletSummary: value.walletSummary,
             ),
-          Failure<AccountSummaryData, Exception>(:final value) =>
-            VoicesErrorIndicator(
-              // TODO(damian): localized message
-              message: value.toString(),
+          Failure<AccountSummaryData, LocalizedException>(:final value) =>
+            _RecoverAccountFailure(
+              exception: value,
               onRetry: onRetry,
             ),
           _ => const Center(child: VoicesCircularProgressIndicator()),
@@ -97,12 +95,15 @@ class _RecoveredAccountSummary extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         WalletConnectionStatus(
           icon: walletConnection.icon,
           name: walletConnection.name,
           isConnected: walletConnection.isConnected,
         ),
+        const SizedBox(height: 8),
+        const _RecoverStatusText(),
         const SizedBox(height: 24),
         WalletSummary(
           balance: walletSummary.balance,
@@ -110,6 +111,45 @@ class _RecoveredAccountSummary extends StatelessWidget {
           clipboardAddress: walletSummary.clipboardAddress,
         ),
       ],
+    );
+  }
+}
+
+class _RecoverAccountFailure extends StatelessWidget {
+  final LocalizedException exception;
+  final VoidCallback? onRetry;
+
+  const _RecoverAccountFailure({
+    required this.exception,
+    this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        VoicesErrorIndicator(
+          message: exception.message(context),
+          onRetry: onRetry,
+        ),
+      ],
+    );
+  }
+}
+
+class _RecoverStatusText extends StatelessWidget {
+  const _RecoverStatusText();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textColor = theme.colors.textOnPrimaryLevel1;
+
+    return Text(
+      context.l10n.recoveryAccountSuccessTitle,
+      style: theme.textTheme.titleMedium?.copyWith(color: textColor),
     );
   }
 }

--- a/catalyst_voices/lib/pages/registration/recover/seed_phrase/account_details_panel.dart
+++ b/catalyst_voices/lib/pages/registration/recover/seed_phrase/account_details_panel.dart
@@ -1,5 +1,9 @@
+import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
+import 'package:catalyst_voices/pages/registration/widgets/wallet_connection_status.dart';
+import 'package:catalyst_voices/pages/registration/widgets/wallet_summary.dart';
 import 'package:catalyst_voices/widgets/buttons/voices_filled_button.dart';
 import 'package:catalyst_voices/widgets/buttons/voices_text_button.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 
 class AccountDetailsPanel extends StatelessWidget {
@@ -10,21 +14,71 @@ class AccountDetailsPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        SizedBox(height: 24),
-        Text('Catalyst account recovery'),
-        SizedBox(height: 24),
-        SizedBox(height: 24),
-        Spacer(),
-        SizedBox(height: 24),
+        const SizedBox(height: 24),
+        Text(context.l10n.recoveryAccountTitle),
+        const SizedBox(height: 24),
+        const Expanded(
+          child: SingleChildScrollView(
+            child: _BlocAccountSummery(),
+          ),
+        ),
+        const SizedBox(height: 24),
         VoicesFilledButton(
           onTap: () {},
-          child: Text('Set unlock password for this device'),
+          child: Text(context.l10n.recoveryAccountDetailsAction),
         ),
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
         VoicesTextButton(
           onTap: () {},
-          child: Text('Back'),
+          child: Text(context.l10n.back),
+        ),
+      ],
+    );
+  }
+}
+
+class _BlocAccountSummery extends StatelessWidget {
+  const _BlocAccountSummery();
+
+  @override
+  Widget build(BuildContext context) {
+    return _RecoveredAccountSummary(
+      walletIcon: null,
+      walletName: 'Testing',
+      balance: const Coin(10),
+      address: ShelleyAddress(const [0]),
+    );
+  }
+}
+
+class _RecoveredAccountSummary extends StatelessWidget {
+  final String? walletIcon;
+  final String walletName;
+  final Coin balance;
+  final ShelleyAddress address;
+
+  const _RecoveredAccountSummary({
+    this.walletIcon,
+    required this.walletName,
+    required this.balance,
+    required this.address,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const WalletConnectionStatus(
+          icon: null,
+          name: 'Testing',
+        ),
+        const SizedBox(height: 24),
+        WalletSummary(
+          balance: const Coin(10),
+          address: ShelleyAddress([0]),
         ),
       ],
     );

--- a/catalyst_voices/lib/pages/registration/recover/seed_phrase/seed_phrase_input_panel.dart
+++ b/catalyst_voices/lib/pages/registration/recover/seed_phrase/seed_phrase_input_panel.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:catalyst_voices/pages/registration/recover/bloc_recover_builder.dart';
 import 'package:catalyst_voices/pages/registration/widgets/registration_stage_message.dart';
 import 'package:catalyst_voices/pages/registration/widgets/registration_stage_navigation.dart';
@@ -59,9 +61,20 @@ class _SeedPhraseInputPanelState extends State<SeedPhraseInputPanel> {
           onResetTap: _resetControllerWords,
         ),
         const SizedBox(height: 12),
-        const _BlocNavigation(),
+        _BlocNavigation(
+          onNextTap: _recoverAccountAndGoNextStage,
+        ),
       ],
     );
+  }
+
+  void _recoverAccountAndGoNextStage() {
+    final registration = RegistrationCubit.of(context);
+
+    // Note. success or failure will be shown in next stage
+    unawaited(registration.recover.recoverAccount());
+
+    registration.nextStep();
   }
 
   Future<void> _uploadSeedPhrase() async {
@@ -105,7 +118,11 @@ class _BlocSeedPhraseField extends StatelessWidget {
 }
 
 class _BlocNavigation extends StatelessWidget {
-  const _BlocNavigation();
+  final VoidCallback onNextTap;
+
+  const _BlocNavigation({
+    required this.onNextTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -113,6 +130,7 @@ class _BlocNavigation extends StatelessWidget {
       selector: (state) => state.isSeedPhraseValid,
       builder: (context, state) {
         return RegistrationBackNextNavigation(
+          onNextTap: onNextTap,
           isNextEnabled: state,
         );
       },

--- a/catalyst_voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/lib/pages/registration/registration_info_panel.dart
@@ -178,7 +178,7 @@ class _RegistrationPicture extends StatelessWidget {
       return switch (stage) {
         RecoverSeedPhraseStage.seedPhraseInstructions ||
         RecoverSeedPhraseStage.seedPhrase ||
-        RecoverSeedPhraseStage.linkedWallet =>
+        RecoverSeedPhraseStage.accountDetails =>
           const KeychainPicture(),
         RecoverSeedPhraseStage.unlockPasswordInstructions ||
         RecoverSeedPhraseStage.unlockPassword =>

--- a/catalyst_voices/lib/pages/registration/wallet_link/stage/wallet_details_panel.dart
+++ b/catalyst_voices/lib/pages/registration/wallet_link/stage/wallet_details_panel.dart
@@ -1,14 +1,13 @@
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices/pages/registration/wallet_link/bloc_wallet_link_builder.dart';
 import 'package:catalyst_voices/pages/registration/widgets/registration_stage_navigation.dart';
+import 'package:catalyst_voices/pages/registration/widgets/wallet_connection_status.dart';
+import 'package:catalyst_voices/pages/registration/widgets/wallet_summary.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
-import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 class WalletDetailsPanel extends StatelessWidget {
   const WalletDetailsPanel({
@@ -26,7 +25,7 @@ class WalletDetailsPanel extends StatelessWidget {
           style: Theme.of(context).textTheme.titleMedium,
         ),
         const SizedBox(height: 32),
-        const _BlocWalletExtension(),
+        const _BlocWalletConnectionStatus(),
         const SizedBox(height: 16),
         const _BlocWalletDetailsText(),
         const SizedBox(height: 24),
@@ -38,8 +37,8 @@ class WalletDetailsPanel extends StatelessWidget {
   }
 }
 
-class _BlocWalletExtension extends StatelessWidget {
-  const _BlocWalletExtension();
+class _BlocWalletConnectionStatus extends StatelessWidget {
+  const _BlocWalletConnectionStatus();
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +49,7 @@ class _BlocWalletExtension extends StatelessWidget {
       },
       builder: (context, state) {
         if (state != null) {
-          return _WalletExtension(
+          return WalletConnectionStatus(
             icon: state.icon,
             name: state.name,
           );
@@ -58,36 +57,6 @@ class _BlocWalletExtension extends StatelessWidget {
           return const Offstage();
         }
       },
-    );
-  }
-}
-
-class _WalletExtension extends StatelessWidget {
-  final String icon;
-  final String name;
-
-  const _WalletExtension({
-    required this.icon,
-    required this.name,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        const SizedBox(width: 8),
-        VoicesWalletTileIcon(iconSrc: icon),
-        const SizedBox(width: 12),
-        Text(name, style: Theme.of(context).textTheme.bodyLarge),
-        const SizedBox(width: 8),
-        VoicesAvatar(
-          radius: 10,
-          padding: const EdgeInsets.all(4),
-          icon: VoicesAssets.icons.check.buildIcon(),
-          foregroundColor: Theme.of(context).colors.success,
-          backgroundColor: Theme.of(context).colors.successContainer,
-        ),
-      ],
     );
   }
 }
@@ -132,186 +101,15 @@ class _BlocWalletSummary extends StatelessWidget {
       },
       builder: (context, state) {
         if (state != null) {
-          return _WalletSummary(
+          return WalletSummary(
             balance: state.balance,
             address: state.address,
-            hasEnoughBalance: state.hasEnoughBalance,
+            showLowBalance: !state.hasEnoughBalance,
           );
         } else {
           return const Offstage();
         }
       },
-    );
-  }
-}
-
-class _WalletSummary extends StatelessWidget {
-  final Coin balance;
-  final ShelleyAddress address;
-  final bool hasEnoughBalance;
-
-  const _WalletSummary({
-    required this.balance,
-    required this.address,
-    required this.hasEnoughBalance,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          width: 1.5,
-          color: Theme.of(context).colors.outlineBorderVariant!,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            context.l10n.walletDetectionSummary,
-            style: Theme.of(context).textTheme.titleSmall,
-          ),
-          const SizedBox(height: 12),
-          _WalletSummaryBalance(
-            balance: balance,
-            hasEnoughBalance: hasEnoughBalance,
-          ),
-          const SizedBox(height: 12),
-          _WalletSummaryAddress(address: address),
-          if (!hasEnoughBalance) ...[
-            const SizedBox(height: 12),
-            Text(
-              context.l10n.notice,
-              style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                    fontWeight: FontWeight.w800,
-                  ),
-            ),
-            const SizedBox(height: 6),
-            Text(
-              context.l10n.walletLinkWalletDetailsNotice,
-              style: Theme.of(context).textTheme.labelSmall,
-            ),
-            const SizedBox(height: 6),
-            Text(
-              context.l10n.walletLinkWalletDetailsNoticeTopUp,
-              style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                    fontWeight: FontWeight.w800,
-                  ),
-            ),
-            const SizedBox(height: 6),
-            BulletList(
-              items: [
-                context.l10n.walletLinkWalletDetailsNoticeTopUpLink,
-              ],
-              style: Theme.of(context).textTheme.labelSmall,
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _WalletSummaryBalance extends StatelessWidget {
-  final Coin balance;
-  final bool hasEnoughBalance;
-
-  const _WalletSummaryBalance({
-    required this.balance,
-    required this.hasEnoughBalance,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return _WalletSummaryItem(
-      label: Text(context.l10n.walletBalance),
-      value: Row(
-        children: [
-          Text(
-            CryptocurrencyFormatter.formatAmount(balance),
-            style: hasEnoughBalance
-                ? null
-                : TextStyle(color: Theme.of(context).colors.iconsError),
-          ),
-          if (!hasEnoughBalance) ...[
-            const SizedBox(width: 4),
-            Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: VoicesAssets.icons.exclamation.buildIcon(
-                color: Theme.of(context).colors.iconsError,
-                size: 16,
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _WalletSummaryAddress extends StatelessWidget {
-  final ShelleyAddress address;
-
-  const _WalletSummaryAddress({
-    required this.address,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return _WalletSummaryItem(
-      label: Text(context.l10n.walletAddress),
-      value: Row(
-        children: [
-          Text(WalletAddressFormatter.formatShort(address)),
-          const SizedBox(width: 4),
-          InkWell(
-            onTap: () async {
-              await Clipboard.setData(
-                ClipboardData(text: address.toBech32()),
-              );
-            },
-            child: Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: VoicesAssets.icons.clipboardCopy.buildIcon(size: 16),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _WalletSummaryItem extends StatelessWidget {
-  final Widget label;
-  final Widget value;
-
-  const _WalletSummaryItem({
-    required this.label,
-    required this.value,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: DefaultTextStyle(
-            style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                  fontWeight: FontWeight.w800,
-                ),
-            child: label,
-          ),
-        ),
-        Expanded(
-          child: DefaultTextStyle(
-            style: Theme.of(context).textTheme.labelMedium!,
-            child: value,
-          ),
-        ),
-      ],
     );
   }
 }

--- a/catalyst_voices/lib/pages/registration/wallet_link/stage/wallet_details_panel.dart
+++ b/catalyst_voices/lib/pages/registration/wallet_link/stage/wallet_details_panel.dart
@@ -1,4 +1,3 @@
-import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices/pages/registration/wallet_link/bloc_wallet_link_builder.dart';
 import 'package:catalyst_voices/pages/registration/widgets/registration_stage_navigation.dart';
 import 'package:catalyst_voices/pages/registration/widgets/wallet_connection_status.dart';
@@ -7,6 +6,7 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
 
 class WalletDetailsPanel extends StatelessWidget {
@@ -42,20 +42,14 @@ class _BlocWalletConnectionStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocWalletLinkBuilder<({String icon, String name})?>(
-      selector: (state) {
-        final wallet = state.selectedWallet?.wallet;
-        return wallet != null ? (icon: wallet.icon, name: wallet.name) : null;
-      },
+    return BlocWalletLinkBuilder<WalletConnectionData?>(
+      selector: (state) => state.walletConnection,
       builder: (context, state) {
-        if (state != null) {
-          return WalletConnectionStatus(
-            icon: state.icon,
-            name: state.name,
-          );
-        } else {
-          return const Offstage();
-        }
+        return WalletConnectionStatus(
+          icon: state?.icon,
+          name: state?.name ?? '',
+          isConnected: state?.isConnected ?? false,
+        );
       },
     );
   }
@@ -83,28 +77,15 @@ class _BlocWalletSummary extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocWalletLinkBuilder<
-        ({
-          Coin balance,
-          ShelleyAddress address,
-          bool hasEnoughBalance,
-        })?>(
-      selector: (state) {
-        final walletDetails = state.selectedWallet;
-        return walletDetails != null
-            ? (
-                balance: walletDetails.balance,
-                address: walletDetails.address,
-                hasEnoughBalance: walletDetails.hasEnoughBalance,
-              )
-            : null;
-      },
+    return BlocWalletLinkBuilder<WalletSummaryData?>(
+      selector: (state) => state.walletSummary,
       builder: (context, state) {
         if (state != null) {
           return WalletSummary(
             balance: state.balance,
             address: state.address,
-            showLowBalance: !state.hasEnoughBalance,
+            clipboardAddress: state.clipboardAddress,
+            showLowBalance: state.showLowBalance,
           );
         } else {
           return const Offstage();

--- a/catalyst_voices/lib/pages/registration/widgets/wallet_connection_status.dart
+++ b/catalyst_voices/lib/pages/registration/widgets/wallet_connection_status.dart
@@ -6,11 +6,13 @@ import 'package:flutter/material.dart';
 class WalletConnectionStatus extends StatelessWidget {
   final String? icon;
   final String name;
+  final bool isConnected;
 
   const WalletConnectionStatus({
     super.key,
     required this.icon,
     required this.name,
+    required this.isConnected,
   });
 
   @override
@@ -21,14 +23,16 @@ class WalletConnectionStatus extends StatelessWidget {
         VoicesWalletTileIcon(iconSrc: icon),
         const SizedBox(width: 12),
         Text(name, style: Theme.of(context).textTheme.bodyLarge),
-        const SizedBox(width: 8),
-        VoicesAvatar(
-          radius: 10,
-          padding: const EdgeInsets.all(4),
-          icon: VoicesAssets.icons.check.buildIcon(),
-          foregroundColor: Theme.of(context).colors.success,
-          backgroundColor: Theme.of(context).colors.successContainer,
-        ),
+        if (isConnected) ...[
+          const SizedBox(width: 8),
+          VoicesAvatar(
+            radius: 10,
+            padding: const EdgeInsets.all(4),
+            icon: VoicesAssets.icons.check.buildIcon(),
+            foregroundColor: Theme.of(context).colors.success,
+            backgroundColor: Theme.of(context).colors.successContainer,
+          ),
+        ],
       ],
     );
   }

--- a/catalyst_voices/lib/pages/registration/widgets/wallet_connection_status.dart
+++ b/catalyst_voices/lib/pages/registration/widgets/wallet_connection_status.dart
@@ -1,0 +1,35 @@
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:flutter/material.dart';
+
+class WalletConnectionStatus extends StatelessWidget {
+  final String icon;
+  final String name;
+
+  const WalletConnectionStatus({
+    super.key,
+    required this.icon,
+    required this.name,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const SizedBox(width: 8),
+        VoicesWalletTileIcon(iconSrc: icon),
+        const SizedBox(width: 12),
+        Text(name, style: Theme.of(context).textTheme.bodyLarge),
+        const SizedBox(width: 8),
+        VoicesAvatar(
+          radius: 10,
+          padding: const EdgeInsets.all(4),
+          icon: VoicesAssets.icons.check.buildIcon(),
+          foregroundColor: Theme.of(context).colors.success,
+          backgroundColor: Theme.of(context).colors.successContainer,
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/pages/registration/widgets/wallet_connection_status.dart
+++ b/catalyst_voices/lib/pages/registration/widgets/wallet_connection_status.dart
@@ -4,7 +4,7 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 
 class WalletConnectionStatus extends StatelessWidget {
-  final String icon;
+  final String? icon;
   final String name;
 
   const WalletConnectionStatus({

--- a/catalyst_voices/lib/pages/registration/widgets/wallet_summary.dart
+++ b/catalyst_voices/lib/pages/registration/widgets/wallet_summary.dart
@@ -16,7 +16,7 @@ class WalletSummary extends StatelessWidget {
     super.key,
     required this.balance,
     required this.address,
-    required this.showLowBalance,
+    this.showLowBalance = false,
   });
 
   @override

--- a/catalyst_voices/lib/pages/registration/widgets/wallet_summary.dart
+++ b/catalyst_voices/lib/pages/registration/widgets/wallet_summary.dart
@@ -1,21 +1,21 @@
-import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
-import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 class WalletSummary extends StatelessWidget {
-  final Coin balance;
-  final ShelleyAddress address;
+  final String balance;
+  final String address;
+  final String clipboardAddress;
   final bool showLowBalance;
 
   const WalletSummary({
     super.key,
     required this.balance,
     required this.address,
+    required this.clipboardAddress,
     this.showLowBalance = false,
   });
 
@@ -43,7 +43,10 @@ class WalletSummary extends StatelessWidget {
             showLowBalance: showLowBalance,
           ),
           const SizedBox(height: 12),
-          _WalletSummaryAddress(address: address),
+          _WalletSummaryAddress(
+            address: address,
+            clipboardAddress: clipboardAddress,
+          ),
           if (showLowBalance) ...[
             const SizedBox(height: 12),
             Text(
@@ -79,7 +82,7 @@ class WalletSummary extends StatelessWidget {
 }
 
 class _WalletSummaryBalance extends StatelessWidget {
-  final Coin balance;
+  final String balance;
   final bool showLowBalance;
 
   const _WalletSummaryBalance({
@@ -94,7 +97,7 @@ class _WalletSummaryBalance extends StatelessWidget {
       value: Row(
         children: [
           Text(
-            CryptocurrencyFormatter.formatAmount(balance),
+            balance,
             style: showLowBalance
                 ? TextStyle(color: Theme.of(context).colors.iconsError)
                 : null,
@@ -116,10 +119,12 @@ class _WalletSummaryBalance extends StatelessWidget {
 }
 
 class _WalletSummaryAddress extends StatelessWidget {
-  final ShelleyAddress address;
+  final String address;
+  final String clipboardAddress;
 
   const _WalletSummaryAddress({
     required this.address,
+    required this.clipboardAddress,
   });
 
   @override
@@ -128,12 +133,12 @@ class _WalletSummaryAddress extends StatelessWidget {
       label: Text(context.l10n.walletAddress),
       value: Row(
         children: [
-          Text(WalletAddressFormatter.formatShort(address)),
+          Text(address),
           const SizedBox(width: 4),
           InkWell(
             onTap: () async {
               await Clipboard.setData(
-                ClipboardData(text: address.toBech32()),
+                ClipboardData(text: clipboardAddress),
               );
             },
             child: Padding(

--- a/catalyst_voices/lib/pages/registration/widgets/wallet_summary.dart
+++ b/catalyst_voices/lib/pages/registration/widgets/wallet_summary.dart
@@ -1,0 +1,180 @@
+import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class WalletSummary extends StatelessWidget {
+  final Coin balance;
+  final ShelleyAddress address;
+  final bool showLowBalance;
+
+  const WalletSummary({
+    super.key,
+    required this.balance,
+    required this.address,
+    required this.showLowBalance,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          width: 1.5,
+          color: Theme.of(context).colors.outlineBorderVariant!,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.l10n.walletDetectionSummary,
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          const SizedBox(height: 12),
+          _WalletSummaryBalance(
+            balance: balance,
+            showLowBalance: showLowBalance,
+          ),
+          const SizedBox(height: 12),
+          _WalletSummaryAddress(address: address),
+          if (showLowBalance) ...[
+            const SizedBox(height: 12),
+            Text(
+              context.l10n.notice,
+              style: Theme.of(context).textTheme.labelSmall!.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              context.l10n.walletLinkWalletDetailsNotice,
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+            const SizedBox(height: 6),
+            Text(
+              context.l10n.walletLinkWalletDetailsNoticeTopUp,
+              style: Theme.of(context).textTheme.labelSmall!.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+            ),
+            const SizedBox(height: 6),
+            BulletList(
+              items: [
+                context.l10n.walletLinkWalletDetailsNoticeTopUpLink,
+              ],
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _WalletSummaryBalance extends StatelessWidget {
+  final Coin balance;
+  final bool showLowBalance;
+
+  const _WalletSummaryBalance({
+    required this.balance,
+    required this.showLowBalance,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _WalletSummaryItem(
+      label: Text(context.l10n.walletBalance),
+      value: Row(
+        children: [
+          Text(
+            CryptocurrencyFormatter.formatAmount(balance),
+            style: showLowBalance
+                ? TextStyle(color: Theme.of(context).colors.iconsError)
+                : null,
+          ),
+          if (showLowBalance) ...[
+            const SizedBox(width: 4),
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: VoicesAssets.icons.exclamation.buildIcon(
+                color: Theme.of(context).colors.iconsError,
+                size: 16,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _WalletSummaryAddress extends StatelessWidget {
+  final ShelleyAddress address;
+
+  const _WalletSummaryAddress({
+    required this.address,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _WalletSummaryItem(
+      label: Text(context.l10n.walletAddress),
+      value: Row(
+        children: [
+          Text(WalletAddressFormatter.formatShort(address)),
+          const SizedBox(width: 4),
+          InkWell(
+            onTap: () async {
+              await Clipboard.setData(
+                ClipboardData(text: address.toBech32()),
+              );
+            },
+            child: Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: VoicesAssets.icons.clipboardCopy.buildIcon(size: 16),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WalletSummaryItem extends StatelessWidget {
+  final Widget label;
+  final Widget value;
+
+  const _WalletSummaryItem({
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: DefaultTextStyle(
+            style: Theme.of(context).textTheme.labelMedium!.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+            child: label,
+          ),
+        ),
+        Expanded(
+          child: DefaultTextStyle(
+            style: Theme.of(context).textTheme.labelMedium!,
+            child: value,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/lib/widgets/text_field/seed_phrase_field.dart
+++ b/catalyst_voices/lib/widgets/text_field/seed_phrase_field.dart
@@ -39,6 +39,7 @@ class SeedPhraseField extends StatefulWidget {
 
 class _SeedPhraseFieldState extends State<SeedPhraseField> {
   final _textEditingController = TextEditingController();
+  final _scrollController = ScrollController();
 
   final _wordFieldKey = GlobalKey();
 
@@ -61,6 +62,7 @@ class _SeedPhraseFieldState extends State<SeedPhraseField> {
   @override
   void dispose() {
     _textEditingController.dispose();
+    _scrollController.dispose();
 
     _focusNode?.dispose();
     _focusNode = null;
@@ -90,8 +92,10 @@ class _SeedPhraseFieldState extends State<SeedPhraseField> {
         position: DecorationPosition.foreground,
         child: VoicesScrollbar(
           mainAxisMargin: 16,
+          controller: _scrollController,
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(20),
+            controller: _scrollController,
             child: ValueListenableBuilder(
               valueListenable: _effectiveController,
               builder: (context, value, _) {

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/recover_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/recover_cubit.dart
@@ -1,34 +1,101 @@
 // ignore_for_file: one_member_abstracts
 
+import 'dart:math';
+
+import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:result_type/result_type.dart';
 
 abstract interface class RecoverManager {
   Future<void> checkLocalKeychains();
 
   void setSeedPhraseWords(List<SeedPhraseWord> words);
+
+  Future<void> recoverAccount();
 }
 
 final class RecoverCubit extends Cubit<RecoverStateData>
     implements RecoverManager {
+  SeedPhrase? _seedPhrase;
+
   RecoverCubit() : super(const RecoverStateData()) {
     /// pre-populate all available words
     emit(state.copyWith(seedPhraseWords: SeedPhrase.wordList));
+
+    if (kDebugMode) {
+      setSeedPhraseWords(_testWords);
+    }
   }
 
   @override
   Future<void> checkLocalKeychains() async {
-    // TODO(damian-molinski): Not implemented
+    // TODO(damian-molinski): to be implemented
   }
 
   @override
   void setSeedPhraseWords(List<SeedPhraseWord> words) {
-    final newState = state.copyWith(
-      userSeedPhraseWords: words,
-      isSeedPhraseValid: SeedPhrase.isValid(words: words),
-    );
+    final isValid = SeedPhrase.isValid(words: words);
+    if (isValid) {
+      _seedPhrase = SeedPhrase.fromWords(words);
+    }
 
-    emit(newState);
+    emit(
+      state.copyWith(
+        userSeedPhraseWords: words,
+        isSeedPhraseValid: isValid,
+      ),
+    );
+  }
+
+  @override
+  Future<void> recoverAccount() async {
+    emit(state.copyWith(accountDetails: const Optional.empty()));
+
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+
+    final seedPhrase = _seedPhrase;
+    // TODO(damian-molinski): to be implemented
+    final isSuccess = seedPhrase != null && Random().nextBool();
+
+    final coin = Coin.fromAda(10);
+    final address = ShelleyAddress(const [0]);
+
+    final accountDetails = isSuccess
+        ? Success<AccountSummaryData, Exception>(
+            AccountSummaryData(
+              walletConnection: const WalletConnectionData(
+                name: 'Test Wallet',
+              ),
+              walletSummary: WalletSummaryData(
+                balance: CryptocurrencyFormatter.formatAmount(coin),
+                address: WalletAddressFormatter.formatShort(address),
+                clipboardAddress: address.toBech32(),
+                showLowBalance: false,
+              ),
+            ),
+          )
+        : Failure<AccountSummaryData, Exception>(Exception());
+
+    emit(state.copyWith(accountDetails: Optional(accountDetails)));
   }
 }
+
+const _testWords = [
+  SeedPhraseWord('broken', nr: 1),
+  SeedPhraseWord('member', nr: 2),
+  SeedPhraseWord('repeat', nr: 3),
+  SeedPhraseWord('liquid', nr: 4),
+  SeedPhraseWord('barely', nr: 5),
+  SeedPhraseWord('electric', nr: 6),
+  SeedPhraseWord('theory', nr: 7),
+  SeedPhraseWord('paddle', nr: 8),
+  SeedPhraseWord('coyote', nr: 9),
+  SeedPhraseWord('behind', nr: 10),
+  SeedPhraseWord('unique', nr: 11),
+  SeedPhraseWord('member', nr: 12),
+];

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
@@ -4,6 +4,7 @@ import 'package:catalyst_cardano/catalyst_cardano.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:result_type/result_type.dart';
 
@@ -51,11 +52,39 @@ final class WalletLinkCubit extends Cubit<WalletLinkStateData>
         address: address,
       );
 
-      emit(state.copyWith(selectedWallet: Optional(walletDetails)));
+      final walletConnection = WalletConnectionData(
+        name: wallet.name,
+        icon: wallet.icon,
+        isConnected: true,
+      );
+      final walletSummary = WalletSummaryData(
+        balance: CryptocurrencyFormatter.formatAmount(balance.coin),
+        address: WalletAddressFormatter.formatShort(address),
+        clipboardAddress: address.toBech32(),
+        showLowBalance:
+            balance.coin < CardanoWalletDetails.minAdaForRegistration,
+      );
+
+      final newState = state.copyWith(
+        selectedWallet: Optional(walletDetails),
+        walletConnection: Optional(walletConnection),
+        walletSummary: Optional(walletSummary),
+      );
+
+      emit(newState);
 
       return true;
     } catch (error, stackTrace) {
       _logger.severe('selectWallet', error, stackTrace);
+
+      emit(
+        state.copyWith(
+          selectedWallet: const Optional.empty(),
+          walletConnection: const Optional.empty(),
+          walletSummary: const Optional.empty(),
+        ),
+      );
+
       return false;
     }
   }

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -71,6 +71,9 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
   }
 
   void recoverWithSeedPhrase() {
+    _goToStep(
+        SeedPhraseRecoverStep(stage: RecoverSeedPhraseStage.accountDetails));
+    return;
     final nextStep = _nextStep(from: const SeedPhraseRecoverStep());
     if (nextStep != null) {
       _goToStep(nextStep);

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -71,9 +71,6 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
   }
 
   void recoverWithSeedPhrase() {
-    _goToStep(
-        SeedPhraseRecoverStep(stage: RecoverSeedPhraseStage.accountDetails));
-    return;
     final nextStep = _nextStep(from: const SeedPhraseRecoverStep());
     if (nextStep != null) {
       _goToStep(nextStep);

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -32,7 +32,9 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
         _walletLinkCubit = WalletLinkCubit(
           registrationService: registrationService,
         ),
-        _recoverCubit = RecoverCubit(),
+        _recoverCubit = RecoverCubit(
+          registrationService: registrationService,
+        ),
         super(const RegistrationState()) {
     _keychainCreationCubit.stream.listen(_onKeychainStateDataChanged);
     _walletLinkCubit.stream.listen(_onWalletLinkStateDataChanged);

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/state_data/recover_state_data.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/state_data/recover_state_data.dart
@@ -8,7 +8,7 @@ final class RecoverStateData extends Equatable {
   final List<SeedPhraseWord> userSeedPhraseWords;
   final List<String> seedPhraseWords;
   final bool isSeedPhraseValid;
-  final Result<AccountSummaryData, Exception>? accountDetails;
+  final Result<AccountSummaryData, LocalizedException>? accountDetails;
 
   bool get isAccountSummaryNextEnabled => accountDetails?.isSuccess ?? false;
 
@@ -25,7 +25,7 @@ final class RecoverStateData extends Equatable {
     List<SeedPhraseWord>? userSeedPhraseWords,
     List<String>? seedPhraseWords,
     bool? isSeedPhraseValid,
-    Optional<Result<AccountSummaryData, Exception>>? accountDetails,
+    Optional<Result<AccountSummaryData, LocalizedException>>? accountDetails,
   }) {
     return RecoverStateData(
       foundKeychain: foundKeychain ?? this.foundKeychain,

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/state_data/recover_state_data.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/state_data/recover_state_data.dart
@@ -1,17 +1,23 @@
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:equatable/equatable.dart';
+import 'package:result_type/result_type.dart';
 
 final class RecoverStateData extends Equatable {
   final bool foundKeychain;
   final List<SeedPhraseWord> userSeedPhraseWords;
   final List<String> seedPhraseWords;
   final bool isSeedPhraseValid;
+  final Result<AccountSummaryData, Exception>? accountDetails;
+
+  bool get isAccountSummaryNextEnabled => accountDetails?.isSuccess ?? false;
 
   const RecoverStateData({
     this.foundKeychain = false,
     this.userSeedPhraseWords = const [],
     this.seedPhraseWords = const [],
     this.isSeedPhraseValid = false,
+    this.accountDetails,
   });
 
   RecoverStateData copyWith({
@@ -19,19 +25,27 @@ final class RecoverStateData extends Equatable {
     List<SeedPhraseWord>? userSeedPhraseWords,
     List<String>? seedPhraseWords,
     bool? isSeedPhraseValid,
+    Optional<Result<AccountSummaryData, Exception>>? accountDetails,
   }) {
     return RecoverStateData(
       foundKeychain: foundKeychain ?? this.foundKeychain,
       userSeedPhraseWords: userSeedPhraseWords ?? this.userSeedPhraseWords,
       seedPhraseWords: seedPhraseWords ?? this.seedPhraseWords,
       isSeedPhraseValid: isSeedPhraseValid ?? this.isSeedPhraseValid,
+      accountDetails: accountDetails.dataOr(this.accountDetails),
     );
   }
 
   @override
   String toString() {
-    return 'RecoverStateData($foundKeychain, $userSeedPhraseWords, '
-        '${seedPhraseWords.length}, $isSeedPhraseValid,)';
+    return 'RecoverStateData('
+        '$foundKeychain, '
+        '$userSeedPhraseWords, '
+        // Note. do not print because this list is often very lage.
+        '${seedPhraseWords.length}, '
+        '$isSeedPhraseValid, '
+        '$accountDetails, '
+        ')';
   }
 
   @override
@@ -40,5 +54,22 @@ final class RecoverStateData extends Equatable {
         userSeedPhraseWords,
         seedPhraseWords,
         isSeedPhraseValid,
+        accountDetails,
+      ];
+}
+
+final class AccountSummaryData extends Equatable {
+  final WalletConnectionData walletConnection;
+  final WalletSummaryData walletSummary;
+
+  const AccountSummaryData({
+    required this.walletConnection,
+    required this.walletSummary,
+  });
+
+  @override
+  List<Object?> get props => [
+        walletConnection,
+        walletSummary,
       ];
 }

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/state_data/wallet_link_state_data.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/state_data/wallet_link_state_data.dart
@@ -1,17 +1,22 @@
 import 'package:catalyst_cardano/catalyst_cardano.dart';
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:equatable/equatable.dart';
 import 'package:result_type/result_type.dart';
 
 final class WalletLinkStateData extends Equatable {
   final Result<List<CardanoWallet>, Exception>? wallets;
   final CardanoWalletDetails? selectedWallet;
+  final WalletConnectionData? walletConnection;
+  final WalletSummaryData? walletSummary;
   final Set<AccountRole>? selectedRoles;
 
   const WalletLinkStateData({
     this.wallets,
     this.selectedWallet,
+    this.walletConnection,
+    this.walletSummary,
     this.selectedRoles,
   });
 
@@ -27,15 +32,25 @@ final class WalletLinkStateData extends Equatable {
   WalletLinkStateData copyWith({
     Optional<Result<List<CardanoWallet>, Exception>>? wallets,
     Optional<CardanoWalletDetails>? selectedWallet,
+    Optional<WalletConnectionData>? walletConnection,
+    Optional<WalletSummaryData>? walletSummary,
     Optional<Set<AccountRole>>? selectedRoles,
   }) {
     return WalletLinkStateData(
       wallets: wallets.dataOr(this.wallets),
       selectedWallet: selectedWallet.dataOr(this.selectedWallet),
+      walletConnection: walletConnection.dataOr(this.walletConnection),
+      walletSummary: walletSummary.dataOr(this.walletSummary),
       selectedRoles: selectedRoles.dataOr(this.selectedRoles),
     );
   }
 
   @override
-  List<Object?> get props => [wallets, selectedWallet, selectedRoles];
+  List<Object?> get props => [
+        wallets,
+        selectedWallet,
+        walletConnection,
+        walletSummary,
+        selectedRoles,
+      ];
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -832,6 +832,12 @@ abstract class VoicesLocalizations {
   /// **'Insufficient balance, please top up your wallet.'**
   String get registrationInsufficientBalance;
 
+  /// Error message shown when attempting to register or recover account but seed phrase was not found
+  ///
+  /// In en, this message translates to:
+  /// **'Seed phrase was not found. Make sure correct words are correct.'**
+  String get registrationSeedPhraseNotFound;
+
   /// A title on the role chooser screen in registration.
   ///
   /// In en, this message translates to:
@@ -1623,6 +1629,12 @@ abstract class VoicesLocalizations {
   /// In en, this message translates to:
   /// **'Catalyst account recovery'**
   String get recoveryAccountTitle;
+
+  /// No description provided for @recoveryAccountSuccessTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Keychain recovered successfully!'**
+  String get recoveryAccountSuccessTitle;
 
   /// No description provided for @recoveryAccountDetailsAction.
   ///

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -1605,6 +1605,18 @@ abstract class VoicesLocalizations {
   /// In en, this message translates to:
   /// **'Enter each word of your Catalyst Key in the right order  to bring your Catalyst account to this device.'**
   String get recoverySeedPhraseInputSubtitle;
+
+  /// No description provided for @recoveryAccountTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Catalyst account recovery'**
+  String get recoveryAccountTitle;
+
+  /// No description provided for @recoveryAccountDetailsAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Set unlock password for this device'**
+  String get recoveryAccountDetailsAction;
 }
 
 class _VoicesLocalizationsDelegate extends LocalizationsDelegate<VoicesLocalizations> {

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -437,6 +437,9 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
   String get registrationInsufficientBalance => 'Insufficient balance, please top up your wallet.';
 
   @override
+  String get registrationSeedPhraseNotFound => 'Seed phrase was not found. Make sure correct words are correct.';
+
+  @override
   String get walletLinkRoleChooserTitle => 'How do you want to participate in Catalyst?';
 
   @override
@@ -852,6 +855,9 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
 
   @override
   String get recoveryAccountTitle => 'Catalyst account recovery';
+
+  @override
+  String get recoveryAccountSuccessTitle => 'Keychain recovered successfully!';
 
   @override
   String get recoveryAccountDetailsAction => 'Set unlock password for this device';

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -843,4 +843,10 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
 
   @override
   String get recoverySeedPhraseInputSubtitle => 'Enter each word of your Catalyst Key in the right order  to bring your Catalyst account to this device.';
+
+  @override
+  String get recoveryAccountTitle => 'Catalyst account recovery';
+
+  @override
+  String get recoveryAccountDetailsAction => 'Set unlock password for this device';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -843,4 +843,10 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
 
   @override
   String get recoverySeedPhraseInputSubtitle => 'Enter each word of your Catalyst Key in the right order  to bring your Catalyst account to this device.';
+
+  @override
+  String get recoveryAccountTitle => 'Catalyst account recovery';
+
+  @override
+  String get recoveryAccountDetailsAction => 'Set unlock password for this device';
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -437,6 +437,9 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
   String get registrationInsufficientBalance => 'Insufficient balance, please top up your wallet.';
 
   @override
+  String get registrationSeedPhraseNotFound => 'Seed phrase was not found. Make sure correct words are correct.';
+
+  @override
   String get walletLinkRoleChooserTitle => 'How do you want to participate in Catalyst?';
 
   @override
@@ -852,6 +855,9 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
 
   @override
   String get recoveryAccountTitle => 'Catalyst account recovery';
+
+  @override
+  String get recoveryAccountSuccessTitle => 'Keychain recovered successfully!';
 
   @override
   String get recoveryAccountDetailsAction => 'Set unlock password for this device';

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -553,6 +553,10 @@
   "@registrationInsufficientBalance": {
     "description": "Indicates an error when preparing a transaction has failed due to low wallet balance."
   },
+  "registrationSeedPhraseNotFound": "Seed phrase was not found. Make sure correct words are correct.",
+  "@registrationSeedPhraseNotFound": {
+    "description": "Error message shown when attempting to register or recover account but seed phrase was not found"
+  },
   "walletLinkRoleChooserTitle": "How do you want to participate in Catalyst?",
   "@walletLinkRoleChooserTitle": {
     "description": "A title on the role chooser screen in registration."
@@ -870,5 +874,6 @@
   "recoverySeedPhraseInputTitle": "Restore your Catalyst Keychain with \u2028your 12 security words",
   "recoverySeedPhraseInputSubtitle": "Enter each word of your Catalyst Key in the right order \u2028to bring your Catalyst account to this device.",
   "recoveryAccountTitle": "Catalyst account recovery",
+  "recoveryAccountSuccessTitle": "Keychain recovered successfully!",
   "recoveryAccountDetailsAction": "Set unlock password for this device"
 }

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -860,5 +860,7 @@
   "recoverySeedPhraseInstructionsTitle": "Restore your Catalyst Keychain with \u2028your 12 security words.",
   "recoverySeedPhraseInstructionsSubtitle": "Enter your security words in the correct order, and sign into your Catalyst account on a new device.",
   "recoverySeedPhraseInputTitle": "Restore your Catalyst Keychain with \u2028your 12 security words",
-  "recoverySeedPhraseInputSubtitle": "Enter each word of your Catalyst Key in the right order \u2028to bring your Catalyst account to this device."
+  "recoverySeedPhraseInputSubtitle": "Enter each word of your Catalyst Key in the right order \u2028to bring your Catalyst account to this device.",
+  "recoveryAccountTitle": "Catalyst account recovery",
+  "recoveryAccountDetailsAction": "Set unlock password for this device"
 }

--- a/catalyst_voices/packages/catalyst_voices_models/lib/src/catalyst_voices_models.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/lib/src/catalyst_voices_models.dart
@@ -19,6 +19,7 @@ export 'treasury/treasury_campaign_segment.dart';
 export 'treasury/treasury_campaign_segment_step.dart';
 export 'user/user.dart';
 export 'wallet/cardano_wallet_details.dart';
+export 'wallet/dummy_cardano_wallet.dart';
 export 'workspace/workspace_proposal_navigation.dart';
 export 'workspace/workspace_proposal_segment.dart';
 export 'workspace/workspace_proposal_segment_step.dart';

--- a/catalyst_voices/packages/catalyst_voices_models/lib/src/registration/recover_seed_phrase_stage.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/lib/src/registration/recover_seed_phrase_stage.dart
@@ -6,8 +6,8 @@ enum RecoverSeedPhraseStage {
   /// Where user enters 12 words for seed phrase.
   seedPhrase,
 
-  /// Shows details about linked wallet to the account.
-  linkedWallet,
+  /// Shows details about restored account.
+  accountDetails,
 
   /// Explains why need unlock password and where it can be used. This
   /// device only.

--- a/catalyst_voices/packages/catalyst_voices_models/lib/src/wallet/dummy_cardano_wallet.dart
+++ b/catalyst_voices/packages/catalyst_voices_models/lib/src/wallet/dummy_cardano_wallet.dart
@@ -1,0 +1,27 @@
+import 'package:catalyst_cardano/catalyst_cardano.dart';
+
+final class DummyCardanoWallet implements CardanoWallet {
+  DummyCardanoWallet({
+    required this.name,
+    required this.icon,
+    this.apiVersion,
+    this.supportedExtensions = const [],
+  });
+
+  @override
+  final String name;
+  @override
+  final String icon;
+  @override
+  final String? apiVersion;
+  @override
+  final List<CipExtension> supportedExtensions;
+
+  @override
+  Future<bool> isEnabled() => Future(() => true);
+
+  @override
+  Future<CardanoWalletApi> enable({List<CipExtension>? extensions}) {
+    throw UnimplementedError();
+  }
+}

--- a/catalyst_voices/packages/catalyst_voices_services/lib/src/registration/registration_service.dart
+++ b/catalyst_voices/packages/catalyst_voices_services/lib/src/registration/registration_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:catalyst_cardano/catalyst_cardano.dart';
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
@@ -33,6 +35,33 @@ final class RegistrationService {
     return CardanoWalletDetails(
       wallet: wallet,
       balance: balance.coin,
+      address: address,
+    );
+  }
+
+  // TODO(damian-molinski): to be implemented
+  Future<CardanoWalletDetails> recoverCardanoWalletDetails(
+    SeedPhrase seedPhrase,
+  ) async {
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+
+    final isSuccess = Random().nextBool();
+    if (!isSuccess) {
+      throw const RegistrationUnknownException();
+    }
+
+    final wallet = DummyCardanoWallet(
+      name: 'Dummy Wallet',
+      icon: '',
+    );
+    final balance = Coin.fromAda(10);
+    final address = ShelleyAddress.fromBech32(
+      'addr_test1vzpwq95z3xyum8vqndgdd9mdnmafh3djcxnc6jemlgdmswcve6tkw',
+    );
+
+    return CardanoWalletDetails(
+      wallet: wallet,
+      balance: balance,
       address: address,
     );
   }

--- a/catalyst_voices/packages/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
+++ b/catalyst_voices/packages/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
@@ -1,1 +1,2 @@
 export 'authentication/authentication.dart';
+export 'registration/registration.dart';

--- a/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/exception/localized_registration_exception.dart
+++ b/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/exception/localized_registration_exception.dart
@@ -43,6 +43,16 @@ final class LocalizedRegistrationTransactionException
       context.l10n.registrationTransactionFailed;
 }
 
+/// An exception thrown when submitting a registration transaction fails.
+final class LocalizedRegistrationSeedPhraseNotFoundException
+    extends LocalizedRegistrationException {
+  const LocalizedRegistrationSeedPhraseNotFoundException();
+
+  @override
+  String message(BuildContext context) =>
+      context.l10n.registrationSeedPhraseNotFound;
+}
+
 /// A generic error for describing a failure during user registration.
 final class LocalizedRegistrationUnknownException
     extends LocalizedRegistrationException {

--- a/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/registration.dart
+++ b/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/registration.dart
@@ -1,0 +1,2 @@
+export 'wallet_connection.dart';
+export 'wallet_summary.dart';

--- a/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/wallet_connection.dart
+++ b/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/wallet_connection.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+final class WalletConnectionData extends Equatable {
+  final String name;
+  final String? icon;
+  final bool isConnected;
+
+  const WalletConnectionData({
+    required this.name,
+    this.icon,
+    this.isConnected = true,
+  });
+
+  @override
+  List<Object?> get props => [
+        name,
+        icon,
+        isConnected,
+      ];
+}

--- a/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/wallet_summary.dart
+++ b/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/wallet_summary.dart
@@ -1,0 +1,23 @@
+import 'package:equatable/equatable.dart';
+
+final class WalletSummaryData extends Equatable {
+  final String balance;
+  final String address;
+  final String clipboardAddress;
+  final bool showLowBalance;
+
+  const WalletSummaryData({
+    required this.balance,
+    required this.address,
+    required this.clipboardAddress,
+    required this.showLowBalance,
+  });
+
+  @override
+  List<Object?> get props => [
+        balance,
+        address,
+        clipboardAddress,
+        showLowBalance,
+      ];
+}


### PR DESCRIPTION
# Description

- Restored account `AccountDetailsPanel`. This is panel where user can see `Success` or `Failure` from restoration 
- Extract common `WalletConnectionStatus` and `WalletSummary` widgets from `WalletDetailsPanel`
- Fix `SeedPhraseField` scrollbar crash
- In `kDebugMode` words is pre-filed
- Introduce `DummyCardanoWallet` which implements `CardanoWallet`. This should be only used as temp replacement for real implementation.

## Related Issue(s)

Resolves #954 

## Demo

https://github.com/user-attachments/assets/14479dd8-3812-4fa2-a83a-ca6c7729e849

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
