### PR TITLE
fix(cat-voices): snackbar no scaffold error

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -51,9 +51,13 @@ class AppContentState extends State<AppContent> {
         brightness: Brightness.dark,
       ),
       builder: (context, child) {
-        return GlobalPrecacheImages(
-          child: GlobalSessionListener(
-            child: child ?? const SizedBox.shrink(),
+        return Scaffold(
+          primary: false,
+          backgroundColor: Colors.transparent,
+          body: GlobalPrecacheImages(
+            child: GlobalSessionListener(
+              child: child ?? const SizedBox.shrink(),
+            ),
           ),
         );
       },


### PR DESCRIPTION
# Description

When app unlock state is resumed there may be no scaffold available yet. This PR is adding one on top of the app.
