### PR TITLE
feat(dart/catalyst_cardano_serialization): replace ulid by UUID in auth token

### DIFF
--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -124,7 +124,6 @@ command:
       convert: ^3.1.1
       path: ^1.9.0
       pinenacl: ^0.6.0
-      ulid: ^2.0.0
       uuid: ^4.5.1
       sentry_flutter: ^8.8.0
       scrollable_positioned_list: ^0.3.8

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/rbac/auth_token.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/rbac/auth_token.dart
@@ -47,7 +47,9 @@ final class AuthToken {
     required DateTime timestamp,
   }) async {
     final uuidConfig = V7Options(timestamp.millisecondsSinceEpoch, null);
-    final uuid = CborBytes((const Uuid().v7(config: uuidConfig)).codeUnits);
+    final uuidString = const Uuid().v7(config: uuidConfig);
+    final uuidBytes = Uuid.parse(uuidString);
+    final uuid = CborBytes(uuidBytes);
 
     final toBeSigned = [
       ...cbor.encode(kid.toCbor()),

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/rbac/auth_token.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/rbac/auth_token.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
+import 'package:catalyst_cardano_serialization/src/utils/cbor.dart';
 import 'package:catalyst_key_derivation/catalyst_key_derivation.dart';
 import 'package:cbor/cbor.dart';
 import 'package:uuid/data.dart';
@@ -49,7 +50,7 @@ final class AuthToken {
     final uuidConfig = V7Options(timestamp.millisecondsSinceEpoch, null);
     final uuidString = const Uuid().v7(config: uuidConfig);
     final uuidBytes = Uuid.parse(uuidString);
-    final uuid = CborBytes(uuidBytes);
+    final uuid = CborBytes(uuidBytes, tags: [CborCustomTags.uuid]);
 
     final toBeSigned = [
       ...cbor.encode(kid.toCbor()),

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/utils/cbor.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/utils/cbor.dart
@@ -2,6 +2,9 @@
 final class CborCustomTags {
   const CborCustomTags._();
 
+  /// A cbor tag describing a uuid.
+  static const int uuid = 37;
+
   /// A cbor tag describing a key-value pairs data.
   static const int map = 259;
 

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/utils/uuid.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/utils/uuid.dart
@@ -60,3 +60,17 @@ extension type UuidV4._(List<int> bytes) {
     return Uint8List.fromList(byteList);
   }
 }
+
+/// Utils around UUID v7.
+abstract class UuidV7 {
+  /// Extracts the timestamp from the Uuid V7 string.
+  static DateTime parseTimestamp(String uuid) {
+    final uuidParts = uuid.split('-');
+    // First 48 bits of UUIDv7
+    final uuidTimestampHex = uuidParts[0] + uuidParts[1].substring(0, 4);
+
+    // Convert timestampHex to milliseconds since Unix epoch
+    final timestamp = int.parse(uuidTimestampHex, radix: 16);
+    return DateTime.fromMillisecondsSinceEpoch(timestamp, isUtc: true);
+  }
+}

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   cryptography: ^2.7.0
   equatable: ^2.0.7
   pinenacl: ^0.6.0
-  ulid: ^2.0.0
+  uuid: ^4.5.1
 
 dev_dependencies:
   build_runner: ^2.4.12

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/test/rbac/auth_token_test.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/test/rbac/auth_token_test.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_key_derivation/catalyst_key_derivation.dart';
 import 'package:cbor/cbor.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:test/test.dart';
-import 'package:ulid/ulid.dart';
 
 // The certificate provided in the request
 final _c509Cert = C509Certificate.fromHex(
@@ -55,19 +54,20 @@ void main() {
       expect(decodedCbor.length, 3);
 
       final decodedKid = decodedCbor[0] as CborBytes;
-      final decodedUlid = decodedCbor[1] as CborBytes;
+      final decodedUuid = decodedCbor[1] as CborBytes;
       final decodedSignature = decodedCbor[2] as CborBytes;
 
       expect(decodedKid.bytes, (kid.toCbor() as CborBytes).bytes);
+
       expect(
-        Ulid.fromBytes(decodedUlid.bytes).toMillis(),
-        timestamp.millisecondsSinceEpoch,
+        UuidV7.parseTimestamp(String.fromCharCodes(decodedUuid.bytes)),
+        timestamp,
       );
 
       // Verify the signature
       final toBeSigned = [
         ...cbor.encode(kid.toCbor()),
-        ...cbor.encode(decodedUlid),
+        ...cbor.encode(decodedUuid),
       ];
 
       final publicKey = await privateKey.derivePublicKey();

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/test/rbac/auth_token_test.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/test/rbac/auth_token_test.dart
@@ -5,6 +5,7 @@ import 'package:catalyst_key_derivation/catalyst_key_derivation.dart';
 import 'package:cbor/cbor.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:test/test.dart';
+import 'package:uuid/parsing.dart';
 
 // The certificate provided in the request
 final _c509Cert = C509Certificate.fromHex(
@@ -59,8 +60,10 @@ void main() {
 
       expect(decodedKid.bytes, (kid.toCbor() as CborBytes).bytes);
 
+      final decodedUuidBytes = decodedUuid.bytes;
+      expect(decodedUuidBytes, hasLength(16));
       expect(
-        UuidV7.parseTimestamp(String.fromCharCodes(decodedUuid.bytes)),
+        UuidV7.parseTimestamp(UuidParsing.unparse(decodedUuidBytes)),
         timestamp,
       );
 


### PR DESCRIPTION
# Description

Replaces ulid by UUID v7 in auth token.

token cbor: 
```
50431d7b744dcc4ac4359b7ee7ffa7be33d8255001856aa0c8007a1d82b02c77a8db72525840604b50613e4ed56d94ec1038bb4fce75b616fc3249134c4cb73407281c7396c608d46990981fccc181211858387926acba5e99036d74e5dc66328a5b0e74b30d
```

uuid cbor:
```
37(h'01856AA0C8007A1D82B02C77A8DB7252')
```

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
