### PR TITLE
fix(cat-gateway): Fix `DATABASE_SCHEMA_VERSION`, remove unused `event_db_url` cli arg

### DIFF
--- a/catalyst-gateway/bin/src/db/event/mod.rs
+++ b/catalyst-gateway/bin/src/db/event/mod.rs
@@ -21,7 +21,7 @@ pub(crate) mod schema_check;
 
 /// Database version this crate matches.
 /// Must equal the last Migrations Version Number from `event-db/migrations`.
-pub(crate) const DATABASE_SCHEMA_VERSION: i32 = 9;
+pub(crate) const DATABASE_SCHEMA_VERSION: i32 = 2;
 
 /// Postgres Connection Manager DB Pool
 type SqlDbPool = Arc<Pool<PostgresConnectionManager<NoTls>>>;

--- a/catalyst-gateway/bin/src/settings/mod.rs
+++ b/catalyst-gateway/bin/src/settings/mod.rs
@@ -73,10 +73,6 @@ fn calculate_service_uuid() -> String {
 #[derive(Args, Clone)]
 #[clap(version = BUILD_INFO)]
 pub(crate) struct ServiceSettings {
-    /// Url to the postgres event db
-    #[clap(long, env)]
-    pub(crate) event_db_url: Option<String>,
-
     /// Logging level
     #[clap(long, default_value = LOG_LEVEL_DEFAULT)]
     pub(crate) log_level: LogLevel,


### PR DESCRIPTION
# Description

- Fixed `DATABASE_SCHEMA_VERSION` from `9` to `2`.
- Removed unused `event_db_url` cat-gateway cli `run` command argument