### PR TITLE
feat(cat-voices): add route guard for account page

### DIFF
--- a/catalyst_voices/lib/routes/guards/composite_route_guard_mixin.dart
+++ b/catalyst_voices/lib/routes/guards/composite_route_guard_mixin.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:catalyst_voices/routes/guards/route_guard.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// A default implementation for [redirect]
+/// that can handle multiple [routeGuards].
+mixin CompositeRouteGuardMixin on GoRouteData {
+  /// An abstract getter to be overriden all [RouteGuard]'s
+  /// that a given route will have.
+  ///
+  /// The guards are called in the order they are returned
+  /// from this method in a FIFO manner.
+  List<RouteGuard> get routeGuards;
+
+  /// A default implementation of route guard logic, it's allowed to override
+  /// it to add custom redirect logic however make sure to call
+  /// `super.redirect()` if your own implementation doesn't redirect anywhere.
+  @override
+  FutureOr<String?> redirect(BuildContext context, GoRouterState state) async {
+    for (final guard in routeGuards) {
+      final location = await guard.redirect(context, state);
+      if (location != null) {
+        return location;
+      }
+    }
+
+    return null;
+  }
+}

--- a/catalyst_voices/lib/routes/guards/composite_route_guard_mixin.dart
+++ b/catalyst_voices/lib/routes/guards/composite_route_guard_mixin.dart
@@ -7,7 +7,7 @@ import 'package:go_router/go_router.dart';
 /// A default implementation for [redirect]
 /// that can handle multiple [routeGuards].
 mixin CompositeRouteGuardMixin on GoRouteData {
-  /// An abstract getter to be overriden all [RouteGuard]'s
+  /// An abstract getter to be overriden by all [RouteGuard]'s
   /// that a given route will have.
   ///
   /// The guards are called in the order they are returned

--- a/catalyst_voices/lib/routes/guards/session_unlocked_guard.dart
+++ b/catalyst_voices/lib/routes/guards/session_unlocked_guard.dart
@@ -1,14 +1,17 @@
 import 'dart:async';
 
-import 'package:catalyst_voices/routes/routing/spaces_route.dart';
+import 'package:catalyst_voices/routes/guards/route_guard.dart';
+import 'package:catalyst_voices/routes/routing/routing.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
-/// A guard mixin which redirects to the discovery page
+/// A guard which redirects to the discovery page
 /// if the keychain is locked.
-mixin UnlockedKeychainGuardMixin on GoRouteData {
+final class SessionUnlockedGuard implements RouteGuard {
+  const SessionUnlockedGuard();
+
   @override
   FutureOr<String?> redirect(BuildContext context, GoRouterState state) {
     final sessionCubit = context.read<SessionCubit>();

--- a/catalyst_voices/lib/routes/guards/unlocked_keychain_guard_mixin.dart
+++ b/catalyst_voices/lib/routes/guards/unlocked_keychain_guard_mixin.dart
@@ -1,0 +1,22 @@
+import 'dart:async';
+
+import 'package:catalyst_voices/routes/routing/spaces_route.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+/// A guard mixin which redirects to the discovery page
+/// if the keychain is locked.
+mixin UnlockedKeychainGuardMixin on GoRouteData {
+  @override
+  FutureOr<String?> redirect(BuildContext context, GoRouterState state) {
+    final sessionCubit = context.read<SessionCubit>();
+    if (sessionCubit.state is ActiveAccountSessionState) {
+      // if already unlocked skip redirection
+      return null;
+    } else {
+      return const DiscoveryRoute().location;
+    }
+  }
+}

--- a/catalyst_voices/lib/routes/routing/account_route.dart
+++ b/catalyst_voices/lib/routes/routing/account_route.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:catalyst_voices/pages/account/account_page.dart';
+import 'package:catalyst_voices/routes/guards/unlocked_keychain_guard_mixin.dart';
 import 'package:catalyst_voices/routes/routing/routes.dart';
 import 'package:catalyst_voices/routes/routing/transitions/fade_page_transition_mixin.dart';
 import 'package:flutter/widgets.dart';
@@ -9,7 +12,8 @@ part 'account_route.g.dart';
 @TypedGoRoute<AccountRoute>(
   path: '/${Routes.currentMilestone}/account',
 )
-final class AccountRoute extends GoRouteData with FadePageTransitionMixin {
+final class AccountRoute extends GoRouteData
+    with FadePageTransitionMixin, UnlockedKeychainGuardMixin {
   const AccountRoute();
 
   @override

--- a/catalyst_voices/lib/routes/routing/account_route.dart
+++ b/catalyst_voices/lib/routes/routing/account_route.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
 import 'package:catalyst_voices/pages/account/account_page.dart';
+import 'package:catalyst_voices/routes/guards/composite_route_guard_mixin.dart';
 import 'package:catalyst_voices/routes/guards/route_guard.dart';
 import 'package:catalyst_voices/routes/guards/session_unlocked_guard.dart';
-import 'package:catalyst_voices/routes/guards/composite_route_guard_mixin.dart';
 import 'package:catalyst_voices/routes/routing/routes.dart';
 import 'package:catalyst_voices/routes/routing/transitions/fade_page_transition_mixin.dart';
 import 'package:flutter/widgets.dart';

--- a/catalyst_voices/lib/routes/routing/account_route.dart
+++ b/catalyst_voices/lib/routes/routing/account_route.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:catalyst_voices/pages/account/account_page.dart';
-import 'package:catalyst_voices/routes/guards/unlocked_keychain_guard_mixin.dart';
+import 'package:catalyst_voices/routes/guards/route_guard.dart';
+import 'package:catalyst_voices/routes/guards/session_unlocked_guard.dart';
+import 'package:catalyst_voices/routes/guards/composite_route_guard_mixin.dart';
 import 'package:catalyst_voices/routes/routing/routes.dart';
 import 'package:catalyst_voices/routes/routing/transitions/fade_page_transition_mixin.dart';
 import 'package:flutter/widgets.dart';
@@ -13,8 +15,11 @@ part 'account_route.g.dart';
   path: '/${Routes.currentMilestone}/account',
 )
 final class AccountRoute extends GoRouteData
-    with FadePageTransitionMixin, UnlockedKeychainGuardMixin {
+    with FadePageTransitionMixin, CompositeRouteGuardMixin {
   const AccountRoute();
+
+  @override
+  List<RouteGuard> get routeGuards => [const SessionUnlockedGuard()];
 
   @override
   Widget build(BuildContext context, GoRouterState state) {


### PR DESCRIPTION
# Description

Adds route guard for account page to prevent by-passing keychain lock by entering the account page url directly in the browser.

## Related Issue(s)

Closes #1045

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
