### PR TITLE
feat(cat-voices): blocs errors stream and basic handling

### DIFF
--- a/catalyst_voices/lib/common/error_handler.dart
+++ b/catalyst_voices/lib/common/error_handler.dart
@@ -1,0 +1,25 @@
+//ignore_for_file: one_member_abstracts
+
+import 'package:catalyst_voices/widgets/snackbar/voices_snackbar.dart';
+import 'package:catalyst_voices/widgets/snackbar/voices_snackbar_type.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter/widgets.dart';
+
+abstract interface class ErrorHandler {
+  void handleError(Object error);
+}
+
+mixin ErrorHandlerStateMixin<T extends StatefulWidget> on State<T>
+    implements ErrorHandler {
+  @override
+  void handleError(Object error) {
+    if (error is LocalizedException) {
+      handleLocalizedException(error);
+    }
+  }
+
+  void handleLocalizedException(LocalizedException exception) {
+    // TODO(damian-molinski): VoicesSnackBar does not support custom text yet.
+    const VoicesSnackBar(type: VoicesSnackBarType.error).show(context);
+  }
+}

--- a/catalyst_voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
+++ b/catalyst_voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
@@ -99,9 +99,11 @@ class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
   Future<void> _createKeychain() async {
     final registrationCubit = RegistrationCubit.of(context);
 
-    await registrationCubit.keychainCreation.createKeychain();
+    final isSuccess = await registrationCubit.keychainCreation.createKeychain();
 
-    registrationCubit.nextStep();
+    if (isSuccess) {
+      registrationCubit.nextStep();
+    }
   }
 }
 

--- a/catalyst_voices/lib/pages/registration/registration_dialog.dart
+++ b/catalyst_voices/lib/pages/registration/registration_dialog.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:catalyst_voices/common/error_handler.dart';
 import 'package:catalyst_voices/dependency/dependencies.dart';
 import 'package:catalyst_voices/pages/registration/registration_details_panel.dart';
 import 'package:catalyst_voices/pages/registration/registration_exit_confirm_dialog.dart';
@@ -9,7 +10,7 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class RegistrationDialog extends StatelessWidget {
+class RegistrationDialog extends StatefulWidget {
   const RegistrationDialog._();
 
   static Future<void> show(BuildContext context) {
@@ -22,9 +23,34 @@ class RegistrationDialog extends StatelessWidget {
   }
 
   @override
+  State<RegistrationDialog> createState() => _RegistrationDialogState();
+}
+
+class _RegistrationDialogState extends State<RegistrationDialog>
+    with ErrorHandlerStateMixin {
+  late final RegistrationCubit _cubit;
+  StreamSubscription<Object>? _errorSub;
+
+  @override
+  void initState() {
+    super.initState();
+    _cubit = Dependencies.instance.get<RegistrationCubit>();
+    _errorSub = _cubit.errorStream.listen(handleError);
+  }
+
+  @override
+  void dispose() {
+    unawaited(_errorSub?.cancel());
+    _errorSub = null;
+
+    unawaited(_cubit.close());
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (context) => Dependencies.instance.get<RegistrationCubit>(),
+    return BlocProvider.value(
+      value: _cubit,
       child: PopScope(
         canPop: false,
         onPopInvokedWithResult: (didPop, result) {

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/bloc_error_emitter_mixin.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/bloc_error_emitter_mixin.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+mixin BlocErrorEmitterMixin<State> on BlocBase<State> {
+  late final _errorController = StreamController<Object>.broadcast();
+
+  Stream<Object> get errorStream => _errorController.stream;
+
+  void emitError(Object error) {
+    if (isClosed) {
+      throw StateError('Cannot emitError after calling close');
+    }
+    _errorController.add(error);
+  }
+
+  @override
+  Future<void> close() async {
+    await _errorController.close();
+    return super.close();
+  }
+}

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/catalyst_voices_blocs.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/catalyst_voices_blocs.dart
@@ -1,4 +1,5 @@
 export 'authentication/authentication.dart';
+export 'bloc_error_emitter_mixin.dart';
 export 'brand/brand.dart';
 export 'login/login.dart';
 export 'registration/registration.dart';

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
@@ -100,8 +100,7 @@ final class KeychainCreationCubit extends Cubit<KeychainStateData>
   Future<void> downloadSeedPhrase() async {
     final mnemonic = _seedPhraseStateData.seedPhrase?.mnemonic;
     if (mnemonic == null) {
-      // TODO(damian-molinski): Use better exception
-      emitError(const LocalizedUnknownException());
+      emitError(const LocalizedRegistrationSeedPhraseNotFoundException());
       return;
     }
 
@@ -148,10 +147,10 @@ final class KeychainCreationCubit extends Cubit<KeychainStateData>
       final password = _unlockPasswordState.password;
 
       if (seedPhrase == null) {
-        throw const LocalizedUnknownException();
+        throw const LocalizedRegistrationSeedPhraseNotFoundException();
       }
       if (password.isEmpty) {
-        throw const LocalizedUnknownException();
+        throw const LocalizedRegistrationUnlockPasswordNotFoundException();
       }
 
       await _registrationService.createKeychain(

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/recover_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/recover_cubit.dart
@@ -11,6 +11,7 @@ abstract interface class RecoverManager {
 }
 
 final class RecoverCubit extends Cubit<RecoverStateData>
+    with BlocErrorEmitterMixin
     implements RecoverManager {
   RecoverCubit() : super(const RecoverStateData()) {
     /// pre-populate all available words

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
@@ -19,6 +19,7 @@ abstract interface class WalletLinkManager {
 }
 
 final class WalletLinkCubit extends Cubit<WalletLinkStateData>
+    with BlocErrorEmitterMixin
     implements WalletLinkManager {
   final RegistrationService registrationService;
 

--- a/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -17,7 +17,8 @@ import 'package:result_type/result_type.dart';
 final _logger = Logger('RegistrationCubit');
 
 /// Manages the registration state.
-final class RegistrationCubit extends Cubit<RegistrationState> {
+final class RegistrationCubit extends Cubit<RegistrationState>
+    with BlocErrorEmitterMixin {
   final KeychainCreationCubit _keychainCreationCubit;
   final WalletLinkCubit _walletLinkCubit;
   final RecoverCubit _recoverCubit;
@@ -28,6 +29,7 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
     required this.registrationService,
   })  : _keychainCreationCubit = KeychainCreationCubit(
           downloader: downloader,
+          registrationService: registrationService,
         ),
         _walletLinkCubit = WalletLinkCubit(
           registrationService: registrationService,
@@ -37,6 +39,10 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
     _keychainCreationCubit.stream.listen(_onKeychainStateDataChanged);
     _walletLinkCubit.stream.listen(_onWalletLinkStateDataChanged);
     _recoverCubit.stream.listen(_onRecoverStateDataChanged);
+
+    _keychainCreationCubit.errorStream.listen(emitError);
+    _walletLinkCubit.errorStream.listen(emitError);
+    _recoverCubit.errorStream.listen(emitError);
 
     // Emits initialization state
     emit(
@@ -64,6 +70,7 @@ final class RegistrationCubit extends Cubit<RegistrationState> {
   Future<void> close() {
     _keychainCreationCubit.close();
     _walletLinkCubit.close();
+    _recoverCubit.close();
     return super.close();
   }
 

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -838,6 +838,12 @@ abstract class VoicesLocalizations {
   /// **'Seed phrase was not found. Make sure correct words are correct.'**
   String get registrationSeedPhraseNotFound;
 
+  /// Error message shown when attempting to register or recover account but password was not found
+  ///
+  /// In en, this message translates to:
+  /// **'Password was not found. Make sure valid password was created.'**
+  String get registrationUnlockPasswordNotFound;
+
   /// A title on the role chooser screen in registration.
   ///
   /// In en, this message translates to:

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -440,6 +440,9 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
   String get registrationSeedPhraseNotFound => 'Seed phrase was not found. Make sure correct words are correct.';
 
   @override
+  String get registrationUnlockPasswordNotFound => 'Password was not found. Make sure valid password was created.';
+
+  @override
   String get walletLinkRoleChooserTitle => 'How do you want to participate in Catalyst?';
 
   @override

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -440,6 +440,9 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
   String get registrationSeedPhraseNotFound => 'Seed phrase was not found. Make sure correct words are correct.';
 
   @override
+  String get registrationUnlockPasswordNotFound => 'Password was not found. Make sure valid password was created.';
+
+  @override
   String get walletLinkRoleChooserTitle => 'How do you want to participate in Catalyst?';
 
   @override

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -557,6 +557,10 @@
   "@registrationSeedPhraseNotFound": {
     "description": "Error message shown when attempting to register or recover account but seed phrase was not found"
   },
+  "registrationUnlockPasswordNotFound": "Password was not found. Make sure valid password was created.",
+  "@registrationUnlockPasswordNotFound": {
+    "description": "Error message shown when attempting to register or recover account but password was not found"
+  },
   "walletLinkRoleChooserTitle": "How do you want to participate in Catalyst?",
   "@walletLinkRoleChooserTitle": {
     "description": "A title on the role chooser screen in registration."

--- a/catalyst_voices/packages/catalyst_voices_services/lib/src/registration/registration_service.dart
+++ b/catalyst_voices/packages/catalyst_voices_services/lib/src/registration/registration_service.dart
@@ -14,6 +14,13 @@ final class RegistrationService {
     this._cardano,
   );
 
+  Future<void> createKeychain({
+    required SeedPhrase seedPhrase,
+    required String unlockPassword,
+  }) async {
+    // TODO(damian-molinski): To be implemented
+  }
+
   /// Returns the available cardano wallet extensions.
   Future<List<CardanoWallet>> getCardanoWallets() {
     return _cardano.getWallets();

--- a/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/exception/localized_registration_exception.dart
+++ b/catalyst_voices/packages/catalyst_voices_view_models/lib/src/registration/exception/localized_registration_exception.dart
@@ -54,6 +54,17 @@ final class LocalizedRegistrationSeedPhraseNotFoundException
       context.l10n.registrationSeedPhraseNotFound;
 }
 
+/// Localized exception thrown when attempting to execute register operation
+/// which requires unlock password but non was found.
+final class LocalizedRegistrationUnlockPasswordNotFoundException
+    extends LocalizedRegistrationException {
+  const LocalizedRegistrationUnlockPasswordNotFoundException();
+
+  @override
+  String message(BuildContext context) =>
+      context.l10n.registrationUnlockPasswordNotFound;
+}
+
 /// A generic error for describing a failure during user registration.
 final class LocalizedRegistrationUnknownException
     extends LocalizedRegistrationException {


### PR DESCRIPTION
# Description

- Adds basic implementation of streaming errors from bloc/cubit to root widget
- Mixing with snackbar handling of `LocalizedException`s

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
