### PR TITLE
fix(general): .earthlyignore to avoid copying irrelevant files into earthly context

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -80,6 +80,7 @@ drep
 dreps
 dtscalac
 earthfile
+earthlyignore
 Easterling
 eddsa
 Edgedriver

--- a/.earthlyignore
+++ b/.earthlyignore
@@ -11,8 +11,6 @@
 **/*.iml
 **/coverage/
 **/test_reports/
-**/Earthfile
-**/.earthlyignore
 
 # node related
 

--- a/.earthlyignore
+++ b/.earthlyignore
@@ -9,7 +9,10 @@
 **/.flutter-plugins-dependencies
 **/.idea/
 **/*.iml
+**/coverage/
+**/test_reports/
 **/Earthfile
+**/.earthlyignore
 
 # node related
 

--- a/catalyst-gateway/.earthlyignore
+++ b/catalyst-gateway/.earthlyignore
@@ -1,3 +1,0 @@
-# Rust related
-
-**/target

--- a/catalyst-gateway/.earthlyignore
+++ b/catalyst-gateway/.earthlyignore
@@ -1,0 +1,3 @@
+# Rust related
+
+**/target

--- a/catalyst_voices/.earthlyignore
+++ b/catalyst_voices/.earthlyignore
@@ -11,8 +11,6 @@
 **/*.iml
 **/coverage/
 **/test_reports/
-**/Earthfile
-**/.earthlyignore
 
 # node related
 

--- a/catalyst_voices/.earthlyignore
+++ b/catalyst_voices/.earthlyignore
@@ -1,0 +1,20 @@
+# Files and directories created by pub
+
+**/.dart_tool/
+**/.packages
+**/build/
+**/pubspec.lock
+**/pubspec_overrides.yaml
+**/.flutter-plugins
+**/.flutter-plugins-dependencies
+**/.idea/
+**/*.iml
+**/Earthfile
+
+# node related
+
+**/node_modules/
+
+# Rust related
+
+**/target

--- a/catalyst_voices/.earthlyignore
+++ b/catalyst_voices/.earthlyignore
@@ -9,7 +9,10 @@
 **/.flutter-plugins-dependencies
 **/.idea/
 **/*.iml
+**/coverage/
+**/test_reports/
 **/Earthfile
+**/.earthlyignore
 
 # node related
 


### PR DESCRIPTION
# Description

The PR adds `.earthlyignore` files next to relevant `Earthfile` so that local files created during development that constantly change are not copied into the earthly build context because it breaks caching.

The `**/Earthfile` exclusion has been removed because it might be necessary to check spelling in this file so it should not be skipped.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
