### PR TITLE
refactor(cat-voices): simplify document parsing

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_schema.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_schema.dart
@@ -46,7 +46,7 @@ final class DocumentSchemaSegment extends Equatable implements DocumentNode {
   final DocumentNodeId nodeId;
   final String id;
   final String title;
-  final String description;
+  final String? description;
   final List<DocumentSchemaSection> sections;
   final List<DocumentNodeId> order;
 
@@ -79,7 +79,7 @@ final class DocumentSchemaSection extends Equatable implements DocumentNode {
   final DocumentNodeId nodeId;
   final String id;
   final String title;
-  final String description;
+  final String? description;
   final List<DocumentSchemaProperty> properties;
   final bool isRequired;
   final List<DocumentNodeId> order;

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_property_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_property_dto.dart
@@ -10,7 +10,7 @@ final class DocumentSchemaPropertyDto {
   final String ref;
   @JsonKey(includeToJson: false)
   final String id;
-  final String? title;
+  final String title;
   final String? description;
   @JsonKey(includeIfNull: false)
   final int? minLength;
@@ -38,12 +38,12 @@ final class DocumentSchemaPropertyDto {
   const DocumentSchemaPropertyDto({
     this.ref = '',
     required this.id,
-    this.title = '',
-    this.description = '',
+    required this.title,
+    this.description,
     this.minLength,
     this.maxLength,
     this.defaultValue,
-    this.guidance = '',
+    this.guidance,
     this.enumValues,
     this.maxItems,
     this.minItems,
@@ -66,7 +66,7 @@ final class DocumentSchemaPropertyDto {
       definition: definitions.getDefinition(ref),
       nodeId: parentNodeId.child(id),
       id: id,
-      title: title!,
+      title: title,
       description: description,
       defaultValue: defaultValue,
       guidance: guidance,

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_section_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_section_dto.dart
@@ -11,7 +11,7 @@ final class DocumentSchemaSectionDto {
   final String id;
   @JsonKey(name: r'$ref')
   final String ref;
-  final String? title;
+  final String title;
   final String? description;
   @DocumentSchemaPropertiesDtoConverter()
   final List<DocumentSchemaPropertyDto> properties;
@@ -19,25 +19,14 @@ final class DocumentSchemaSectionDto {
   @JsonKey(name: 'x-order')
   final List<String>? order;
 
-  // conditional logic
-  @JsonKey(name: 'if')
-  final DocumentSchemaIfConditionDto? ifs;
-  @JsonKey(name: 'then')
-  final DocumentSchemaSectionBodyDto? then;
-  @JsonKey(name: 'else')
-  final DocumentSchemaSectionBodyDto? elses;
-
   const DocumentSchemaSectionDto({
     required this.id,
     required this.ref,
-    this.title,
+    required this.title,
     this.description,
     required this.properties,
     this.required,
     this.order,
-    this.ifs,
-    this.then,
-    this.elses,
   });
 
   factory DocumentSchemaSectionDto.fromJson(Map<String, dynamic> json) =>
@@ -69,65 +58,11 @@ final class DocumentSchemaSectionDto {
       definition: definitions.getDefinition(ref),
       nodeId: nodeId,
       id: id,
-      title: title ?? '',
-      description: description ?? '',
+      title: title,
+      description: description,
       properties: mappedProperties,
       isRequired: isRequired,
       order: order.map(nodeId.child).toList(),
     );
   }
-}
-
-/// Similar to [DocumentSchemaSectionDto] but all fields must be optional.
-@JsonSerializable()
-final class DocumentSchemaSectionBodyDto {
-  @JsonKey(name: r'$ref')
-  final String? ref;
-  final String? title;
-  final String? description;
-  @DocumentSchemaPropertiesDtoConverter()
-  final List<DocumentSchemaPropertyDto>? properties;
-  final List<String>? required;
-  @JsonKey(name: 'x-order')
-  final List<String>? order;
-
-  // conditional logic
-  @JsonKey(name: 'if')
-  final DocumentSchemaIfConditionDto? ifs;
-  @JsonKey(name: 'then')
-  final DocumentSchemaSectionBodyDto? then;
-  @JsonKey(name: 'else')
-  final DocumentSchemaSectionBodyDto? elses;
-
-  const DocumentSchemaSectionBodyDto({
-    this.ref,
-    this.title,
-    this.description,
-    this.properties,
-    this.required,
-    this.order,
-    this.ifs,
-    this.then,
-    this.elses,
-  });
-
-  factory DocumentSchemaSectionBodyDto.fromJson(Map<String, dynamic> json) =>
-      _$DocumentSchemaSectionBodyDtoFromJson(json);
-
-  Map<String, dynamic> toJson() => _$DocumentSchemaSectionBodyDtoToJson(this);
-}
-
-@JsonSerializable()
-final class DocumentSchemaIfConditionDto {
-  @JsonKey(name: 'properties')
-  final Map<String, dynamic>? properties;
-
-  const DocumentSchemaIfConditionDto({
-    required this.properties,
-  });
-
-  factory DocumentSchemaIfConditionDto.fromJson(Map<String, dynamic> json) =>
-      _$DocumentSchemaIfConditionDtoFromJson(json);
-
-  Map<String, dynamic> toJson() => _$DocumentSchemaIfConditionDtoToJson(this);
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_segment_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_segment_dto.dart
@@ -12,7 +12,7 @@ final class DocumentSchemaSegmentDto {
   @JsonKey(name: r'$ref')
   final String ref;
   final String title;
-  final String description;
+  final String? description;
   @JsonKey(name: 'properties')
   @DocumentSchemaSectionsDtoConverter()
   final List<DocumentSchemaSectionDto> sections;
@@ -23,8 +23,8 @@ final class DocumentSchemaSegmentDto {
   const DocumentSchemaSegmentDto({
     required this.id,
     required this.ref,
-    this.title = '',
-    this.description = '',
+    required this.title,
+    this.description,
     required this.sections,
     this.required,
     this.order,

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/utils/document_schema_dto_converter.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/utils/document_schema_dto_converter.dart
@@ -6,17 +6,21 @@ import 'package:json_annotation/json_annotation.dart';
 
 final class DocumentSchemaSegmentsDtoConverter
     implements
-        JsonConverter<List<DocumentSchemaSegmentDto>, Map<String, dynamic>> {
+        JsonConverter<List<DocumentSchemaSegmentDto>, Map<String, dynamic>?> {
   const DocumentSchemaSegmentsDtoConverter();
 
   @override
-  List<DocumentSchemaSegmentDto> fromJson(Map<String, dynamic> json) {
+  List<DocumentSchemaSegmentDto> fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return [];
+    }
+
     final properties = json.convertMapToListWithIds();
     return properties.map(DocumentSchemaSegmentDto.fromJson).toList();
   }
 
   @override
-  Map<String, dynamic> toJson(List<DocumentSchemaSegmentDto> segments) {
+  Map<String, dynamic>? toJson(List<DocumentSchemaSegmentDto> segments) {
     return {
       for (final segment in segments) segment.id: segment.toJson(),
     };
@@ -25,17 +29,21 @@ final class DocumentSchemaSegmentsDtoConverter
 
 final class DocumentSchemaSectionsDtoConverter
     implements
-        JsonConverter<List<DocumentSchemaSectionDto>, Map<String, dynamic>> {
+        JsonConverter<List<DocumentSchemaSectionDto>, Map<String, dynamic>?> {
   const DocumentSchemaSectionsDtoConverter();
 
   @override
-  List<DocumentSchemaSectionDto> fromJson(Map<String, dynamic> json) {
+  List<DocumentSchemaSectionDto> fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return [];
+    }
+
     final properties = json.convertMapToListWithIds();
     return properties.map(DocumentSchemaSectionDto.fromJson).toList();
   }
 
   @override
-  Map<String, dynamic> toJson(List<DocumentSchemaSectionDto> sections) {
+  Map<String, dynamic>? toJson(List<DocumentSchemaSectionDto> sections) {
     return {
       for (final section in sections) section.id: section.toJson(),
     };
@@ -44,17 +52,21 @@ final class DocumentSchemaSectionsDtoConverter
 
 final class DocumentSchemaPropertiesDtoConverter
     implements
-        JsonConverter<List<DocumentSchemaPropertyDto>, Map<String, dynamic>> {
+        JsonConverter<List<DocumentSchemaPropertyDto>, Map<String, dynamic>?> {
   const DocumentSchemaPropertiesDtoConverter();
 
   @override
-  List<DocumentSchemaPropertyDto> fromJson(Map<String, dynamic> json) {
+  List<DocumentSchemaPropertyDto> fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return [];
+    }
+
     final properties = json.convertMapToListWithIds();
     return properties.map(DocumentSchemaPropertyDto.fromJson).toList();
   }
 
   @override
-  Map<String, dynamic> toJson(List<DocumentSchemaPropertyDto> properties) {
+  Map<String, dynamic>? toJson(List<DocumentSchemaPropertyDto> properties) {
     return {
       for (final property in properties) property.id: property.toJson(),
     };


### PR DESCRIPTION
# Description

- Ignore conditional logic, skipped for F14.
- Allow `properties` to be nullable.
- Make `title` required, `description` optional.

## Related Issue(s)

List the issue numbers related to this pull request.

Refers #1265

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
