### PR TITLE
refactor(rust/cardano-chain-follower): update `MultiEraBlock` and `MultiEraTx` to use with `WithRawAuxiliary` suffix

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace =  true
 workspace = true
 
 [dependencies]
-cardano-chain-follower = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "2024-10-15-01" }
+cardano-chain-follower = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", rev = "bb3b10e175114f7171a974809bf60ab6d7bc0a93"}
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "v0.0.3" }
 
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }

--- a/catalyst-gateway/bin/src/db/index/block/certs.rs
+++ b/catalyst-gateway/bin/src/db/index/block/certs.rs
@@ -251,7 +251,7 @@ impl CertInsertQuery {
 
     /// Index the certificates in a transaction.
     pub(crate) fn index(
-        &mut self, txs: &pallas::ledger::traverse::MultiEraTx<'_>, slot_no: u64, txn: i16,
+        &mut self, txs: &pallas::ledger::traverse::MultiEraTxWithRawAuxiliary<'_>, slot_no: u64, txn: i16,
         block: &MultiEraBlock,
     ) {
         #[allow(clippy::match_same_arms)]

--- a/catalyst-gateway/bin/src/db/index/block/txi.rs
+++ b/catalyst-gateway/bin/src/db/index/block/txi.rs
@@ -74,7 +74,7 @@ impl TxiInsertQuery {
     }
 
     /// Index the transaction Inputs.
-    pub(crate) fn index(&mut self, txs: &pallas_traverse::MultiEraTx<'_>, slot_no: u64) {
+    pub(crate) fn index(&mut self, txs: &pallas_traverse::MultiEraTxWithRawAuxiliary<'_>, slot_no: u64) {
         // Index the TXI's.
         for txi in txs.inputs() {
             let txn_hash = txi.hash().to_vec();

--- a/catalyst-gateway/bin/src/db/index/block/txo/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/txo/mod.rs
@@ -136,7 +136,7 @@ impl TxoInsertQuery {
 
     /// Index the transaction Inputs.
     pub(crate) fn index(
-        &mut self, txs: &pallas::ledger::traverse::MultiEraTx<'_>, slot_no: u64, txn_hash: &[u8],
+        &mut self, txs: &pallas::ledger::traverse::MultiEraTxWithRawAuxiliary<'_>, slot_no: u64, txn_hash: &[u8],
         txn: i16,
     ) {
         let txn_id = hex::encode_upper(txn_hash);


### PR DESCRIPTION
# Description

- Updated `cardano-chain-follower` to use this branch ([PR](https://github.com/input-output-hk/catalyst-libs/pull/68)).
- Changed the parts that previously used `MultiEraTx` or `MultiEraBlock` to have suffix `WithRawAuxiliary`.

## Related Issue(s)

Closes [#1037](https://github.com/input-output-hk/catalyst-voices/issues/1037)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
