### PR TITLE
feat(cat-voices): admin preview tools

### DIFF
--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -254,6 +254,7 @@ seedphrase
 sendfile
 servernum
 serviceworker
+shrunked
 slotno
 sqlfluff
 SRCROOT

--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -254,7 +254,6 @@ seedphrase
 sendfile
 servernum
 serviceworker
-shrunked
 slotno
 sqlfluff
 SRCROOT

--- a/.config/dictionaries/project.dic
+++ b/.config/dictionaries/project.dic
@@ -278,6 +278,7 @@ testplan
 testunit
 thiserror
 thollander
+Timelapse
 timelike
 Toastify
 todos

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -1,12 +1,16 @@
+import 'dart:async';
+
 import 'package:catalyst_voices/common/ext/space_ext.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// A draggable [CampaignAdminToolsDialog],
 /// should be used as a child of a [Stack].
@@ -320,7 +324,7 @@ class _EventItem extends StatelessWidget {
             Expanded(
               child: Text(
                 _text(context.l10n),
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                       color: color,
                     ),
               ),
@@ -328,7 +332,7 @@ class _EventItem extends StatelessWidget {
             if (isActive)
               Text(
                 context.l10n.active.toUpperCase(),
-                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
                       fontWeight: FontWeight.w500,
                       fontSize: 11,
                       color: color,
@@ -396,16 +400,102 @@ class _EventTimelapseControls extends StatelessWidget {
   }
 }
 
-class _ViewsTab extends StatelessWidget {
+class _ViewsTab extends StatefulWidget {
   const _ViewsTab();
 
   @override
+  State<_ViewsTab> createState() => _ViewsTabState();
+}
+
+class _ViewsTabState extends State<_ViewsTab> {
+  @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 50,
-      height: 50,
-      color: Colors.blue,
+    return Material(
+      color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              context.l10n.userAuthenticationState,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 16),
+            BlocBuilder<SessionCubit, SessionState>(
+              builder: (context, state) {
+                return VoicesSegmentedButton<_UserAuthState>(
+                  segments: [
+                    for (final userState in _UserAuthState.values)
+                      ButtonSegment(
+                        value: userState,
+                        label: Text(userState.name(context.l10n)),
+                      ),
+                  ],
+                  selected: {_UserAuthState.fromSessionState(state)},
+                  onChanged: (selected) {
+                    unawaited(_switchToState(selected.first));
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
     );
+  }
+
+  Future<void> _switchToState(_UserAuthState state) async {
+    switch (state) {
+      case _UserAuthState.actor:
+        await _switchToActor();
+      case _UserAuthState.guest:
+        await _switchToGuest();
+      case _UserAuthState.visitor:
+        await _switchToVisitor();
+    }
+  }
+
+  Future<void> _switchToActor() async {
+    final sessionBloc = context.read<SessionCubit>();
+    await sessionBloc
+        .switchToDummyAccount()
+        .then((_) => sessionBloc.unlock(SessionCubit.dummyUnlockFactor));
+  }
+
+  Future<void> _switchToGuest() async {
+    final sessionBloc = context.read<SessionCubit>();
+    if (sessionBloc.state is ActiveAccountSessionState) {
+      await sessionBloc.lock();
+    } else if (sessionBloc.state is VisitorSessionState) {
+      await sessionBloc.switchToDummyAccount().then((_) => sessionBloc.lock());
+    }
+  }
+
+  Future<void> _switchToVisitor() async {
+    await context.read<SessionCubit>().removeKeychain();
+  }
+}
+
+enum _UserAuthState {
+  actor,
+  guest,
+  visitor;
+
+  factory _UserAuthState.fromSessionState(SessionState state) {
+    return switch (state) {
+      VisitorSessionState() => _UserAuthState.visitor,
+      GuestSessionState() => _UserAuthState.guest,
+      ActiveAccountSessionState() => _UserAuthState.actor,
+    };
+  }
+
+  String name(VoicesLocalizations l10n) {
+    return switch (this) {
+      _UserAuthState.actor => l10n.actor,
+      _UserAuthState.guest => l10n.guest,
+      _UserAuthState.visitor => l10n.visitor,
+    };
   }
 }
 

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -1,16 +1,14 @@
-import 'dart:async';
-
 import 'package:catalyst_voices/common/ext/space_ext.dart';
+import 'package:catalyst_voices/pages/campaign/admin_tools/campaign_admin_tools_events.dart';
+import 'package:catalyst_voices/pages/campaign/admin_tools/campaign_admin_tools_views.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
-import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// A draggable [CampaignAdminToolsDialog],
 /// should be used as a child of a [Stack].
@@ -224,8 +222,8 @@ class _Tabs extends StatelessWidget {
           Expanded(
             child: TabBarStackView(
               children: [
-                _EventsTab(),
-                _ViewsTab(),
+                CampaignAdminToolsEventsTab(),
+                CampaignAdminToolsViewsTab(),
               ],
             ),
           ),
@@ -252,250 +250,6 @@ class _TabBar extends StatelessWidget {
         ),
       ],
     );
-  }
-}
-
-class _EventsTab extends StatelessWidget {
-  const _EventsTab();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Column(
-      children: [
-        Expanded(child: _CampaignStatusChooser()),
-        _EventTimelapseControls(),
-      ],
-    );
-  }
-}
-
-class _CampaignStatusChooser extends StatelessWidget {
-  const _CampaignStatusChooser();
-
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
-      child: Column(
-        children: [
-          const SizedBox(height: 8),
-          for (final status in CampaignStatus.values)
-            // TODO(dtscalac): store active one somewhere
-            _EventItem(
-              status: status,
-              isActive: status == CampaignStatus.draft,
-              onTap: () {},
-            ),
-          const SizedBox(height: 8),
-        ],
-      ),
-    );
-  }
-}
-
-class _EventItem extends StatelessWidget {
-  final CampaignStatus status;
-  final bool isActive;
-  final VoidCallback onTap;
-
-  const _EventItem({
-    required this.status,
-    required this.isActive,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final color = isActive
-        ? Theme.of(context).colorScheme.primary
-        : Theme.of(context).colors.textOnPrimary;
-
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 12, 24, 12),
-        child: Row(
-          children: [
-            _icon.buildIcon(
-              size: 24,
-              color: color,
-            ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Text(
-                _text(context.l10n),
-                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                      color: color,
-                    ),
-              ),
-            ),
-            if (isActive)
-              Text(
-                context.l10n.active.toUpperCase(),
-                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                      fontWeight: FontWeight.w500,
-                      fontSize: 11,
-                      color: color,
-                    ),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  SvgGenImage get _icon => switch (status) {
-        CampaignStatus.draft => VoicesAssets.icons.clock,
-        CampaignStatus.live => VoicesAssets.icons.flag,
-        CampaignStatus.completed => VoicesAssets.icons.calendar,
-      };
-
-  String _text(VoicesLocalizations l10n) => switch (status) {
-        CampaignStatus.draft => l10n.campaignPreviewEventBefore,
-        CampaignStatus.live => l10n.campaignPreviewEventDuring,
-        CampaignStatus.completed => l10n.campaignPreviewEventAfter,
-      };
-}
-
-class _EventTimelapseControls extends StatelessWidget {
-  const _EventTimelapseControls();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Row(
-        children: [
-          Expanded(
-            child: VoicesTextButton(
-              leading: VoicesAssets.icons.rewind.buildIcon(),
-              child: Text(context.l10n.previous),
-              // TODO(dtscalac): implement button action
-              onTap: () {},
-            ),
-          ),
-          Container(
-            width: 60,
-            height: 56,
-            margin: const EdgeInsets.symmetric(horizontal: 16),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(8),
-              color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
-            ),
-            alignment: Alignment.center,
-            // TODO(dtscalac): implement timer ticking
-            child: const Text('-5s'),
-          ),
-          Expanded(
-            child: VoicesTextButton(
-              leading: VoicesAssets.icons.fastForward.buildIcon(),
-              child: Text(context.l10n.next),
-              // TODO(dtscalac): implement button action
-              onTap: () {},
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ViewsTab extends StatefulWidget {
-  const _ViewsTab();
-
-  @override
-  State<_ViewsTab> createState() => _ViewsTabState();
-}
-
-class _ViewsTabState extends State<_ViewsTab> {
-  @override
-  Widget build(BuildContext context) {
-    return Material(
-      color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              context.l10n.userAuthenticationState,
-              style: Theme.of(context).textTheme.labelLarge,
-            ),
-            const SizedBox(height: 16),
-            BlocBuilder<SessionCubit, SessionState>(
-              builder: (context, state) {
-                return VoicesSegmentedButton<_UserAuthState>(
-                  segments: [
-                    for (final userState in _UserAuthState.values)
-                      ButtonSegment(
-                        value: userState,
-                        label: Text(userState.name(context.l10n)),
-                      ),
-                  ],
-                  selected: {_UserAuthState.fromSessionState(state)},
-                  onChanged: (selected) {
-                    unawaited(_switchToState(selected.first));
-                  },
-                );
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Future<void> _switchToState(_UserAuthState state) async {
-    switch (state) {
-      case _UserAuthState.actor:
-        await _switchToActor();
-      case _UserAuthState.guest:
-        await _switchToGuest();
-      case _UserAuthState.visitor:
-        await _switchToVisitor();
-    }
-  }
-
-  Future<void> _switchToActor() async {
-    final sessionBloc = context.read<SessionCubit>();
-    await sessionBloc
-        .switchToDummyAccount()
-        .then((_) => sessionBloc.unlock(SessionCubit.dummyUnlockFactor));
-  }
-
-  Future<void> _switchToGuest() async {
-    final sessionBloc = context.read<SessionCubit>();
-    if (sessionBloc.state is ActiveAccountSessionState) {
-      await sessionBloc.lock();
-    } else if (sessionBloc.state is VisitorSessionState) {
-      await sessionBloc.switchToDummyAccount().then((_) => sessionBloc.lock());
-    }
-  }
-
-  Future<void> _switchToVisitor() async {
-    await context.read<SessionCubit>().removeKeychain();
-  }
-}
-
-enum _UserAuthState {
-  actor,
-  guest,
-  visitor;
-
-  factory _UserAuthState.fromSessionState(SessionState state) {
-    return switch (state) {
-      VisitorSessionState() => _UserAuthState.visitor,
-      GuestSessionState() => _UserAuthState.guest,
-      ActiveAccountSessionState() => _UserAuthState.actor,
-    };
-  }
-
-  String name(VoicesLocalizations l10n) {
-    return switch (this) {
-      _UserAuthState.actor => l10n.actor,
-      _UserAuthState.guest => l10n.guest,
-      _UserAuthState.visitor => l10n.visitor,
-    };
   }
 }
 

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 /// A draggable [CampaignAdminToolsDialog],
 /// should be used as a child of a [Stack].
 ///
-/// Initially shown at bottom-left corner with [initialPadding] offset.
+/// Initially shown at bottom-left corner with [initialOffset] offset.
 class DraggableCampaignAdminToolsDialog extends StatefulWidget {
   /// The key for the [CampaignAdminToolsDialog] to make sure it's state
   /// is kept when a user keeps dragging it.
@@ -32,11 +32,7 @@ class DraggableCampaignAdminToolsDialog extends StatefulWidget {
   final VoidCallback onClose;
 
   /// The initial offset from bottom-left for the dialog.
-  ///
-  /// The widget should be used inside a stack so left/bottom properties
-  /// from [EdgeInsets] correspond to left/bottom properties
-  /// from the related [Positioned] widget.
-  final EdgeInsets initialPadding;
+  final Offset initialOffset;
 
   const DraggableCampaignAdminToolsDialog({
     super.key,
@@ -44,7 +40,7 @@ class DraggableCampaignAdminToolsDialog extends StatefulWidget {
     required this.selectedSpace,
     required this.onSpaceSelected,
     required this.onClose,
-    this.initialPadding = const EdgeInsets.only(left: 32, bottom: 32),
+    this.initialOffset = const Offset(32, 32),
   });
 
   @override
@@ -54,7 +50,7 @@ class DraggableCampaignAdminToolsDialog extends StatefulWidget {
 
 class _DraggableCampaignAdminToolsDialogState
     extends State<DraggableCampaignAdminToolsDialog> {
-  late Offset _position;
+  Offset _position = Offset.infinite;
   late Size _screenSize;
 
   @override
@@ -62,12 +58,30 @@ class _DraggableCampaignAdminToolsDialogState
     super.didChangeDependencies();
 
     _screenSize = MediaQuery.sizeOf(context);
-    _position = Offset(
-      widget.initialPadding.left,
-      _screenSize.height -
-          CampaignAdminToolsDialog._height -
-          widget.initialPadding.bottom,
-    );
+
+    if (_position.isInfinite) {
+      // initialize it for the first time
+      _position = Offset(
+        widget.initialOffset.dx,
+        _screenSize.height -
+            CampaignAdminToolsDialog._height -
+            widget.initialOffset.dy,
+      );
+    } else {
+      // clamp it so that it fits into the screen
+      // in case user shrinks the app window
+
+      _position = Offset(
+        _position.dx.clamp(
+          0,
+          _screenSize.width - CampaignAdminToolsDialog._width,
+        ),
+        _position.dy.clamp(
+          0,
+          _screenSize.height - CampaignAdminToolsDialog._height,
+        ),
+      );
+    }
   }
 
   @override

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -108,7 +108,7 @@ class _DraggableCampaignAdminToolsDialogState
   }
 
   /// Makes sure the dialog would fit into a screen window
-  /// even if the window gets shrunked, etc.
+  /// even if the window gets shrunk, etc.
   Offset _clampIntoScreenBounds(Offset offset) {
     return Offset(
       offset.dx.clamp(

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -1,0 +1,465 @@
+import 'package:catalyst_voices/common/ext/space_ext.dart';
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// A draggable [CampaignAdminToolsDialog],
+/// should be used as a child of a [Stack].
+///
+/// Initially shown at bottom-left corner with [initialPadding] offset.
+class DraggableCampaignAdminToolsDialog extends StatefulWidget {
+  /// The key for the [CampaignAdminToolsDialog] to make sure it's state
+  /// is kept when a user keeps dragging it.
+  ///
+  /// The state might include currently open tab from [TabBar],
+  /// scroll position, etc.
+  final GlobalKey dialogKey;
+
+  /// See [CampaignAdminToolsDialog.selectedSpace].
+  final Space selectedSpace;
+
+  /// See [CampaignAdminToolsDialog.onSpaceSelected].
+  final ValueChanged<Space> onSpaceSelected;
+
+  /// See [CampaignAdminToolsDialog.onClose].
+  final VoidCallback onClose;
+
+  /// The initial offset from bottom-left for the dialog.
+  ///
+  /// The widget should be used inside a stack so left/bottom properties
+  /// from [EdgeInsets] correspond to left/bottom properties
+  /// from the related [Positioned] widget.
+  final EdgeInsets initialPadding;
+
+  const DraggableCampaignAdminToolsDialog({
+    super.key,
+    required this.dialogKey,
+    required this.selectedSpace,
+    required this.onSpaceSelected,
+    required this.onClose,
+    this.initialPadding = const EdgeInsets.only(left: 32, bottom: 32),
+  });
+
+  @override
+  State<DraggableCampaignAdminToolsDialog> createState() =>
+      _DraggableCampaignAdminToolsDialogState();
+}
+
+class _DraggableCampaignAdminToolsDialogState
+    extends State<DraggableCampaignAdminToolsDialog> {
+  late Offset _position;
+  late Size _screenSize;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _screenSize = MediaQuery.sizeOf(context);
+    _position = Offset(
+      widget.initialPadding.left,
+      _screenSize.height -
+          CampaignAdminToolsDialog._height -
+          widget.initialPadding.bottom,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget child = CampaignAdminToolsDialog(
+      key: widget.dialogKey,
+      selectedSpace: widget.selectedSpace,
+      onSpaceSelected: widget.onSpaceSelected,
+      onClose: widget.onClose,
+    );
+
+    return Positioned(
+      left: _position.dx,
+      top: _position.dy,
+      child: Draggable(
+        onDragUpdate: _onDragUpdate,
+        childWhenDragging: const Offstage(),
+        feedback: child,
+        child: child,
+      ),
+    );
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    final newPosition = _position + details.delta;
+    final clampedPosition = Offset(
+      newPosition.dx.clamp(
+        0,
+        _screenSize.width - CampaignAdminToolsDialog._width,
+      ),
+      newPosition.dy.clamp(
+        0,
+        _screenSize.height - CampaignAdminToolsDialog._height,
+      ),
+    );
+
+    if (_position != clampedPosition) {
+      setState(() {
+        _position = clampedPosition;
+      });
+    }
+  }
+}
+
+/// The campaign admin tools dialog which supports
+/// mocking different campaign and user states.
+///
+/// With it you can mock the keychain, mock the
+/// campaign state or quickly switch between states.
+class CampaignAdminToolsDialog extends StatelessWidget {
+  /// The keyboard shortcut to activate the admin tools.
+  ///
+  /// You must handle the shortcut in the parent widget,
+  /// it is added here for convenience.
+  static final ShortcutActivator shortcut = LogicalKeySet(
+    LogicalKeyboardKey.control,
+    LogicalKeyboardKey.shift,
+    LogicalKeyboardKey.keyA,
+  );
+
+  static const double _width = 360;
+  static const double _height = 480;
+
+  /// The current selected [Space].
+  /// Admin tools reuse the currently selected space from the navigation drawer.
+  final Space selectedSpace;
+
+  /// Callback to notify when [Space] changes.
+  /// In response to this event the app should navigate to given space.
+  final ValueChanged<Space> onSpaceSelected;
+
+  /// Called when the user wants to close the admin tools.
+  final VoidCallback onClose;
+
+  const CampaignAdminToolsDialog({
+    super.key,
+    required this.selectedSpace,
+    required this.onSpaceSelected,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: _width,
+      height: _height,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1White,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Material(
+        type: MaterialType.transparency,
+        child: Column(
+          children: [
+            _Header(onClose: onClose),
+            const Expanded(child: _Tabs()),
+            const Divider(
+              height: 0,
+              indent: 0,
+              endIndent: 0,
+            ),
+            _Footer(
+              selectedSpace: selectedSpace,
+              onSpaceSelected: onSpaceSelected,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final VoidCallback onClose;
+
+  const _Header({
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 12, 12, 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              context.l10n.campaignPreviewTitle,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          XButton(onTap: onClose),
+        ],
+      ),
+    );
+  }
+}
+
+class _Tabs extends StatelessWidget {
+  const _Tabs();
+
+  @override
+  Widget build(BuildContext context) {
+    return const DefaultTabController(
+      length: 2,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _TabBar(),
+          Expanded(
+            child: TabBarStackView(
+              children: [
+                _EventsTab(),
+                _ViewsTab(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TabBar extends StatelessWidget {
+  const _TabBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return TabBar(
+      tabAlignment: TabAlignment.fill,
+      indicatorSize: TabBarIndicatorSize.tab,
+      tabs: [
+        Tab(
+          text: context.l10n.campaignPreviewEvents,
+        ),
+        Tab(
+          text: context.l10n.campaignPreviewViews,
+        ),
+      ],
+    );
+  }
+}
+
+class _EventsTab extends StatelessWidget {
+  const _EventsTab();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        Expanded(child: _CampaignStatusChooser()),
+        _EventTimelapseControls(),
+      ],
+    );
+  }
+}
+
+class _CampaignStatusChooser extends StatelessWidget {
+  const _CampaignStatusChooser();
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
+      child: Column(
+        children: [
+          const SizedBox(height: 8),
+          for (final status in CampaignStatus.values)
+            // TODO(dtscalac): store active one somewhere
+            _EventItem(
+              status: status,
+              isActive: status == CampaignStatus.draft,
+              onTap: () {},
+            ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventItem extends StatelessWidget {
+  final CampaignStatus status;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _EventItem({
+    required this.status,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isActive
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colors.textOnPrimary;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 24, 12),
+        child: Row(
+          children: [
+            _icon.buildIcon(
+              size: 24,
+              color: color,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                _text(context.l10n),
+                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      color: color,
+                    ),
+              ),
+            ),
+            if (isActive)
+              Text(
+                context.l10n.active.toUpperCase(),
+                style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                      fontWeight: FontWeight.w500,
+                      fontSize: 11,
+                      color: color,
+                    ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  SvgGenImage get _icon => switch (status) {
+        CampaignStatus.draft => VoicesAssets.icons.clock,
+        CampaignStatus.live => VoicesAssets.icons.flag,
+        CampaignStatus.completed => VoicesAssets.icons.calendar,
+      };
+
+  String _text(VoicesLocalizations l10n) => switch (status) {
+        CampaignStatus.draft => l10n.campaignPreviewEventBefore,
+        CampaignStatus.live => l10n.campaignPreviewEventDuring,
+        CampaignStatus.completed => l10n.campaignPreviewEventAfter,
+      };
+}
+
+class _EventTimelapseControls extends StatelessWidget {
+  const _EventTimelapseControls();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: VoicesTextButton(
+              leading: VoicesAssets.icons.rewind.buildIcon(),
+              child: Text(context.l10n.previous),
+              // TODO(dtscalac): implement button action
+              onTap: () {},
+            ),
+          ),
+          Container(
+            width: 60,
+            height: 56,
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
+            ),
+            alignment: Alignment.center,
+            // TODO(dtscalac): implement timer ticking
+            child: const Text('-5s'),
+          ),
+          Expanded(
+            child: VoicesTextButton(
+              leading: VoicesAssets.icons.fastForward.buildIcon(),
+              child: Text(context.l10n.next),
+              // TODO(dtscalac): implement button action
+              onTap: () {},
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ViewsTab extends StatelessWidget {
+  const _ViewsTab();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 50,
+      height: 50,
+      color: Colors.blue,
+    );
+  }
+}
+
+class _Footer extends StatelessWidget {
+  final Space selectedSpace;
+  final ValueChanged<Space> onSpaceSelected;
+
+  const _Footer({
+    required this.selectedSpace,
+    required this.onSpaceSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          for (final space in Space.values)
+            _SpaceItem(
+              space: space,
+              isActive: space == selectedSpace,
+              onTap: () => onSpaceSelected(space),
+            ),
+        ].separatedBy(const SizedBox(width: 8)).toList(),
+      ),
+    );
+  }
+}
+
+class _SpaceItem extends StatelessWidget {
+  final Space space;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _SpaceItem({
+    required this.space,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return VoicesAvatar(
+      icon: space.icon.buildIcon(),
+      backgroundColor:
+          isActive ? space.backgroundColor(context) : Colors.transparent,
+      foregroundColor: isActive
+          ? space.foregroundColor(context)
+          : Theme.of(context).colors.iconsForeground,
+      padding: const EdgeInsets.all(8),
+      radius: 20,
+      onTap: onTap,
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -71,16 +71,7 @@ class _DraggableCampaignAdminToolsDialogState
       // clamp it so that it fits into the screen
       // in case user shrinks the app window
 
-      _position = Offset(
-        _position.dx.clamp(
-          0,
-          _screenSize.width - CampaignAdminToolsDialog._width,
-        ),
-        _position.dy.clamp(
-          0,
-          _screenSize.height - CampaignAdminToolsDialog._height,
-        ),
-      );
+      _position = _clampIntoScreenBounds(_position);
     }
   }
 
@@ -107,22 +98,28 @@ class _DraggableCampaignAdminToolsDialogState
 
   void _onDragUpdate(DragUpdateDetails details) {
     final newPosition = _position + details.delta;
-    final clampedPosition = Offset(
-      newPosition.dx.clamp(
-        0,
-        _screenSize.width - CampaignAdminToolsDialog._width,
-      ),
-      newPosition.dy.clamp(
-        0,
-        _screenSize.height - CampaignAdminToolsDialog._height,
-      ),
-    );
+    final clampedPosition = _clampIntoScreenBounds(newPosition);
 
     if (_position != clampedPosition) {
       setState(() {
         _position = clampedPosition;
       });
     }
+  }
+
+  /// Makes sure the dialog would fit into a screen window
+  /// even if the window gets shrunked, etc.
+  Offset _clampIntoScreenBounds(Offset offset) {
+    return Offset(
+      offset.dx.clamp(
+        0,
+        _screenSize.width - CampaignAdminToolsDialog._width,
+      ),
+      offset.dy.clamp(
+        0,
+        _screenSize.height - CampaignAdminToolsDialog._height,
+      ),
+    );
   }
 }
 

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_events.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_events.dart
@@ -1,0 +1,153 @@
+import 'package:catalyst_voices/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart';
+import 'package:catalyst_voices/widgets/buttons/voices_text_button.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:flutter/material.dart';
+
+/// The "events" tab of the [CampaignAdminToolsDialog].
+class CampaignAdminToolsEventsTab extends StatelessWidget {
+  const CampaignAdminToolsEventsTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        Expanded(child: _CampaignStatusChooser()),
+        _EventTimelapseControls(),
+      ],
+    );
+  }
+}
+
+class _CampaignStatusChooser extends StatelessWidget {
+  const _CampaignStatusChooser();
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
+      child: Column(
+        children: [
+          const SizedBox(height: 8),
+          for (final status in CampaignStatus.values)
+            // TODO(dtscalac): store active one somewhere
+            _EventItem(
+              status: status,
+              isActive: status == CampaignStatus.draft,
+              onTap: () {},
+            ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+class _EventItem extends StatelessWidget {
+  final CampaignStatus status;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _EventItem({
+    required this.status,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isActive
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colors.textOnPrimary;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 24, 12),
+        child: Row(
+          children: [
+            _icon.buildIcon(
+              size: 24,
+              color: color,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                _text(context.l10n),
+                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                      color: color,
+                    ),
+              ),
+            ),
+            if (isActive)
+              Text(
+                context.l10n.active.toUpperCase(),
+                style: Theme.of(context).textTheme.bodyMedium!.copyWith(
+                      fontWeight: FontWeight.w500,
+                      fontSize: 11,
+                      color: color,
+                    ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  SvgGenImage get _icon => switch (status) {
+        CampaignStatus.draft => VoicesAssets.icons.clock,
+        CampaignStatus.live => VoicesAssets.icons.flag,
+        CampaignStatus.completed => VoicesAssets.icons.calendar,
+      };
+
+  String _text(VoicesLocalizations l10n) => switch (status) {
+        CampaignStatus.draft => l10n.campaignPreviewEventBefore,
+        CampaignStatus.live => l10n.campaignPreviewEventDuring,
+        CampaignStatus.completed => l10n.campaignPreviewEventAfter,
+      };
+}
+
+class _EventTimelapseControls extends StatelessWidget {
+  const _EventTimelapseControls();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: VoicesTextButton(
+              leading: VoicesAssets.icons.rewind.buildIcon(),
+              child: Text(context.l10n.previous),
+              // TODO(dtscalac): implement button action
+              onTap: () {},
+            ),
+          ),
+          Container(
+            width: 60,
+            height: 56,
+            margin: const EdgeInsets.symmetric(horizontal: 16),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
+            ),
+            alignment: Alignment.center,
+            // TODO(dtscalac): implement timer ticking
+            child: const Text('-5s'),
+          ),
+          Expanded(
+            child: VoicesTextButton(
+              leading: VoicesAssets.icons.fastForward.buildIcon(),
+              child: Text(context.l10n.next),
+              // TODO(dtscalac): implement button action
+              onTap: () {},
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_views.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_views.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:catalyst_voices/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart';
+import 'package:catalyst_voices/widgets/buttons/voices_segmented_button.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// The "views" tab of the [CampaignAdminToolsDialog].
+class CampaignAdminToolsViewsTab extends StatefulWidget {
+  const CampaignAdminToolsViewsTab({super.key});
+
+  @override
+  State<CampaignAdminToolsViewsTab> createState() =>
+      _CampaignAdminToolsViewsTabState();
+}
+
+class _CampaignAdminToolsViewsTabState
+    extends State<CampaignAdminToolsViewsTab> {
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Theme.of(context).colors.elevationsOnSurfaceNeutralLv1Grey,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              context.l10n.userAuthenticationState,
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 16),
+            BlocBuilder<SessionCubit, SessionState>(
+              builder: (context, state) {
+                return VoicesSegmentedButton<_UserAuthState>(
+                  segments: [
+                    for (final userState in _UserAuthState.values)
+                      ButtonSegment(
+                        value: userState,
+                        label: Text(userState.name(context.l10n)),
+                      ),
+                  ],
+                  selected: {_UserAuthState.fromSessionState(state)},
+                  onChanged: (selected) {
+                    unawaited(_switchToState(selected.first));
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _switchToState(_UserAuthState state) async {
+    switch (state) {
+      case _UserAuthState.actor:
+        await _switchToActor();
+      case _UserAuthState.guest:
+        await _switchToGuest();
+      case _UserAuthState.visitor:
+        await _switchToVisitor();
+    }
+  }
+
+  Future<void> _switchToActor() async {
+    final sessionBloc = context.read<SessionCubit>();
+    await sessionBloc
+        .switchToDummyAccount()
+        .then((_) => sessionBloc.unlock(SessionCubit.dummyUnlockFactor));
+  }
+
+  Future<void> _switchToGuest() async {
+    final sessionBloc = context.read<SessionCubit>();
+    if (sessionBloc.state is ActiveAccountSessionState) {
+      await sessionBloc.lock();
+    } else if (sessionBloc.state is VisitorSessionState) {
+      await sessionBloc.switchToDummyAccount().then((_) => sessionBloc.lock());
+    }
+  }
+
+  Future<void> _switchToVisitor() async {
+    await context.read<SessionCubit>().removeKeychain();
+  }
+}
+
+enum _UserAuthState {
+  actor,
+  guest,
+  visitor;
+
+  factory _UserAuthState.fromSessionState(SessionState state) {
+    return switch (state) {
+      VisitorSessionState() => _UserAuthState.visitor,
+      GuestSessionState() => _UserAuthState.guest,
+      ActiveAccountSessionState() => _UserAuthState.actor,
+    };
+  }
+
+  String name(VoicesLocalizations l10n) {
+    return switch (this) {
+      _UserAuthState.actor => l10n.actor,
+      _UserAuthState.guest => l10n.guest,
+      _UserAuthState.visitor => l10n.visitor,
+    };
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices/common/ext/ext.dart';
+import 'package:catalyst_voices/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart';
 import 'package:catalyst_voices/pages/spaces/appbar/spaces_theme_mode_switch.dart';
 import 'package:catalyst_voices/pages/spaces/drawer/spaces_drawer.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
@@ -46,6 +47,9 @@ class SpacesShellPage extends StatefulWidget {
 }
 
 class _SpacesShellPageState extends State<SpacesShellPage> {
+  final GlobalKey _adminToolsKey = GlobalKey(debugLabel: 'admin_tools');
+  bool _showAdminTools = false;
+
   @override
   Widget build(BuildContext context) {
     final sessionBloc = context.watch<SessionCubit>();
@@ -56,27 +60,51 @@ class _SpacesShellPageState extends State<SpacesShellPage> {
       bindings: <ShortcutActivator, VoidCallback>{
         for (final entry in SpacesShellPage._spacesShortcutsActivators.entries)
           entry.value: () => entry.key.go(context),
+        CampaignAdminToolsDialog.shortcut: _toggleCampaignAdminTools,
       },
-      child: Scaffold(
-        appBar: VoicesAppBar(
-          leading: isVisitor ? null : const DrawerToggleButton(),
-          automaticallyImplyLeading: false,
-          actions: const [
-            SpacesThemeModeSwitch(),
-            SessionActionHeader(),
-            SessionStateHeader(),
-          ],
-        ),
-        drawer: isVisitor
-            ? null
-            : SpacesDrawer(
-                space: widget.space,
-                spacesShortcutsActivators:
-                    SpacesShellPage._spacesShortcutsActivators,
-                isUnlocked: isUnlocked,
-              ),
-        body: widget.child,
+      child: Stack(
+        children: [
+          Scaffold(
+            appBar: VoicesAppBar(
+              leading: isVisitor ? null : const DrawerToggleButton(),
+              automaticallyImplyLeading: false,
+              actions: const [
+                SpacesThemeModeSwitch(),
+                SessionActionHeader(),
+                SessionStateHeader(),
+              ],
+            ),
+            drawer: isVisitor
+                ? null
+                : SpacesDrawer(
+                    space: widget.space,
+                    spacesShortcutsActivators:
+                        SpacesShellPage._spacesShortcutsActivators,
+                    isUnlocked: isUnlocked,
+                  ),
+            body: widget.child,
+          ),
+          if (_showAdminTools)
+            DraggableCampaignAdminToolsDialog(
+              dialogKey: _adminToolsKey,
+              selectedSpace: widget.space,
+              onSpaceSelected: (space) => space.go(context),
+              onClose: _closeCampaignAdminTools,
+            ),
+        ],
       ),
     );
+  }
+
+  void _toggleCampaignAdminTools() {
+    setState(() {
+      _showAdminTools = !_showAdminTools;
+    });
+  }
+
+  void _closeCampaignAdminTools() {
+    setState(() {
+      _showAdminTools = false;
+    });
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/cards/campaign_preview_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/campaign_preview_card.dart
@@ -3,6 +3,7 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
 
@@ -75,7 +76,7 @@ class CampaignPreviewCard extends StatelessWidget {
   }
 
   String _getButtonText(BuildContext context) {
-    if (campaign.stage == CampaignStage.live) {
+    if (campaign.stage == CampaignStatus.live) {
       return context.l10n.viewProposals;
     } else {
       return context.l10n.viewVotingResults;

--- a/catalyst_voices/apps/voices/lib/widgets/cards/campaign_preview_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/campaign_preview_card.dart
@@ -6,12 +6,12 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
 
-class InPageInformationCard extends StatelessWidget {
-  final InPageInformation information;
+class CampaignPreviewCard extends StatelessWidget {
+  final CampaignPreviewInfo campaign;
 
-  const InPageInformationCard({
+  const CampaignPreviewCard({
     super.key,
-    required this.information,
+    required this.campaign,
   });
 
   @override
@@ -43,11 +43,11 @@ class InPageInformationCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        information.stage.localizedName(context.l10n),
+                        campaign.stage.localizedName(context.l10n),
                         style: textTheme.titleMedium,
                       ),
                       Text(
-                        information.description,
+                        campaign.description,
                         style: textTheme.bodyMedium,
                       ),
                       if (_getDateInformation(context).isNotEmpty)
@@ -60,10 +60,11 @@ class InPageInformationCard extends StatelessWidget {
                 ),
               ],
             ),
-            if (!information.stage.isDraft) ...[
+            if (!campaign.stage.isDraft) ...[
               const SizedBox(height: 16),
               OutlinedButton(
-                onPressed: () {}, // TODO(ryszard-schossler): add logic
+                // TODO(ryszard-schossler): add logic
+                onPressed: () {},
                 child: Text(_getButtonText(context)),
               ),
             ],
@@ -74,7 +75,7 @@ class InPageInformationCard extends StatelessWidget {
   }
 
   String _getButtonText(BuildContext context) {
-    if (information.stage == CampaignStage.live) {
+    if (campaign.stage == CampaignStage.live) {
       return context.l10n.viewProposals;
     } else {
       return context.l10n.viewVotingResults;
@@ -82,9 +83,9 @@ class InPageInformationCard extends StatelessWidget {
   }
 
   String _getDateInformation(BuildContext context) {
-    if (information is LiveCampaignInformation ||
-        information is DraftCampaignInformation) {
-      final dateMixin = (information as DateTimeMixin);
+    if (campaign is LiveCampaignInformation ||
+        campaign is DraftCampaignInformation) {
+      final dateMixin = (campaign as DateTimeMixin);
       final formattedDate = DateFormatter.formatDateTimeParts(dateMixin.date);
       return dateMixin.localizedDate(
         context.l10n,

--- a/catalyst_voices/apps/voices/test/widgets/cards/campaign_preview_card_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/cards/campaign_preview_card_test.dart
@@ -1,4 +1,4 @@
-import 'package:catalyst_voices/widgets/cards/in_page_information_card.dart';
+import 'package:catalyst_voices/widgets/cards/campaign_preview_card.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
@@ -31,18 +31,18 @@ void main() {
     );
   });
 
-  Widget buildTestWidget(InPageInformation information) {
+  Widget buildTestWidget(CampaignPreviewInfo campaign) {
     return Scaffold(
       body: SizedBox(
         width: 1000,
-        child: InPageInformationCard(
-          information: information,
+        child: CampaignPreviewCard(
+          campaign: campaign,
         ),
       ),
     );
   }
 
-  group('InPageInformationCard', () {
+  group(CampaignPreviewCard, () {
     testWidgets(
       'Renders correctly always display elements which are always render',
       (tester) async {
@@ -53,7 +53,7 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        expect(find.byType(InPageInformationCard), findsOneWidget);
+        expect(find.byType(CampaignPreviewCard), findsOneWidget);
         expect(find.byType(CatalystSvgIcon), findsOneWidget);
       },
     );
@@ -66,11 +66,11 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(InPageInformationCard), findsOneWidget);
+      expect(find.byType(CampaignPreviewCard), findsOneWidget);
       expect(find.byType(Text), findsExactly(3));
       expect(find.byType(CatalystSvgIcon), findsExactly(2));
       expect(
-        find.text('Campaign Staring Soon (Ready to deploy)'),
+        find.text('Campaign Starting Soon (Ready to deploy)'),
         findsOneWidget,
       );
       expect(find.text(draftInformationTest.description), findsOneWidget);
@@ -85,7 +85,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(InPageInformationCard), findsOneWidget);
+      expect(find.byType(CampaignPreviewCard), findsOneWidget);
       expect(find.byType(Text), findsExactly(4));
       expect(find.byType(CatalystSvgIcon), findsExactly(2));
       expect(
@@ -105,7 +105,7 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(InPageInformationCard), findsOneWidget);
+      expect(find.byType(CampaignPreviewCard), findsOneWidget);
       expect(find.byType(Text), findsExactly(3));
       expect(find.byType(CatalystSvgIcon), findsOneWidget);
       expect(

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -656,6 +656,10 @@
   "accountCreationSplashNextButton": "Create your Keychain now",
   "accountInstructionsTitle": "Great! Your Catalyst Keychain \u2028has been created.",
   "accountInstructionsMessage": "On the next screen, you're going to see 12 words. \u2028This is called your \"seed phrase\".   \u2028\u2028It's like a super secure password that only you know, \u2028that allows you to prove ownership of your keychain.  \u2028\u2028You'll use it to login and recover your account on \u2028different devices, so be sure to put it somewhere safe!\n\nYou need to write this seed phrase down with pen and paper, so get this ready.",
+  "previous": "Previous",
+  "@previous": {
+    "description": "(Action) switch to the previous item."
+  },
   "next": "Next",
   "@next": {
     "description": "For example in button that goes to next stage of registration"
@@ -1081,5 +1085,49 @@
   "@discoverySpaceEmptyProposals": {
     "description": "Description for empty state on discovery space when there are no draft proposals."
   },
-  "campaign": "Campaign"
+  "campaign": "Campaign",
+  "campaignPreviewTitle": "Campaign Preview",
+  "@campaignPreviewTitle": {
+    "description": "Title for the campaign preview dialog (admin mode)."
+  },
+  "campaignPreviewEvents": "Events",
+  "@campaignPreviewEvents": {
+    "description": "Tab label in campaign preview dialog for campaign events."
+  },
+  "campaignPreviewViews": "Views",
+  "@campaignPreviewViews": {
+    "description": "Tab label in campaign preview dialog for campaign views."
+  },
+  "campaignPreviewEventBefore": "Before Campaign",
+  "@campaignPreviewEventBefore": {
+    "description": "A name of the state of a campaign before it starts."
+  },
+  "campaignPreviewEventDuring": "During Campaign",
+  "@campaignPreviewEventDuring": {
+    "description": "A name of the state of a campaign when it is active."
+  },
+  "campaignPreviewEventAfter": "After Campaign",
+  "@campaignPreviewEventAfter": {
+    "description": "A name of the state of a campaign when it is active."
+  },
+  "userAuthenticationState": "User Authentication State",
+  "@userAuthenticationState": {
+    "description": "The state of the user (keychain), actor, guest, visitor, etc."
+  },
+  "activeUserState": "Actor",
+  "@activeUserState": {
+    "description": "User state with unlocked keychain."
+  },
+  "guestUserState": "Guest",
+  "@guestUserState": {
+    "description": "User state with locked keychain."
+  },
+  "visitorUserState": "Visitor",
+  "@visitorUserState": {
+    "description": "User state without a keychain."
+  },
+  "active": "Active",
+  "@active": {
+    "description": "Activated state"
+  }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -392,6 +392,10 @@
   "@visitor": {
     "description": "Refers to user that created keychain but is locked"
   },
+  "actor": "Actor",
+  "@actor": {
+    "description": "Refers to user that created keychain and is unlocked."
+  },
   "noConnectionBannerRefreshButtonText": "Refresh",
   "@noConnectionBannerRefreshButtonText": {
     "description": "Text shown in the No Internet Connection Banner widget for the refresh button."
@@ -1113,18 +1117,6 @@
   "userAuthenticationState": "User Authentication State",
   "@userAuthenticationState": {
     "description": "The state of the user (keychain), actor, guest, visitor, etc."
-  },
-  "activeUserState": "Actor",
-  "@activeUserState": {
-    "description": "User state with unlocked keychain."
-  },
-  "guestUserState": "Guest",
-  "@guestUserState": {
-    "description": "User state with locked keychain."
-  },
-  "visitorUserState": "Visitor",
-  "@visitorUserState": {
-    "description": "User state without a keychain."
   },
   "active": "Active",
   "@active": {

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -1011,9 +1011,9 @@
   "@campaignIsLive": {
     "description": "Title of the campaign is live (published) space"
   },
-  "campaignStaringSoon": "Campaign Staring Soon (Ready to deploy)",
-  "@campaignStaringSoon": {
-    "description": "Title of the campaign staring soon space"
+  "campaignStartingSoon": "Campaign Starting Soon (Ready to deploy)",
+  "@campaignStartingSoon": {
+    "description": "Title of the campaign starting soon space"
   },
   "campaignConcluded": "Campaign Concluded, Result are in!",
   "@campaignConcluded": {

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/campaign/campaign_status.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/campaign/campaign_status.dart
@@ -1,0 +1,8 @@
+enum CampaignStatus {
+  draft,
+  live,
+  completed;
+
+  bool get isCompleted => this == CampaignStatus.completed;
+  bool get isDraft => this == CampaignStatus.draft;
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/catalyst_voices_models.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/catalyst_voices_models.dart
@@ -5,6 +5,7 @@ export 'auth/password_strength.dart';
 export 'campaign/campaign.dart';
 export 'campaign/campaign_category.dart';
 export 'campaign/campaign_section.dart';
+export 'campaign/campaign_status.dart';
 export 'crypto/keychain_metadata.dart';
 export 'crypto/lock_factor.dart';
 export 'document/document_json.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/admin/campaign_preview_info.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/admin/campaign_preview_info.dart
@@ -1,26 +1,12 @@
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:equatable/equatable.dart';
 
-enum CampaignStage {
-  draft,
-  live,
-  completed;
-
-  bool get isCompleted => this == CampaignStage.completed;
-  bool get isDraft => this == CampaignStage.draft;
-
-  String localizedName(VoicesLocalizations l10n) => switch (this) {
-        CampaignStage.draft => l10n.campaignStaringSoon,
-        CampaignStage.live => l10n.campaignIsLive,
-        CampaignStage.completed => l10n.campaignConcluded,
-      };
-}
-
-sealed class InPageInformation extends Equatable {
-  final CampaignStage stage;
+sealed class CampaignPreviewInfo extends Equatable {
+  final CampaignStatus stage;
   final String description;
 
-  const InPageInformation({
+  const CampaignPreviewInfo({
     required this.stage,
     required this.description,
   });
@@ -29,32 +15,32 @@ sealed class InPageInformation extends Equatable {
   List<Object?> get props => [stage, description];
 }
 
-class CompletedCampaignInformation extends InPageInformation {
+class CompletedCampaignInformation extends CampaignPreviewInfo {
   const CompletedCampaignInformation({required super.description})
-      : super(stage: CampaignStage.completed);
+      : super(stage: CampaignStatus.completed);
 }
 
-class DraftCampaignInformation extends InPageInformation with DateTimeMixin {
+class DraftCampaignInformation extends CampaignPreviewInfo with DateTimeMixin {
   @override
   final DateTime date;
 
   const DraftCampaignInformation({
     required this.date,
     required super.description,
-  }) : super(stage: CampaignStage.draft);
+  }) : super(stage: CampaignStatus.draft);
 
   @override
   List<Object?> get props => [date, description];
 }
 
-class LiveCampaignInformation extends InPageInformation with DateTimeMixin {
+class LiveCampaignInformation extends CampaignPreviewInfo with DateTimeMixin {
   @override
   final DateTime date;
 
   const LiveCampaignInformation({
     required this.date,
     required super.description,
-  }) : super(stage: CampaignStage.live);
+  }) : super(stage: CampaignStatus.live);
 
   @override
   List<Object?> get props => [date, description];
@@ -62,13 +48,13 @@ class LiveCampaignInformation extends InPageInformation with DateTimeMixin {
 
 mixin DateTimeMixin {
   DateTime get date;
-  CampaignStage get stage;
+  CampaignStatus get stage;
 
   String localizedDate(
     VoicesLocalizations l10n,
     (String date, String time) formattedDate,
   ) {
-    if (stage == CampaignStage.draft) {
+    if (stage == CampaignStatus.draft) {
       return l10n.campaignBeginsOn(formattedDate.$1, formattedDate.$2);
     } else {
       return l10n.campaignEndsOn(formattedDate.$1, formattedDate.$2);

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/admin/campaign_status_info.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/admin/campaign_status_info.dart
@@ -1,0 +1,10 @@
+import 'package:catalyst_voices_localization/generated/catalyst_voices_localizations.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+
+extension CampaignStatusExt on CampaignStatus {
+  String localizedName(VoicesLocalizations l10n) => switch (this) {
+        CampaignStatus.draft => l10n.campaignStartingSoon,
+        CampaignStatus.live => l10n.campaignIsLive,
+        CampaignStatus.completed => l10n.campaignConcluded,
+      };
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
@@ -1,4 +1,6 @@
 export 'authentication/authentication.dart';
+export 'campaign/admin/campaign_preview_info.dart';
+export 'campaign/admin/campaign_status_info.dart';
 export 'campaign/campaign_category_section.dart';
 export 'campaign/campaign_list_item.dart';
 export 'exception/localized_exception.dart';
@@ -10,7 +12,6 @@ export 'navigation/sections_navigation.dart';
 export 'proposal/comment.dart';
 export 'proposal/guidance/guidance.dart';
 export 'proposal/guidance/guidance_type.dart';
-export 'proposal/in_page_information.dart';
 export 'registration/exception/localized_registration_exception.dart';
 export 'registration/registration.dart';
 export 'treasury/treasury_sections.dart';


### PR DESCRIPTION
# Description

Adds the first iteration of campaign admin tools which allows:

- switching between spaces
- switching between session states (actor, visitor, guest)
- switching between different campaign stages (to be done in the next PR)

The admin tools dialog can be shown/closed with ctrl+shift+A keyboard combination.

## Related Issue(s)

Refers #1113

## Screenshots

https://github.com/user-attachments/assets/ae6e7634-9ddd-4c69-981a-cab905d329ac

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
