### PR TITLE
fix(cat-voices): equatable lint issue fix

### DIFF
--- a/catalyst_voices/apps/voices/pubspec.yaml
+++ b/catalyst_voices/apps/voices/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
     path: ../../packages/internal/catalyst_voices_view_models
   collection: ^1.18.0
   dotted_border: ^2.1.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   file_picker: ^8.0.7
   flutter:
     sdk: flutter

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -92,7 +92,7 @@ command:
       cryptography: ^2.7.0
       dotted_border: ^2.1.0
       ed25519_hd_key: ^2.3.0
-      equatable: ^2.0.5
+      equatable: ^2.0.7
       ffi: ^2.1.0
       ffigen: ^11.0.0
       file_picker: ^8.0.7

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   catalyst_voices_view_models:
     path: ../catalyst_voices_view_models
   collection: ^1.18.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.5

--- a/catalyst_voices/packages/internal/catalyst_voices_models/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   catalyst_cardano_web: ^0.3.0
   collection: ^1.18.0
   convert: ^3.1.1
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   meta: ^1.10.0
   password_strength: ^0.2.0
 

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/keychain/vault_keychain.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/keychain/vault_keychain.dart
@@ -127,7 +127,4 @@ final class VaultKeychain extends SecureStorageVault implements Keychain {
 
   @override
   String toString() => 'VaultKeychain[$id]';
-
-  @override
-  List<Object?> get props => [id];
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/secure_storage_vault.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/secure_storage_vault.dart
@@ -14,6 +14,7 @@ const _lockKey = 'LockKey';
 /// Implementation of [Vault] that uses [FlutterSecureStorage] as
 /// facade for read/write operations.
 base class SecureStorageVault with StorageAsStringMixin implements Vault {
+  @override
   final String id;
   @protected
   final FlutterSecureStorage secureStorage;

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/secure_storage_vault.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/secure_storage_vault.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_services/src/crypto/crypto_service.dart';
 import 'package:catalyst_voices_services/src/crypto/vault_crypto_service.dart';
 import 'package:catalyst_voices_services/src/storage/storage_string_mixin.dart';
 import 'package:catalyst_voices_services/src/storage/vault/vault.dart';
-import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
@@ -14,9 +13,7 @@ const _lockKey = 'LockKey';
 
 /// Implementation of [Vault] that uses [FlutterSecureStorage] as
 /// facade for read/write operations.
-base class SecureStorageVault
-    with StorageAsStringMixin, EquatableMixin
-    implements Vault {
+base class SecureStorageVault with StorageAsStringMixin implements Vault {
   final String id;
   @protected
   final FlutterSecureStorage secureStorage;
@@ -171,6 +168,11 @@ base class SecureStorageVault
     }
   }
 
+  @override
+  String toString() {
+    return 'SecureStorageVault{id: $id}';
+  }
+
   /// Allows operation only when [isUnlocked] it true, otherwise returns null.
   ///
   /// Returns value assigned to [key]. May return null if not found for [key].
@@ -246,7 +248,4 @@ base class SecureStorageVault
   void _erase(Uint8List list) {
     list.fillRange(0, list.length, 0);
   }
-
-  @override
-  List<Object?> get props => [id];
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/vault.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/storage/vault/vault.dart
@@ -7,4 +7,6 @@ import 'package:catalyst_voices_services/src/storage/storage.dart';
 ///
 /// In order to unlock [Vault] sufficient [LockFactor] have to be
 /// set via [unlock] that can unlock [LockFactor] from [setLock].
-abstract interface class Vault implements Storage, Lockable {}
+abstract interface class Vault implements Storage, Lockable {
+  String get id;
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_services/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   convert: ^3.1.1
   cryptography: ^2.7.0
   ed25519_hd_key: ^2.3.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   flutter_secure_storage: ^9.2.2

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_provider_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_provider_test.dart
@@ -24,7 +24,10 @@ void main() {
 
       // Then
       expect(await provider.exists(id), isTrue);
-      expect([keychain], await provider.getAll());
+      expect(
+        [keychain.id],
+        await provider.getAll().then((value) => value.map((e) => e.id)),
+      );
     });
 
     test('calling create twice on keychain will empty previous data', () async {

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/keychain/vault_keychain_test.dart
@@ -68,7 +68,7 @@ void main() {
       );
     });
 
-    test('are equal when id is matching', () async {
+    test('are not equal when id is matching', () async {
       // Given
       final id = const Uuid().v4();
 
@@ -77,7 +77,7 @@ void main() {
       final vaultTwo = VaultKeychain(id: id);
 
       // Then
-      expect(vaultOne, equals(vaultTwo));
+      expect(vaultOne, isNot(equals(vaultTwo)));
     });
 
     test('metadata dates are in UTC', () async {

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -29,7 +29,7 @@ void main() {
       // Then
       final currentKeychain = service.keychain;
 
-      expect(currentKeychain, keychain);
+      expect(currentKeychain?.id, keychain.id);
     });
 
     test('using different keychain emits update in stream', () async {
@@ -48,8 +48,8 @@ void main() {
         keychainStream,
         emitsInOrder([
           isNull,
-          keychainOne,
-          keychainTwo,
+          predicate<Keychain>((e) => e.id == keychainOne.id),
+          predicate<Keychain>((e) => e.id == keychainTwo.id),
           isNull,
         ]),
       );
@@ -75,7 +75,7 @@ void main() {
       // Then
       final serviceKeychains = await service.keychains;
 
-      expect(serviceKeychains, keychains);
+      expect(serviceKeychains.map((e) => e.id), keychains.map((e) => e.id));
     });
   });
 
@@ -92,7 +92,7 @@ void main() {
       await service.useLastAccount();
 
       // Then
-      expect(service.keychain, expectedKeychain);
+      expect(service.keychain?.id, expectedKeychain.id);
     });
 
     test('use last account does nothing on clear instance', () async {

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../catalyst_voices_localization
   catalyst_voices_models:
     path: ../catalyst_voices_models
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   formz: ^0.7.0

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   cbor: ^6.2.0
   convert: ^3.1.1
   cupertino_icons: ^1.0.6
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
 

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   catalyst_cardano_serialization: ^0.4.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.7

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   cbor: ^6.2.0
   convert: ^3.1.1
   cryptography: ^2.7.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   pinenacl: ^0.6.0
   ulid: ^2.0.0
 

--- a/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression_platform_interface/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.7

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   cbor: ^6.2.0
   convert: ^3.1.1
   cryptography: ^2.7.0
-  equatable: ^2.0.5
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   flutter_rust_bridge: 2.5.1


### PR DESCRIPTION
# Description

Fixes broken lint in Catalyst Voices. This has been already [fixed in MVE3](https://github.com/input-output-hk/catalyst-voices/pull/1251/files#diff-c31fec6393780fb65b13601aa23ce31c94b845b8b04013ddb182aca8655edd54L251) but we need to fix in `main` too before we can merge `main` branch into `mve3` due to required checks (like static-analysis).

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
