### PR TITLE
fix(cat-voices): update key derivation path

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_role.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_role.dart
@@ -1,18 +1,18 @@
 enum AccountRole {
   /// An account role that is assigned to every account.
   /// Allows to vote for proposals.
-  voter(roleNumber: 0),
+  voter(number: 0),
 
   /// A delegated representative that can vote on behalf of other accounts.
-  drep(roleNumber: 1),
+  drep(number: 1),
 
   /// An account role that can create new proposals.
-  proposer(roleNumber: 3);
+  proposer(number: 3);
 
   /// The RBAC specified role number.
-  final int roleNumber;
+  final int number;
 
-  const AccountRole({required this.roleNumber});
+  const AccountRole({required this.number});
 
   /// Returns the role which is assigned to every user.
   static AccountRole get root => voter;

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_role.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_role.dart
@@ -1,13 +1,13 @@
 enum AccountRole {
+  /// An account role that is assigned to every account.
+  /// Allows to vote for proposals.
   voter(roleNumber: 0),
 
-  // TODO(dtscalac): the RBAC specification doesn't define yet the role number
-  // for the proposer, replace this arbitrary number when it's specified.
-  proposer(roleNumber: 1),
+  /// A delegated representative that can vote on behalf of other accounts.
+  drep(roleNumber: 1),
 
-  // TODO(dtscalac): the RBAC specification doesn't define yet the role number
-  // for the drep, replace this arbitrary number when it's specified.
-  drep(roleNumber: 2);
+  /// An account role that can create new proposals.
+  proposer(roleNumber: 3);
 
   /// The RBAC specified role number.
   final int roleNumber;

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
@@ -44,9 +44,7 @@ final class KeyDerivation {
 
   /// The path feed into key derivation algorithm
   /// to generate a key pair from a seed phrase.
-  ///
-  // TODO(dtscalac): update when RBAC specifies it
   String _roleKeyDerivationPath(AccountRole role) {
-    return "m/${role.roleNumber}'/1234'";
+    return "m/508'/139'/0'/${role.roleNumber}/0";
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
@@ -6,7 +6,7 @@ final class KeyDerivation {
   /// See: https://github.com/input-output-hk/catalyst-voices/pull/1300
   static const int _purpose = 508;
   static const int _type = 139;
-static const int _account = 0; // Future Use
+  static const int _account = 0; // Future Use
   final CatalystKeyDerivation _keyDerivation;
 
   const KeyDerivation(this._keyDerivation);

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
@@ -3,6 +3,9 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 
 /// Derives key pairs from a seed phrase.
 final class KeyDerivation {
+  static const int _purpose = 508;
+  static const int _type = 139;
+
   final CatalystKeyDerivation _keyDerivation;
 
   const KeyDerivation(this._keyDerivation);
@@ -47,6 +50,6 @@ final class KeyDerivation {
   ///
   /// See: https://github.com/input-output-hk/catalyst-voices/pull/1300
   String _roleKeyDerivationPath(AccountRole role) {
-    return "m/508'/139'/0'/${role.roleNumber}/0";
+    return "m/$_purpose'/$_type'/0'/${role.number}/0";
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
@@ -44,6 +44,8 @@ final class KeyDerivation {
 
   /// The path feed into key derivation algorithm
   /// to generate a key pair from a seed phrase.
+  ///
+  /// See: https://github.com/input-output-hk/catalyst-voices/pull/1300
   String _roleKeyDerivationPath(AccountRole role) {
     return "m/508'/139'/0'/${role.roleNumber}/0";
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
@@ -3,6 +3,7 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 
 /// Derives key pairs from a seed phrase.
 final class KeyDerivation {
+  /// See: https://github.com/input-output-hk/catalyst-voices/pull/1300
   static const int _purpose = 508;
   static const int _type = 139;
 
@@ -47,8 +48,6 @@ final class KeyDerivation {
 
   /// The path feed into key derivation algorithm
   /// to generate a key pair from a seed phrase.
-  ///
-  /// See: https://github.com/input-output-hk/catalyst-voices/pull/1300
   String _roleKeyDerivationPath(AccountRole role) {
     return "m/$_purpose'/$_type'/0'/${role.number}/0";
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/crypto/key_derivation.dart
@@ -6,7 +6,7 @@ final class KeyDerivation {
   /// See: https://github.com/input-output-hk/catalyst-voices/pull/1300
   static const int _purpose = 508;
   static const int _type = 139;
-
+static const int _account = 0; // Future Use
   final CatalystKeyDerivation _keyDerivation;
 
   const KeyDerivation(this._keyDerivation);
@@ -49,6 +49,6 @@ final class KeyDerivation {
   /// The path feed into key derivation algorithm
   /// to generate a key pair from a seed phrase.
   String _roleKeyDerivationPath(AccountRole role) {
-    return "m/$_purpose'/$_type'/0'/${role.number}/0";
+    return "m/$_purpose'/$_type'/$_account'/${role.number}/0";
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_transaction_builder.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_transaction_builder.dart
@@ -82,7 +82,7 @@ final class RegistrationTransactionBuilder {
           // TODO(dtscalac): when RBAC specification will define other roles
           // they should be registered here
           RoleData(
-            roleNumber: AccountRole.root.roleNumber,
+            roleNumber: AccountRole.root.number,
             roleSigningKey: const LocalKeyReference(
               keyType: LocalKeyReferenceType.x509Certs,
               offset: 0,

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/crypto/key_derivation_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/crypto/key_derivation_test.dart
@@ -31,7 +31,7 @@ void main() {
       for (final role in AccountRole.values) {
         final keyPair = await keyDerivation.deriveKeyPair(
           masterKey: masterKey,
-          path: "m/${role.roleNumber}'/1234'",
+          path: "m/${role.number}'/1234'",
         );
         expect(keyPair, isNotNull);
       }


### PR DESCRIPTION
# Description

Updates key derivation path based on new specification: https://github.com/input-output-hk/catalyst-voices/pull/1300

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
