### PR TITLE
fix(cat-voices): escape special characters in arb

### DIFF
--- a/catalyst_voices/packages/catalyst_voices_localization/l10n.yaml
+++ b/catalyst_voices/packages/catalyst_voices_localization/l10n.yaml
@@ -7,3 +7,4 @@ preferred-supported-locales:
   - en
 use-deferred-loading: true
 synthetic-package: false
+use-escaping: true

--- a/catalyst_voices/packages/catalyst_voices_localization/l10n.yaml
+++ b/catalyst_voices/packages/catalyst_voices_localization/l10n.yaml
@@ -7,4 +7,5 @@ preferred-supported-locales:
   - en
 use-deferred-loading: true
 synthetic-package: false
-use-escaping: true
+use-escaping: false
+relax-syntax: true

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -211,7 +211,7 @@ abstract class VoicesLocalizations {
   /// Text shown as description in coming soon page
   ///
   /// In en, this message translates to:
-  /// **'Project Catalyst is the world\'\'s largest decentralized innovation engine for solving real-world challenges.'**
+  /// **'Project Catalyst is the world\'s largest decentralized innovation engine for solving real-world challenges.'**
   String get comingSoonDescription;
 
   /// Label text shown in the ConnectingStatus widget during re-connection.
@@ -715,7 +715,7 @@ abstract class VoicesLocalizations {
   /// A message (content) in link wallet flow on intro screen.
   ///
   /// In en, this message translates to:
-  /// **'You\'\'re almost there! This is the final and most important step in your account setup.\n\nWe\'\'re going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe\'\'ll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.'**
+  /// **'You\'re almost there! This is the final and most important step in your account setup.\n\nWe\'re going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe\'ll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.'**
   String get walletLinkIntroContent;
 
   /// A title in link wallet flow on select wallet screen.
@@ -727,7 +727,7 @@ abstract class VoicesLocalizations {
   /// A message (content) in link wallet flow on select wallet screen.
   ///
   /// In en, this message translates to:
-  /// **'To complete this action, you\'\'ll submit a signed transaction to Cardano. There will be an ADA transaction fee.'**
+  /// **'To complete this action, you\'ll submit a signed transaction to Cardano. There will be an ADA transaction fee.'**
   String get walletLinkSelectWalletContent;
 
   /// A title in link wallet flow on wallet details screen.
@@ -742,7 +742,7 @@ abstract class VoicesLocalizations {
   /// **'{wallet} connected successfully!'**
   String walletLinkWalletDetailsContent(String wallet);
 
-  /// A message in link wallet flow on wallet details screen when a user wallet doesn''t have enough balance.
+  /// A message in link wallet flow on wallet details screen when a user wallet doesn't have enough balance.
   ///
   /// In en, this message translates to:
   /// **'Wallet and role registrations require a minimal transaction fee. You can setup your default dApp connector wallet in your browser extension settings.'**
@@ -754,7 +754,7 @@ abstract class VoicesLocalizations {
   /// **'Top up ADA'**
   String get walletLinkWalletDetailsNoticeTopUp;
 
-  /// A link to top-up provide when the user doesn''t have enough balance on wallet link screen
+  /// A link to top-up provide when the user doesn't have enough balance on wallet link screen
   ///
   /// In en, this message translates to:
   /// **'Link to top-up provider'**
@@ -763,7 +763,7 @@ abstract class VoicesLocalizations {
   /// A title in link wallet flow on transaction screen.
   ///
   /// In en, this message translates to:
-  /// **'Let\'\'s make sure everything looks right.'**
+  /// **'Let\'s make sure everything looks right.'**
   String get walletLinkTransactionTitle;
 
   /// A subtitle in link wallet flow on transaction screen.
@@ -1027,7 +1027,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @accountCreationSplashMessage.
   ///
   /// In en, this message translates to:
-  /// **'Your keychain is your ticket to participate in  distributed innovation on the global stage.    Once you have it, you\'\'ll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.    As you add new keys to your keychain, you\'\'ll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.'**
+  /// **'Your keychain is your ticket to participate in  distributed innovation on the global stage.    Once you have it, you\'ll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.    As you add new keys to your keychain, you\'ll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.'**
   String get accountCreationSplashMessage;
 
   /// No description provided for @accountCreationSplashNextButton.
@@ -1045,7 +1045,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @accountInstructionsMessage.
   ///
   /// In en, this message translates to:
-  /// **'On the next screen, you\'\'re going to see 12 words.  This is called your \"seed phrase\".     It\'\'s like a super secure password that only you know,  that allows you to prove ownership of your keychain.    You\'\'ll use it to login and recover your account on  different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.'**
+  /// **'On the next screen, you\'re going to see 12 words.  This is called your \"seed phrase\".     It\'s like a super secure password that only you know,  that allows you to prove ownership of your keychain.    You\'ll use it to login and recover your account on  different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.'**
   String get accountInstructionsMessage;
 
   /// For example in button that goes to next stage of registration
@@ -1117,7 +1117,7 @@ abstract class VoicesLocalizations {
   /// An error text on text field on delete keychain dialog
   ///
   /// In en, this message translates to:
-  /// **'Error. Please type \'\'Remove Keychain\'\' to remove your account from this device.'**
+  /// **'Error. Please type \'Remove Keychain\' to remove your account from this device.'**
   String get deleteKeychainDialogErrorText;
 
   /// A removing phrase on delete keychain dialog
@@ -1132,7 +1132,7 @@ abstract class VoicesLocalizations {
   /// **'Learn about Catalyst Roles'**
   String get accountRoleDialogTitle;
 
-  /// A label on account role dialog''s button
+  /// A label on account role dialog's button
   ///
   /// In en, this message translates to:
   /// **'Continue Role setup'**
@@ -1333,7 +1333,7 @@ abstract class VoicesLocalizations {
   /// An info on keychain upload dialog
   ///
   /// In en, this message translates to:
-  /// **'Make sure it\'\'s a correct Catalyst keychain file.'**
+  /// **'Make sure it\'s a correct Catalyst keychain file.'**
   String get uploadKeychainInfo;
 
   /// Refers to a light theme mode.
@@ -1471,7 +1471,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @createKeychainSeedPhraseCheckInstructionsSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Next, we\'\'re going to make sure that you\'\'ve written down your words correctly.     We don\'\'t save your seed phrase, so it\'\'s important  to make sure you have it right. That\'\'s why we do this confirmation before continuing.     It\'\'s also good practice to get familiar with using a seed phrase if you\'\'re new to crypto.'**
+  /// **'Next, we\'re going to make sure that you\'ve written down your words correctly.     We don\'t save your seed phrase, so it\'s important  to make sure you have it right. That\'s why we do this confirmation before continuing.     It\'s also good practice to get familiar with using a seed phrase if you\'re new to crypto.'**
   String get createKeychainSeedPhraseCheckInstructionsSubtitle;
 
   /// No description provided for @createKeychainSeedPhraseCheckSubtitle.
@@ -1501,13 +1501,13 @@ abstract class VoicesLocalizations {
   /// No description provided for @createKeychainSeedPhraseCheckSuccessTitle.
   ///
   /// In en, this message translates to:
-  /// **'Nice job! You\'\'ve successfully verified the seed phrase for your keychain.'**
+  /// **'Nice job! You\'ve successfully verified the seed phrase for your keychain.'**
   String get createKeychainSeedPhraseCheckSuccessTitle;
 
   /// No description provided for @createKeychainSeedPhraseCheckSuccessSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we\'\'ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.'**
+  /// **'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we\'ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.'**
   String get createKeychainSeedPhraseCheckSuccessSubtitle;
 
   /// No description provided for @yourNextStep.
@@ -1531,7 +1531,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @createKeychainUnlockPasswordInstructionsSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'\'ll set your Unlock Password for your current device. It\'\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
+  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
   String get createKeychainUnlockPasswordInstructionsSubtitle;
 
   /// No description provided for @createKeychainCreatedTitle.
@@ -1735,7 +1735,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @recoveryUnlockPasswordInstructionsSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'\'ll set your Unlock Password for your current device. It\'\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
+  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
   String get recoveryUnlockPasswordInstructionsSubtitle;
 
   /// The header label in unlock dialog.

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations.dart
@@ -211,7 +211,7 @@ abstract class VoicesLocalizations {
   /// Text shown as description in coming soon page
   ///
   /// In en, this message translates to:
-  /// **'Project Catalyst is the world\'s largest decentralized innovation engine for solving real-world challenges.'**
+  /// **'Project Catalyst is the world\'\'s largest decentralized innovation engine for solving real-world challenges.'**
   String get comingSoonDescription;
 
   /// Label text shown in the ConnectingStatus widget during re-connection.
@@ -715,7 +715,7 @@ abstract class VoicesLocalizations {
   /// A message (content) in link wallet flow on intro screen.
   ///
   /// In en, this message translates to:
-  /// **'You\'re almost there! This is the final and most important step in your account setup.\n\nWe\'re going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe\'ll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.'**
+  /// **'You\'\'re almost there! This is the final and most important step in your account setup.\n\nWe\'\'re going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe\'\'ll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.'**
   String get walletLinkIntroContent;
 
   /// A title in link wallet flow on select wallet screen.
@@ -727,7 +727,7 @@ abstract class VoicesLocalizations {
   /// A message (content) in link wallet flow on select wallet screen.
   ///
   /// In en, this message translates to:
-  /// **'To complete this action, you\'ll submit a signed transaction to Cardano. There will be an ADA transaction fee.'**
+  /// **'To complete this action, you\'\'ll submit a signed transaction to Cardano. There will be an ADA transaction fee.'**
   String get walletLinkSelectWalletContent;
 
   /// A title in link wallet flow on wallet details screen.
@@ -742,7 +742,7 @@ abstract class VoicesLocalizations {
   /// **'{wallet} connected successfully!'**
   String walletLinkWalletDetailsContent(String wallet);
 
-  /// A message in link wallet flow on wallet details screen when a user wallet doesn't have enough balance.
+  /// A message in link wallet flow on wallet details screen when a user wallet doesn''t have enough balance.
   ///
   /// In en, this message translates to:
   /// **'Wallet and role registrations require a minimal transaction fee. You can setup your default dApp connector wallet in your browser extension settings.'**
@@ -754,7 +754,7 @@ abstract class VoicesLocalizations {
   /// **'Top up ADA'**
   String get walletLinkWalletDetailsNoticeTopUp;
 
-  /// A link to top-up provide when the user doesn't have enough balance on wallet link screen
+  /// A link to top-up provide when the user doesn''t have enough balance on wallet link screen
   ///
   /// In en, this message translates to:
   /// **'Link to top-up provider'**
@@ -763,7 +763,7 @@ abstract class VoicesLocalizations {
   /// A title in link wallet flow on transaction screen.
   ///
   /// In en, this message translates to:
-  /// **'Let\'s make sure everything looks right.'**
+  /// **'Let\'\'s make sure everything looks right.'**
   String get walletLinkTransactionTitle;
 
   /// A subtitle in link wallet flow on transaction screen.
@@ -1027,7 +1027,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @accountCreationSplashMessage.
   ///
   /// In en, this message translates to:
-  /// **'Your keychain is your ticket to participate in  distributed innovation on the global stage.    Once you have it, you\'ll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.    As you add new keys to your keychain, you\'ll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.'**
+  /// **'Your keychain is your ticket to participate in  distributed innovation on the global stage.    Once you have it, you\'\'ll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.    As you add new keys to your keychain, you\'\'ll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.'**
   String get accountCreationSplashMessage;
 
   /// No description provided for @accountCreationSplashNextButton.
@@ -1045,7 +1045,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @accountInstructionsMessage.
   ///
   /// In en, this message translates to:
-  /// **'On the next screen, you\'re going to see 12 words.  This is called your \"seed phrase\".     It\'s like a super secure password that only you know,  that allows you to prove ownership of your keychain.    You\'ll use it to login and recover your account on  different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.'**
+  /// **'On the next screen, you\'\'re going to see 12 words.  This is called your \"seed phrase\".     It\'\'s like a super secure password that only you know,  that allows you to prove ownership of your keychain.    You\'\'ll use it to login and recover your account on  different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.'**
   String get accountInstructionsMessage;
 
   /// For example in button that goes to next stage of registration
@@ -1117,7 +1117,7 @@ abstract class VoicesLocalizations {
   /// An error text on text field on delete keychain dialog
   ///
   /// In en, this message translates to:
-  /// **'Error. Please type \'Remove Keychain\' to remove your account from this device.'**
+  /// **'Error. Please type \'\'Remove Keychain\'\' to remove your account from this device.'**
   String get deleteKeychainDialogErrorText;
 
   /// A removing phrase on delete keychain dialog
@@ -1132,7 +1132,7 @@ abstract class VoicesLocalizations {
   /// **'Learn about Catalyst Roles'**
   String get accountRoleDialogTitle;
 
-  /// A label on account role dialog's button
+  /// A label on account role dialog''s button
   ///
   /// In en, this message translates to:
   /// **'Continue Role setup'**
@@ -1333,7 +1333,7 @@ abstract class VoicesLocalizations {
   /// An info on keychain upload dialog
   ///
   /// In en, this message translates to:
-  /// **'Make sure it\'s a correct Catalyst keychain file.'**
+  /// **'Make sure it\'\'s a correct Catalyst keychain file.'**
   String get uploadKeychainInfo;
 
   /// Refers to a light theme mode.
@@ -1471,7 +1471,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @createKeychainSeedPhraseCheckInstructionsSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Next, we\'re going to make sure that you\'ve written down your words correctly.     We don\'t save your seed phrase, so it\'s important  to make sure you have it right. That\'s why we do this confirmation before continuing.     It\'s also good practice to get familiar with using a seed phrase if you\'re new to crypto.'**
+  /// **'Next, we\'\'re going to make sure that you\'\'ve written down your words correctly.     We don\'\'t save your seed phrase, so it\'\'s important  to make sure you have it right. That\'\'s why we do this confirmation before continuing.     It\'\'s also good practice to get familiar with using a seed phrase if you\'\'re new to crypto.'**
   String get createKeychainSeedPhraseCheckInstructionsSubtitle;
 
   /// No description provided for @createKeychainSeedPhraseCheckSubtitle.
@@ -1501,13 +1501,13 @@ abstract class VoicesLocalizations {
   /// No description provided for @createKeychainSeedPhraseCheckSuccessTitle.
   ///
   /// In en, this message translates to:
-  /// **'Nice job! You\'ve successfully verified the seed phrase for your keychain.'**
+  /// **'Nice job! You\'\'ve successfully verified the seed phrase for your keychain.'**
   String get createKeychainSeedPhraseCheckSuccessTitle;
 
   /// No description provided for @createKeychainSeedPhraseCheckSuccessSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.'**
+  /// **'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we\'\'ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.'**
   String get createKeychainSeedPhraseCheckSuccessSubtitle;
 
   /// No description provided for @yourNextStep.
@@ -1531,7 +1531,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @createKeychainUnlockPasswordInstructionsSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
+  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'\'ll set your Unlock Password for your current device. It\'\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
   String get createKeychainUnlockPasswordInstructionsSubtitle;
 
   /// No description provided for @createKeychainCreatedTitle.
@@ -1735,7 +1735,7 @@ abstract class VoicesLocalizations {
   /// No description provided for @recoveryUnlockPasswordInstructionsSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'ll set your Unlock Password for your current device. It\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
+  /// **'With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.    But it can be a bit tedious to enter every single time you want to use the app.    In this next step, you\'\'ll set your Unlock Password for your current device. It\'\'s like a shortcut for proving ownership of your Keychain.    Whenever you recover your account for the first time on a new device, you\'\'ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.'**
   String get recoveryUnlockPasswordInstructionsSubtitle;
 
   /// The header label in unlock dialog.

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_en.dart
@@ -796,7 +796,7 @@ class VoicesLocalizationsEn extends VoicesLocalizations {
   String get createKeychainSeedPhraseCheckSuccessTitle => 'Nice job! You\'ve successfully verified the seed phrase for your keychain.';
 
   @override
-  String get createKeychainSeedPhraseCheckSuccessSubtitle => 'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.';
+  String get createKeychainSeedPhraseCheckSuccessSubtitle => 'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we\'ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.';
 
   @override
   String get yourNextStep => 'Your next step';

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/generated/catalyst_voices_localizations_es.dart
@@ -796,7 +796,7 @@ class VoicesLocalizationsEs extends VoicesLocalizations {
   String get createKeychainSeedPhraseCheckSuccessTitle => 'Nice job! You\'ve successfully verified the seed phrase for your keychain.';
 
   @override
-  String get createKeychainSeedPhraseCheckSuccessSubtitle => 'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.';
+  String get createKeychainSeedPhraseCheckSuccessSubtitle => 'Enter your seed phrase to recover your Catalyst Keychain on any device.  It\'s kinda like your email and password all rolled into one, so keep it somewhere safe!  In the next step we\'ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.';
 
   @override
   String get yourNextStep => 'Your next step';

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -458,7 +458,7 @@
   "@walletLinkIntroTitle": {
     "description": "A title in link wallet flow on intro screen."
   },
-  "walletLinkIntroContent": "You''re almost there! This is the final and most important step in your account setup.\n\nWe're going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe'll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.",
+  "walletLinkIntroContent": "You''re almost there! This is the final and most important step in your account setup.\n\nWe''re going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe''ll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.",
   "@walletLinkIntroContent": {
     "description": "A message (content) in link wallet flow on intro screen."
   },
@@ -485,7 +485,7 @@
   },
   "walletLinkWalletDetailsNotice": "Wallet and role registrations require a minimal transaction fee. You can setup your default dApp connector wallet in your browser extension settings.",
   "@walletLinkWalletDetailsNotice": {
-    "description": "A message in link wallet flow on wallet details screen when a user wallet doesn't have enough balance."
+    "description": "A message in link wallet flow on wallet details screen when a user wallet doesn''t have enough balance."
   },
   "walletLinkWalletDetailsNoticeTopUp": "Top up ADA",
   "@walletLinkWalletDetailsNoticeTopUp": {
@@ -493,7 +493,7 @@
   },
   "walletLinkWalletDetailsNoticeTopUpLink": "Link to top-up provider",
   "@walletLinkWalletDetailsNoticeTopUpLink": {
-    "description": "A link to top-up provide when the user doesn't have enough balance on wallet link screen"
+    "description": "A link to top-up provide when the user doesn''t have enough balance on wallet link screen"
   },
   "walletLinkTransactionTitle": "Let''s make sure everything looks right.",
   "@walletLinkTransactionTitle": {
@@ -666,10 +666,10 @@
   },
   "catalystKeychain": "Catalyst Keychain",
   "accountCreationSplashTitle": "Create your Catalyst Keychain",
-  "accountCreationSplashMessage": "Your keychain is your ticket to participate in \u2028distributed innovation on the global stage.  \u2028\u2028Once you have it, you'll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.  \u2028\u2028As you add new keys to your keychain, you'll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.",
+  "accountCreationSplashMessage": "Your keychain is your ticket to participate in \u2028distributed innovation on the global stage.  \u2028\u2028Once you have it, you''ll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.  \u2028\u2028As you add new keys to your keychain, you''ll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.",
   "accountCreationSplashNextButton": "Create your Keychain now",
   "accountInstructionsTitle": "Great! Your Catalyst Keychain \u2028has been created.",
-  "accountInstructionsMessage": "On the next screen, you''re going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It's like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You'll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
+  "accountInstructionsMessage": "On the next screen, you''re going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It''s like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You''ll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
   "next": "Next",
   "@next": {
     "description": "For example in button that goes to next stage of registration"
@@ -714,7 +714,7 @@
   "@deleteKeychainDialogInputLabel": {
     "description": "An input label on delete keychain dialog"
   },
-  "deleteKeychainDialogErrorText": "Error. Please type 'Remove Keychain' to remove your account from this device.",
+  "deleteKeychainDialogErrorText": "Error. Please type ''Remove Keychain'' to remove your account from this device.",
   "@deleteKeychainDialogErrorText": {
     "description": "An error text on text field on delete keychain dialog"
   },
@@ -728,7 +728,7 @@
   },
   "accountRoleDialogButton": "Continue Role setup",
   "@accountRoleDialogButton": {
-    "description": "A label on account role dialog's button"
+    "description": "A label on account role dialog''s button"
   },
   "accountRoleDialogRoleSummaryTitle": "{role} role summary",
   "@accountRoleDialogRoleSummaryTitle": {
@@ -854,7 +854,7 @@
   "createKeychainSeedPhraseDownload": "Download Catalyst key",
   "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words",
   "createKeychainSeedPhraseCheckInstructionsTitle": "Check your Catalyst security keys",
-  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we''re going to make sure that you've written down your words correctly.   \u2028\u2028We don't save your seed phrase, so it's important \u2028to make sure you have it right. That's why we do this confirmation before continuing.   \u2028\u2028It's also good practice to get familiar with using a seed phrase if you're new to crypto.",
+  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we''re going to make sure that you''ve written down your words correctly.   \u2028\u2028We don''t save your seed phrase, so it''s important \u2028to make sure you have it right. That''s why we do this confirmation before continuing.   \u2028\u2028It''s also good practice to get familiar with using a seed phrase if you''re new to crypto.",
   "createKeychainSeedPhraseCheckSubtitle": "Input your Catalyst security keys",
   "createKeychainSeedPhraseCheckBody": "Select your 12 written down words in \u2028the correct order.",
   "uploadCatalystKey": "Upload Catalyst Key",
@@ -863,11 +863,11 @@
   },
   "reset": "Reset",
   "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You''ve successfully verified the seed phrase for your keychain.",
-  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It''s kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
+  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It''s kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we''ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
   "yourNextStep": "Your next step",
   "createKeychainSeedPhraseCheckSuccessNextStep": "Now let’s set your Unlock password for this device!",
   "createKeychainUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password \u2028for this device",
-  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you''ll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
+  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you''ll set your Unlock Password for your current device. It''s like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you''ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
   "createKeychainCreatedTitle": "Congratulations your Catalyst \u2028Keychain is created!",
   "createKeychainCreatedNextStep": "In the next step you write your Catalyst roles and \u2028account to the Cardano Mainnet.",
   "createKeychainLinkWalletAndRoles": "Link your Cardano Wallet & Roles",
@@ -911,7 +911,7 @@
   "recoveryAccountSuccessTitle": "Keychain recovered successfully!",
   "recoveryAccountDetailsAction": "Set unlock password for this device",
   "recoveryUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password f\u2028or this device",
-  "recoveryUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It''s like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
+  "recoveryUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you''ll set your Unlock Password for your current device. It''s like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you''ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
   "unlockDialogHeader": "Unlock Catalyst",
   "@unlockDialogHeader": {
     "description": "The header label in unlock dialog."

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -76,7 +76,7 @@
   "@comingSoonTitle2": {
     "description": "Text shown as main title in coming soon page"
   },
-  "comingSoonDescription": "Project Catalyst is the world's largest decentralized innovation engine for solving real-world challenges.",
+  "comingSoonDescription": "Project Catalyst is the world''s largest decentralized innovation engine for solving real-world challenges.",
   "@comingSoonDescription": {
     "description": "Text shown as description in coming soon page"
   },
@@ -458,7 +458,7 @@
   "@walletLinkIntroTitle": {
     "description": "A title in link wallet flow on intro screen."
   },
-  "walletLinkIntroContent": "You're almost there! This is the final and most important step in your account setup.\n\nWe're going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe'll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.",
+  "walletLinkIntroContent": "You''re almost there! This is the final and most important step in your account setup.\n\nWe're going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe'll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.",
   "@walletLinkIntroContent": {
     "description": "A message (content) in link wallet flow on intro screen."
   },
@@ -466,7 +466,7 @@
   "@walletLinkSelectWalletTitle": {
     "description": "A title in link wallet flow on select wallet screen."
   },
-  "walletLinkSelectWalletContent": "To complete this action, you'll submit a signed transaction to Cardano. There will be an ADA transaction fee.",
+  "walletLinkSelectWalletContent": "To complete this action, you''ll submit a signed transaction to Cardano. There will be an ADA transaction fee.",
   "@walletLinkSelectWalletContent": {
     "description": "A message (content) in link wallet flow on select wallet screen."
   },
@@ -495,7 +495,7 @@
   "@walletLinkWalletDetailsNoticeTopUpLink": {
     "description": "A link to top-up provide when the user doesn't have enough balance on wallet link screen"
   },
-  "walletLinkTransactionTitle": "Let's make sure everything looks right.",
+  "walletLinkTransactionTitle": "Let''s make sure everything looks right.",
   "@walletLinkTransactionTitle": {
     "description": "A title in link wallet flow on transaction screen."
   },
@@ -669,7 +669,7 @@
   "accountCreationSplashMessage": "Your keychain is your ticket to participate in \u2028distributed innovation on the global stage.  \u2028\u2028Once you have it, you'll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.  \u2028\u2028As you add new keys to your keychain, you'll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.",
   "accountCreationSplashNextButton": "Create your Keychain now",
   "accountInstructionsTitle": "Great! Your Catalyst Keychain \u2028has been created.",
-  "accountInstructionsMessage": "On the next screen, you're going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It's like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You'll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
+  "accountInstructionsMessage": "On the next screen, you''re going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It's like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You'll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
   "next": "Next",
   "@next": {
     "description": "For example in button that goes to next stage of registration"
@@ -799,7 +799,7 @@
   "@uploadKeychainTitle": {
     "description": "A title on keychain upload dialog"
   },
-  "uploadKeychainInfo": "Make sure it's a correct Catalyst keychain file.",
+  "uploadKeychainInfo": "Make sure it''s a correct Catalyst keychain file.",
   "@uploadKeychainInfo": {
     "description": "An info on keychain upload dialog"
   },
@@ -854,7 +854,7 @@
   "createKeychainSeedPhraseDownload": "Download Catalyst key",
   "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words",
   "createKeychainSeedPhraseCheckInstructionsTitle": "Check your Catalyst security keys",
-  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we're going to make sure that you've written down your words correctly.   \u2028\u2028We don't save your seed phrase, so it's important \u2028to make sure you have it right. That's why we do this confirmation before continuing.   \u2028\u2028It's also good practice to get familiar with using a seed phrase if you're new to crypto.",
+  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we''re going to make sure that you've written down your words correctly.   \u2028\u2028We don't save your seed phrase, so it's important \u2028to make sure you have it right. That's why we do this confirmation before continuing.   \u2028\u2028It's also good practice to get familiar with using a seed phrase if you're new to crypto.",
   "createKeychainSeedPhraseCheckSubtitle": "Input your Catalyst security keys",
   "createKeychainSeedPhraseCheckBody": "Select your 12 written down words in \u2028the correct order.",
   "uploadCatalystKey": "Upload Catalyst Key",
@@ -862,12 +862,12 @@
     "description": "When user checks correct seed phrase words order he can upload it too"
   },
   "reset": "Reset",
-  "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You've successfully verified the seed phrase for your keychain.",
-  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It's kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
+  "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You''ve successfully verified the seed phrase for your keychain.",
+  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It''s kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we’ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
   "yourNextStep": "Your next step",
   "createKeychainSeedPhraseCheckSuccessNextStep": "Now let’s set your Unlock password for this device!",
   "createKeychainUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password \u2028for this device",
-  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
+  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you''ll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
   "createKeychainCreatedTitle": "Congratulations your Catalyst \u2028Keychain is created!",
   "createKeychainCreatedNextStep": "In the next step you write your Catalyst roles and \u2028account to the Cardano Mainnet.",
   "createKeychainLinkWalletAndRoles": "Link your Cardano Wallet & Roles",
@@ -911,7 +911,7 @@
   "recoveryAccountSuccessTitle": "Keychain recovered successfully!",
   "recoveryAccountDetailsAction": "Set unlock password for this device",
   "recoveryUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password f\u2028or this device",
-  "recoveryUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
+  "recoveryUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It''s like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
   "unlockDialogHeader": "Unlock Catalyst",
   "@unlockDialogHeader": {
     "description": "The header label in unlock dialog."

--- a/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -76,7 +76,7 @@
   "@comingSoonTitle2": {
     "description": "Text shown as main title in coming soon page"
   },
-  "comingSoonDescription": "Project Catalyst is the world''s largest decentralized innovation engine for solving real-world challenges.",
+  "comingSoonDescription": "Project Catalyst is the world's largest decentralized innovation engine for solving real-world challenges.",
   "@comingSoonDescription": {
     "description": "Text shown as description in coming soon page"
   },
@@ -458,7 +458,7 @@
   "@walletLinkIntroTitle": {
     "description": "A title in link wallet flow on intro screen."
   },
-  "walletLinkIntroContent": "You''re almost there! This is the final and most important step in your account setup.\n\nWe''re going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe''ll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.",
+  "walletLinkIntroContent": "You're almost there! This is the final and most important step in your account setup.\n\nWe're going to link a Cardano Wallet to your Catalyst Keychain, so you can start collecting Role Keys.\n\nRole Keys allow you to enter new spaces, discover new ways to participate, and unlock new ways to earn rewards.\n\nWe'll start with your Voter Key by default. You can decide to add a Proposer Key and Drep key if you want, or you can always add them later.",
   "@walletLinkIntroContent": {
     "description": "A message (content) in link wallet flow on intro screen."
   },
@@ -466,7 +466,7 @@
   "@walletLinkSelectWalletTitle": {
     "description": "A title in link wallet flow on select wallet screen."
   },
-  "walletLinkSelectWalletContent": "To complete this action, you''ll submit a signed transaction to Cardano. There will be an ADA transaction fee.",
+  "walletLinkSelectWalletContent": "To complete this action, you'll submit a signed transaction to Cardano. There will be an ADA transaction fee.",
   "@walletLinkSelectWalletContent": {
     "description": "A message (content) in link wallet flow on select wallet screen."
   },
@@ -485,7 +485,7 @@
   },
   "walletLinkWalletDetailsNotice": "Wallet and role registrations require a minimal transaction fee. You can setup your default dApp connector wallet in your browser extension settings.",
   "@walletLinkWalletDetailsNotice": {
-    "description": "A message in link wallet flow on wallet details screen when a user wallet doesn''t have enough balance."
+    "description": "A message in link wallet flow on wallet details screen when a user wallet doesn't have enough balance."
   },
   "walletLinkWalletDetailsNoticeTopUp": "Top up ADA",
   "@walletLinkWalletDetailsNoticeTopUp": {
@@ -493,9 +493,9 @@
   },
   "walletLinkWalletDetailsNoticeTopUpLink": "Link to top-up provider",
   "@walletLinkWalletDetailsNoticeTopUpLink": {
-    "description": "A link to top-up provide when the user doesn''t have enough balance on wallet link screen"
+    "description": "A link to top-up provide when the user doesn't have enough balance on wallet link screen"
   },
-  "walletLinkTransactionTitle": "Let''s make sure everything looks right.",
+  "walletLinkTransactionTitle": "Let's make sure everything looks right.",
   "@walletLinkTransactionTitle": {
     "description": "A title in link wallet flow on transaction screen."
   },
@@ -666,10 +666,10 @@
   },
   "catalystKeychain": "Catalyst Keychain",
   "accountCreationSplashTitle": "Create your Catalyst Keychain",
-  "accountCreationSplashMessage": "Your keychain is your ticket to participate in \u2028distributed innovation on the global stage.  \u2028\u2028Once you have it, you''ll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.  \u2028\u2028As you add new keys to your keychain, you''ll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.",
+  "accountCreationSplashMessage": "Your keychain is your ticket to participate in \u2028distributed innovation on the global stage.  \u2028\u2028Once you have it, you'll be able to enter different spaces, discover awesome ideas, and share your feedback to hep improve ideas.  \u2028\u2028As you add new keys to your keychain, you'll be able to enter new spaces, unlock new rewards opportunities, and have your voice heard in community decisions.",
   "accountCreationSplashNextButton": "Create your Keychain now",
   "accountInstructionsTitle": "Great! Your Catalyst Keychain \u2028has been created.",
-  "accountInstructionsMessage": "On the next screen, you''re going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It''s like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You''ll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
+  "accountInstructionsMessage": "On the next screen, you're going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It's like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You'll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
   "next": "Next",
   "@next": {
     "description": "For example in button that goes to next stage of registration"
@@ -714,7 +714,7 @@
   "@deleteKeychainDialogInputLabel": {
     "description": "An input label on delete keychain dialog"
   },
-  "deleteKeychainDialogErrorText": "Error. Please type ''Remove Keychain'' to remove your account from this device.",
+  "deleteKeychainDialogErrorText": "Error. Please type 'Remove Keychain' to remove your account from this device.",
   "@deleteKeychainDialogErrorText": {
     "description": "An error text on text field on delete keychain dialog"
   },
@@ -728,7 +728,7 @@
   },
   "accountRoleDialogButton": "Continue Role setup",
   "@accountRoleDialogButton": {
-    "description": "A label on account role dialog''s button"
+    "description": "A label on account role dialog's button"
   },
   "accountRoleDialogRoleSummaryTitle": "{role} role summary",
   "@accountRoleDialogRoleSummaryTitle": {
@@ -799,7 +799,7 @@
   "@uploadKeychainTitle": {
     "description": "A title on keychain upload dialog"
   },
-  "uploadKeychainInfo": "Make sure it''s a correct Catalyst keychain file.",
+  "uploadKeychainInfo": "Make sure it's a correct Catalyst keychain file.",
   "@uploadKeychainInfo": {
     "description": "An info on keychain upload dialog"
   },
@@ -854,7 +854,7 @@
   "createKeychainSeedPhraseDownload": "Download Catalyst key",
   "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words",
   "createKeychainSeedPhraseCheckInstructionsTitle": "Check your Catalyst security keys",
-  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we''re going to make sure that you''ve written down your words correctly.   \u2028\u2028We don''t save your seed phrase, so it''s important \u2028to make sure you have it right. That''s why we do this confirmation before continuing.   \u2028\u2028It''s also good practice to get familiar with using a seed phrase if you''re new to crypto.",
+  "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we're going to make sure that you've written down your words correctly.   \u2028\u2028We don't save your seed phrase, so it's important \u2028to make sure you have it right. That's why we do this confirmation before continuing.   \u2028\u2028It's also good practice to get familiar with using a seed phrase if you're new to crypto.",
   "createKeychainSeedPhraseCheckSubtitle": "Input your Catalyst security keys",
   "createKeychainSeedPhraseCheckBody": "Select your 12 written down words in \u2028the correct order.",
   "uploadCatalystKey": "Upload Catalyst Key",
@@ -862,12 +862,12 @@
     "description": "When user checks correct seed phrase words order he can upload it too"
   },
   "reset": "Reset",
-  "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You''ve successfully verified the seed phrase for your keychain.",
-  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It''s kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we''ll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
+  "createKeychainSeedPhraseCheckSuccessTitle": "Nice job! You've successfully verified the seed phrase for your keychain.",
+  "createKeychainSeedPhraseCheckSuccessSubtitle": "Enter your seed phrase to recover your Catalyst Keychain on any device.\u2028\u2028It's kinda like your email and password all rolled into one, so keep it somewhere safe!\u2028\u2028In the next step we'll add a password to your Catalyst Keychain, so you can lock/unlock access to Voices.",
   "yourNextStep": "Your next step",
   "createKeychainSeedPhraseCheckSuccessNextStep": "Now let’s set your Unlock password for this device!",
   "createKeychainUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password \u2028for this device",
-  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you''ll set your Unlock Password for your current device. It''s like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you''ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
+  "createKeychainUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
   "createKeychainCreatedTitle": "Congratulations your Catalyst \u2028Keychain is created!",
   "createKeychainCreatedNextStep": "In the next step you write your Catalyst roles and \u2028account to the Cardano Mainnet.",
   "createKeychainLinkWalletAndRoles": "Link your Cardano Wallet & Roles",
@@ -911,7 +911,7 @@
   "recoveryAccountSuccessTitle": "Keychain recovered successfully!",
   "recoveryAccountDetailsAction": "Set unlock password for this device",
   "recoveryUnlockPasswordInstructionsTitle": "Set your Catalyst unlock password f\u2028or this device",
-  "recoveryUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you''ll set your Unlock Password for your current device. It''s like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you''ll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
+  "recoveryUnlockPasswordInstructionsSubtitle": "With over 300 trillion possible combinations, your 12 word seed phrase is great for keeping your account safe.  \u2028\u2028But it can be a bit tedious to enter every single time you want to use the app.  \u2028\u2028In this next step, you'll set your Unlock Password for your current device. It's like a shortcut for proving ownership of your Keychain.  \u2028\u2028Whenever you recover your account for the first time on a new device, you'll need to use your Catalyst Keychain to get started. Every time after that, you can use your Unlock Password to quickly regain access.",
   "unlockDialogHeader": "Unlock Catalyst",
   "@unlockDialogHeader": {
     "description": "The header label in unlock dialog."


### PR DESCRIPTION
# Description

The special character `'` needs to be escaped in arb files by prepending another `'` in front of it, otherwise it's interpreted as a start of escaping sequence. Since this would require a lot of attention while adding localizations lets disable escaping but allow relax-syntax which will show special characters as they are if they are not formed properly.

I.e. `{name}` would be considered a localization with name variable, `{name` would just simply display as `{name`.

- docs with available `l10n.yaml` options: https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization#configuring-the-l10n-yaml-file

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
