### PR TITLE
feat(cat-voices): campaign categories

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/menu/voices_menu.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/menu/voices_menu.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
 
 /// A menu of the app that
@@ -68,7 +69,7 @@ class _MenuButton extends StatelessWidget {
 
     final textStyle = textTheme.bodyMedium?.copyWith(
       color:
-          menuItem.enabled ? textTheme.bodySmall?.color : theme.disabledColor,
+          menuItem.isEnabled ? textTheme.bodySmall?.color : theme.disabledColor,
     );
 
     final children = menuChildren;
@@ -85,7 +86,7 @@ class _MenuButton extends StatelessWidget {
                     child: IconTheme(
                       data: IconThemeData(
                         size: 24,
-                        color: menuItem.enabled
+                        color: menuItem.isEnabled
                             ? textTheme.bodySmall?.color
                             : theme.disabledColor,
                       ),
@@ -138,32 +139,29 @@ class _MenuButton extends StatelessWidget {
 }
 
 /// Model representing Menu Item
-class MenuItem {
-  final int id;
-  final String label;
-  final Widget? icon;
-  final bool showDivider;
-  final bool enabled;
-
-  MenuItem({
-    required this.id,
-    required this.label,
-    this.icon,
-    this.showDivider = false,
-    this.enabled = true,
+final class MenuItem extends BasicPopupMenuItem {
+  const MenuItem({
+    required super.id,
+    required super.label,
+    super.isEnabled = true,
+    super.icon,
+    super.showDivider = false,
   });
 }
 
 /// Model representing Submenu Item
 /// and extending from MenuItem
-class SubMenuItem extends MenuItem {
-  List<MenuItem> children;
+final class SubMenuItem extends MenuItem {
+  final List<MenuItem> children;
 
-  SubMenuItem({
+  const SubMenuItem({
     required super.id,
     required super.label,
     required this.children,
     super.icon,
     super.showDivider,
   });
+
+  @override
+  List<Object?> get props => super.props + [children];
 }

--- a/catalyst_voices/apps/voices/lib/widgets/menu/voices_modal_menu.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/menu/voices_modal_menu.dart
@@ -1,30 +1,11 @@
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
-import 'package:equatable/equatable.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-
-class ModalMenuItem extends Equatable {
-  final String id;
-  final String label;
-  final bool isEnabled;
-
-  const ModalMenuItem({
-    required this.id,
-    required this.label,
-    this.isEnabled = true,
-  });
-
-  @override
-  List<Object?> get props => [
-        id,
-        label,
-        isEnabled,
-      ];
-}
 
 class VoicesModalMenu extends StatelessWidget {
   final String? selectedId;
-  final List<ModalMenuItem> menuItems;
+  final List<MenuItem> menuItems;
   final ValueChanged<String>? onTap;
 
   const VoicesModalMenu({

--- a/catalyst_voices/apps/voices/lib/widgets/modals/campaign/campaign_categories_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/campaign/campaign_categories_tile.dart
@@ -4,6 +4,7 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class CampaignCategoriesTile extends StatefulWidget {
@@ -32,7 +33,7 @@ class _CampaignCategoriesTileState extends State<CampaignCategoriesTile> {
   void didUpdateWidget(covariant CampaignCategoriesTile oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    if (widget.sections != oldWidget.sections) {
+    if (!listEquals(widget.sections, oldWidget.sections)) {
       if (!widget.sections.any((element) => element.id == _selectedSectionId)) {
         _selectedSectionId = widget.sections.firstOrNull?.id;
       }

--- a/catalyst_voices/apps/voices/lib/widgets/modals/campaign/campaign_categories_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/campaign/campaign_categories_tile.dart
@@ -1,11 +1,17 @@
 import 'package:catalyst_voices/widgets/menu/voices_modal_menu.dart';
 import 'package:catalyst_voices/widgets/tiles/voices_expansion_tile.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 class CampaignCategoriesTile extends StatefulWidget {
+  final List<CampaignSection> sections;
+
   const CampaignCategoriesTile({
     super.key,
+    required this.sections,
   });
 
   @override
@@ -13,27 +19,72 @@ class CampaignCategoriesTile extends StatefulWidget {
 }
 
 class _CampaignCategoriesTileState extends State<CampaignCategoriesTile> {
+  String? _selectedSectionId;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _selectedSectionId = widget.sections.firstOrNull?.id;
+  }
+
+  @override
+  void didUpdateWidget(covariant CampaignCategoriesTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.sections != oldWidget.sections) {
+      if (!widget.sections.any((element) => element.id == _selectedSectionId)) {
+        _selectedSectionId = widget.sections.firstOrNull?.id;
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final selectedSection = widget.sections
+        .singleWhereOrNull((element) => element.id == _selectedSectionId);
+
     return VoicesExpansionTile(
       initiallyExpanded: true,
-      title: Text('Campaign Categories'),
+      title: Text(context.l10n.campaignCategories),
       children: [
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _Menu(),
-            SizedBox(width: 32),
-            Expanded(child: _Details()),
+            _Menu(
+              selectedId: _selectedSectionId,
+              menuItems: widget.sections,
+              onTap: _updateSelection,
+            ),
+            const SizedBox(width: 32),
+            Expanded(
+              child: selectedSection != null
+                  ? _Details(section: selectedSection)
+                  : const SizedBox(),
+            ),
           ],
         ),
       ],
     );
   }
+
+  void _updateSelection(String id) {
+    setState(() {
+      _selectedSectionId = id;
+    });
+  }
 }
 
 class _Menu extends StatelessWidget {
-  const _Menu();
+  final String? selectedId;
+  final List<MenuItem> menuItems;
+  final ValueChanged<String> onTap;
+
+  const _Menu({
+    this.selectedId,
+    required this.menuItems,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +98,7 @@ class _Menu extends StatelessWidget {
       children: [
         const SizedBox(height: 16),
         Text(
-          'Cardano Use Cases',
+          context.l10n.cardanoUseCases,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
           style: textTheme.titleSmall?.copyWith(
@@ -56,11 +107,9 @@ class _Menu extends StatelessWidget {
         ),
         const SizedBox(height: 12),
         VoicesModalMenu(
-          selectedId: '1',
-          menuItems: [
-            ModalMenuItem(id: '1', label: 'Concept'),
-            ModalMenuItem(id: '2', label: 'Product'),
-          ],
+          selectedId: selectedId,
+          menuItems: menuItems,
+          onTap: onTap,
         ),
         const SizedBox(height: 16),
       ],
@@ -69,7 +118,11 @@ class _Menu extends StatelessWidget {
 }
 
 class _Details extends StatelessWidget {
-  const _Details();
+  final CampaignSection section;
+
+  const _Details({
+    required this.section,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -83,7 +136,7 @@ class _Details extends StatelessWidget {
       children: [
         const SizedBox(height: 48),
         Text(
-          'Concept',
+          section.label,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
           style: textTheme.headlineMedium?.copyWith(
@@ -92,19 +145,14 @@ class _Details extends StatelessWidget {
         ),
         const SizedBox(height: 24),
         Text(
-          'Section Title',
+          section.title,
           style: textTheme.titleLarge?.copyWith(
             color: colors.textOnPrimaryLevel0,
           ),
         ),
         const SizedBox(height: 16),
         Text(
-          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
-          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
-          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
-          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
-          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
-          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum',
+          section.body,
           style: textTheme.bodyLarge?.copyWith(
             color: colors.textOnPrimaryLevel1,
           ),

--- a/catalyst_voices/apps/voices/lib/widgets/modals/campaign/campaign_categories_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/campaign/campaign_categories_tile.dart
@@ -1,0 +1,116 @@
+import 'package:catalyst_voices/widgets/menu/voices_modal_menu.dart';
+import 'package:catalyst_voices/widgets/tiles/voices_expansion_tile.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:flutter/material.dart';
+
+class CampaignCategoriesTile extends StatefulWidget {
+  const CampaignCategoriesTile({
+    super.key,
+  });
+
+  @override
+  State<CampaignCategoriesTile> createState() => _CampaignCategoriesTileState();
+}
+
+class _CampaignCategoriesTileState extends State<CampaignCategoriesTile> {
+  @override
+  Widget build(BuildContext context) {
+    return VoicesExpansionTile(
+      initiallyExpanded: true,
+      title: Text('Campaign Categories'),
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Menu(),
+            SizedBox(width: 32),
+            Expanded(child: _Details()),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _Menu extends StatelessWidget {
+  const _Menu();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colors = theme.colors;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        Text(
+          'Cardano Use Cases',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: textTheme.titleSmall?.copyWith(
+            color: colors.textOnPrimaryLevel0,
+          ),
+        ),
+        const SizedBox(height: 12),
+        VoicesModalMenu(
+          selectedId: '1',
+          menuItems: [
+            ModalMenuItem(id: '1', label: 'Concept'),
+            ModalMenuItem(id: '2', label: 'Product'),
+          ],
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+}
+
+class _Details extends StatelessWidget {
+  const _Details();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colors = theme.colors;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 48),
+        Text(
+          'Concept',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: textTheme.headlineMedium?.copyWith(
+            color: colors.textOnPrimaryLevel1,
+          ),
+        ),
+        const SizedBox(height: 24),
+        Text(
+          'Section Title',
+          style: textTheme.titleLarge?.copyWith(
+            color: colors.textOnPrimaryLevel0,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
+          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
+          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
+          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
+          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum '
+          'Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum',
+          style: textTheme.bodyLarge?.copyWith(
+            color: colors.textOnPrimaryLevel1,
+          ),
+        ),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/test/widgets/menu/voices_menu_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/menu/voices_menu_test.dart
@@ -9,34 +9,34 @@ import '../../helpers/helpers.dart';
 void main() {
   final menu = [
     MenuItem(
-      id: 1,
+      id: '1',
       label: 'Rename',
       icon: VoicesAssets.icons.pencil.buildIcon(),
     ),
     SubMenuItem(
-      id: 2,
+      id: '2',
       label: 'Move Private Team',
       icon: VoicesAssets.icons.switchHorizontal.buildIcon(),
-      children: [
+      children: const [
         MenuItem(
-          id: 3,
+          id: '3',
           label: 'Team 1: The Vikings',
         ),
         MenuItem(
-          id: 4,
+          id: '4',
           label: 'Team 2: Pure Hearts',
         ),
       ],
     ),
     MenuItem(
-      id: 5,
+      id: '5',
       label: 'Move to public',
       icon: VoicesAssets.icons.switchHorizontal.buildIcon(),
       showDivider: true,
-      enabled: false,
+      isEnabled: false,
     ),
     MenuItem(
-      id: 6,
+      id: '6',
       label: 'Delete',
       icon: VoicesAssets.icons.trash.buildIcon(),
     ),

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -1009,5 +1009,7 @@
         "type": "int"
       }
     }
-  }
+  },
+  "campaignCategories": "Campaign Categories",
+  "cardanoUseCases": "Cardano Use Cases"
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/keychain/vault_keychain.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/keychain/vault_keychain.dart
@@ -127,7 +127,4 @@ final class VaultKeychain extends SecureStorageVault implements Keychain {
 
   @override
   String toString() => 'VaultKeychain[$id]';
-
-  @override
-  List<Object?> get props => [id];
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/secure_storage_vault.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/secure_storage_vault.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_services/src/crypto/crypto_service.dart';
 import 'package:catalyst_voices_services/src/crypto/vault_crypto_service.dart';
 import 'package:catalyst_voices_services/src/storage/storage_string_mixin.dart';
 import 'package:catalyst_voices_services/src/storage/vault/vault.dart';
-import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -14,9 +13,8 @@ const _lockKey = 'LockKey';
 
 /// Implementation of [Vault] that uses [FlutterSecureStorage] as
 /// facade for read/write operations.
-base class SecureStorageVault
-    with StorageAsStringMixin, EquatableMixin
-    implements Vault {
+base class SecureStorageVault with StorageAsStringMixin implements Vault {
+  @override
   final String id;
   @protected
   final FlutterSecureStorage secureStorage;
@@ -171,6 +169,11 @@ base class SecureStorageVault
     }
   }
 
+  @override
+  String toString() {
+    return 'SecureStorageVault{id: $id}';
+  }
+
   /// Allows operation only when [isUnlocked] it true, otherwise returns null.
   ///
   /// Returns value assigned to [key]. May return null if not found for [key].
@@ -246,7 +249,4 @@ base class SecureStorageVault
   void _erase(Uint8List list) {
     list.fillRange(0, list.length, 0);
   }
-
-  @override
-  List<Object?> get props => [id];
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/vault.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/vault.dart
@@ -7,4 +7,6 @@ import 'package:catalyst_voices_services/src/storage/storage.dart';
 ///
 /// In order to unlock [Vault] sufficient [LockFactor] have to be
 /// set via [unlock] that can unlock [LockFactor] from [setLock].
-abstract interface class Vault implements Storage, Lockable {}
+abstract interface class Vault implements Storage, Lockable {
+  String get id;
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_provider_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_provider_test.dart
@@ -24,7 +24,10 @@ void main() {
 
       // Then
       expect(await provider.exists(id), isTrue);
-      expect([keychain], await provider.getAll());
+      expect(
+        [keychain.id],
+        await provider.getAll().then((value) => value.map((e) => e.id)),
+      );
     });
 
     test('calling create twice on keychain will empty previous data', () async {

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_test.dart
@@ -68,7 +68,7 @@ void main() {
       );
     });
 
-    test('are equal when id is matching', () async {
+    test('are not equal when id is matching', () async {
       // Given
       final id = const Uuid().v4();
 
@@ -77,7 +77,7 @@ void main() {
       final vaultTwo = VaultKeychain(id: id);
 
       // Then
-      expect(vaultOne, equals(vaultTwo));
+      expect(vaultOne, isNot(equals(vaultTwo)));
     });
 
     test('metadata dates are in UTC', () async {

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -29,7 +29,7 @@ void main() {
       // Then
       final currentKeychain = service.keychain;
 
-      expect(currentKeychain, keychain);
+      expect(currentKeychain?.id, keychain.id);
     });
 
     test('using different keychain emits update in stream', () async {
@@ -48,8 +48,8 @@ void main() {
         keychainStream,
         emitsInOrder([
           isNull,
-          keychainOne,
-          keychainTwo,
+          predicate<Keychain>((e) => e.id == keychainOne.id),
+          predicate<Keychain>((e) => e.id == keychainTwo.id),
           isNull,
         ]),
       );
@@ -75,7 +75,7 @@ void main() {
       // Then
       final serviceKeychains = await service.keychains;
 
-      expect(serviceKeychains, keychains);
+      expect(serviceKeychains.map((e) => e.id), keychains.map((e) => e.id));
     });
   });
 
@@ -92,7 +92,7 @@ void main() {
       await service.useLastAccount();
 
       // Then
-      expect(service.keychain, expectedKeychain);
+      expect(service.keychain?.id, expectedKeychain.id);
     });
 
     test('use last account does nothing on clear instance', () async {

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/campaign_category.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/campaign_category.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+final class CampaignCategory extends Equatable {
+  final String id;
+  final String name;
+
+  const CampaignCategory({
+    required this.id,
+    required this.name,
+  });
+
+  @override
+  List<Object?> get props => [id, name];
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/campaign_section.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/campaign_section.dart
@@ -1,0 +1,31 @@
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:equatable/equatable.dart';
+
+final class CampaignSection extends Equatable implements MenuItem {
+  @override
+  final String id;
+  final CampaignCategory category;
+  final String title;
+  final String body;
+
+  const CampaignSection({
+    required this.id,
+    required this.category,
+    required this.title,
+    required this.body,
+  });
+
+  @override
+  String get label => category.name;
+
+  @override
+  bool get isEnabled => true;
+
+  @override
+  List<Object?> get props => [
+        id,
+        category,
+        title,
+        body,
+      ];
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
@@ -1,6 +1,10 @@
 export 'authentication/authentication.dart';
+export 'campaign/campaign_category.dart';
+export 'campaign/campaign_section.dart';
 export 'exception/localized_exception.dart';
 export 'exception/localized_unknown_exception.dart';
+export 'menu/menu_item.dart';
+export 'menu/popup_menu_item.dart';
 export 'navigation/sections_list_view_item.dart';
 export 'navigation/sections_navigation.dart';
 export 'proposal/comment.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/menu/menu_item.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/menu/menu_item.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+
+abstract interface class MenuItem {
+  String get id;
+
+  String get label;
+
+  bool get isEnabled;
+}
+
+base class BasicMenuItem extends Equatable implements MenuItem {
+  @override
+  final String id;
+  @override
+  final String label;
+  @override
+  final bool isEnabled;
+
+  const BasicMenuItem({
+    required this.id,
+    required this.label,
+    this.isEnabled = true,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        label,
+        isEnabled,
+      ];
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/menu/popup_menu_item.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/menu/popup_menu_item.dart
@@ -1,0 +1,32 @@
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter/widgets.dart';
+
+abstract interface class PopupMenuItem implements MenuItem {
+  Widget? get icon;
+
+  bool get showDivider;
+}
+
+base class BasicPopupMenuItem extends BasicMenuItem implements PopupMenuItem {
+  @override
+  final Widget? icon;
+
+  @override
+  final bool showDivider;
+
+  const BasicPopupMenuItem({
+    required super.id,
+    required super.label,
+    super.isEnabled,
+    this.icon,
+    this.showDivider = false,
+  });
+
+  @override
+  List<Object?> get props =>
+      super.props +
+      [
+        icon,
+        showDivider,
+      ];
+}

--- a/catalyst_voices/utilities/uikit_example/lib/examples/voices_menu_example.dart
+++ b/catalyst_voices/utilities/uikit_example/lib/examples/voices_menu_example.dart
@@ -71,28 +71,28 @@ class _MenuExample1 extends StatelessWidget {
       onTap: (menuItem) => debugPrint('Selected label: ${menuItem.label}'),
       menuItems: [
         MenuItem(
-          id: 1,
+          id: '1',
           label: 'Rename',
           icon: VoicesAssets.icons.pencil.buildIcon(),
         ),
         SubMenuItem(
-          id: 4,
+          id: '4',
           label: 'Move Private Team',
           icon: VoicesAssets.icons.switchHorizontal.buildIcon(),
-          children: [
-            MenuItem(id: 5, label: 'Team 1: The Vikings'),
-            MenuItem(id: 6, label: 'Team 2: Pure Hearts'),
+          children: const [
+            MenuItem(id: '5', label: 'Team 1: The Vikings'),
+            MenuItem(id: '6', label: 'Team 2: Pure Hearts'),
           ],
         ),
         MenuItem(
-          id: 2,
+          id: '2',
           label: 'Move to public',
           icon: VoicesAssets.icons.switchHorizontal.buildIcon(),
           showDivider: true,
-          enabled: false,
+          isEnabled: false,
         ),
         MenuItem(
-          id: 3,
+          id: '3',
           label: 'Delete',
           icon: VoicesAssets.icons.trash.buildIcon(),
         ),
@@ -118,27 +118,27 @@ class _MenuExample2 extends StatelessWidget {
       onTap: (menuItem) => debugPrint('Selected label: ${menuItem.label}'),
       menuItems: [
         MenuItem(
-          id: 1,
+          id: '1',
           label: 'Rename',
           icon: VoicesAssets.icons.pencil.buildIcon(),
         ),
         SubMenuItem(
-          id: 4,
+          id: '4',
           label: 'Move Private Team',
           icon: VoicesAssets.icons.switchHorizontal.buildIcon(),
-          children: [
-            MenuItem(id: 5, label: 'Team 1: The Vikings'),
-            MenuItem(id: 6, label: 'Team 2: Pure Hearts'),
+          children: const [
+            MenuItem(id: '5', label: 'Team 1: The Vikings'),
+            MenuItem(id: '6', label: 'Team 2: Pure Hearts'),
           ],
         ),
         MenuItem(
-          id: 2,
+          id: '2',
           label: 'Move to public',
           icon: VoicesAssets.icons.switchHorizontal.buildIcon(),
           showDivider: true,
         ),
         MenuItem(
-          id: 3,
+          id: '3',
           label: 'Delete',
           icon: VoicesAssets.icons.trash.buildIcon(),
         ),


### PR DESCRIPTION
# Description

This PR adds new widget component

## Changes

- Interface `MenuItem` and `PopupMenuItem` so other models can be used as items for models widgets.
- Very probably `CampaignSection` should have body as `RichText` body (Markdown?) but atm. using simple String

## Related Issue(s)

Resolves #1185 

## Demo

https://github.com/user-attachments/assets/d0e7ff89-cfb5-4832-8c28-1d1268ce8eee

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
