### PR TITLE
refactor(cat-voices): Changing NoProposals widget to EmptyState

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/empty_state/empty_state.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/empty_state/empty_state.dart
@@ -4,14 +4,18 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 
-class NoProposals extends StatelessWidget {
+class EmptyState extends StatelessWidget {
   final String? title;
   final String? description;
+  final Widget? image;
+  final Widget? imageBackground;
 
-  const NoProposals({
+  const EmptyState({
     super.key,
     this.title,
     this.description,
+    this.image,
+    this.imageBackground,
   });
 
   @override
@@ -23,18 +27,20 @@ class NoProposals extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 64),
         child: Column(
           children: [
-            VoicesImagesScheme(
-              image: CatalystSvgPicture.asset(
-                VoicesAssets.images.noProposalForeground.path,
-              ),
-              background: Container(
-                height: 180,
-                decoration: BoxDecoration(
-                  color: theme.colors.onSurfaceNeutral08,
-                  shape: BoxShape.circle,
+            image ??
+                VoicesImagesScheme(
+                  image: CatalystSvgPicture.asset(
+                    VoicesAssets.images.noProposalForeground.path,
+                  ),
+                  background: imageBackground ??
+                      Container(
+                        height: 180,
+                        decoration: BoxDecoration(
+                          color: theme.colors.onSurfaceNeutral08,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
                 ),
-              ),
-            ),
             const SizedBox(height: 24),
             SizedBox(
               width: 430,
@@ -61,11 +67,11 @@ class NoProposals extends StatelessWidget {
     );
   }
 
-  String _buildTitle(BuildContext context) {
-    return title ?? context.l10n.noProposalStateTitle;
-  }
-
   String _buildDescription(BuildContext context) {
     return description ?? context.l10n.noProposalStateDescription;
+  }
+
+  String _buildTitle(BuildContext context) {
+    return title ?? context.l10n.noProposalStateTitle;
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/images/voices_image_scheme.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/images/voices_image_scheme.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class VoicesImagesScheme extends StatelessWidget {
   final Widget image;
-  final Widget background;
+  final Widget? background;
 
   const VoicesImagesScheme({
     super.key,
@@ -15,7 +15,7 @@ class VoicesImagesScheme extends StatelessWidget {
     return Stack(
       alignment: Alignment.center,
       children: [
-        background,
+        if (background != null) background!,
         image,
       ],
     );

--- a/catalyst_voices/apps/voices/test/widgets/empty_state/empty_state_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/empty_state/empty_state_test.dart
@@ -1,4 +1,4 @@
-import 'package:catalyst_voices/widgets/proposals/no_proposals.dart';
+import 'package:catalyst_voices/widgets/empty_state/empty_state.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +10,7 @@ void main() {
   group('NoProposals Widget Tests', () {
     testWidgets('Renders correctly with default values', (tester) async {
       await tester.pumpApp(
-        const NoProposals(),
+        const EmptyState(),
       );
       await tester.pumpAndSettle();
 
@@ -28,7 +28,7 @@ void main() {
 
     testWidgets('Renders correctly with custom values', (tester) async {
       await tester.pumpApp(
-        const NoProposals(
+        const EmptyState(
           title: 'Custom Title',
           description: 'Custom Description',
         ),
@@ -45,7 +45,7 @@ void main() {
           VoicesColorScheme.optional(textOnPrimaryLevel1: Colors.red);
       await tester.pumpApp(
         voicesColors: colors,
-        const NoProposals(
+        const EmptyState(
           title: 'Custom Title',
           description: 'Custom Description',
         ),
@@ -75,7 +75,7 @@ void main() {
       'Proposal image changes depending on theme brightness',
       (tester) async {
         // Given
-        const widget = NoProposals();
+        const widget = EmptyState();
 
         // When - Light theme
         await tester.pumpApp(

--- a/catalyst_voices/apps/voices/test/widgets/empty_state/empty_state_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/empty_state/empty_state_test.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices/widgets/empty_state/empty_state.dart';
+import 'package:catalyst_voices/widgets/images/voices_image_scheme.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
@@ -112,5 +113,19 @@ void main() {
         );
       },
     );
+
+    testWidgets('Renders correctly with custom image', (tester) async {
+      await tester.pumpApp(
+        EmptyState(
+          image: CatalystSvgPicture.asset(
+            VoicesAssets.images.noProposalForeground.path,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CatalystSvgPicture), findsOneWidget);
+      expect(find.byType(VoicesImagesScheme), findsNothing);
+    });
   });
 }

--- a/catalyst_voices/apps/voices/test/widgets/empty_state/empty_state_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/empty_state/empty_state_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../helpers/helpers.dart';
 
 void main() {
-  group('NoProposals Widget Tests', () {
+  group('EmptyState Widget Tests', () {
     testWidgets('Renders correctly with default values', (tester) async {
       await tester.pumpApp(
         const EmptyState(),


### PR DESCRIPTION
# Description

I transform NoProposals widget to EmptyState to more usability.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
