### PR TITLE
fix(cat-voices): allow optional title in document properties/sections

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_schema.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_schema.dart
@@ -114,7 +114,7 @@ final class DocumentSchemaProperty extends Equatable implements DocumentNode {
   @override
   final DocumentNodeId nodeId;
   final String id;
-  final String title;
+  final String? title;
   final String? description;
   final Object? defaultValue;
   final String? guidance;

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_schema.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_schema.dart
@@ -78,7 +78,7 @@ final class DocumentSchemaSection extends Equatable implements DocumentNode {
   @override
   final DocumentNodeId nodeId;
   final String id;
-  final String title;
+  final String? title;
   final String? description;
   final List<DocumentSchemaProperty> properties;
   final bool isRequired;

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_property_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_property_dto.dart
@@ -10,7 +10,7 @@ final class DocumentSchemaPropertyDto {
   final String ref;
   @JsonKey(includeToJson: false)
   final String id;
-  final String title;
+  final String? title;
   final String? description;
   @JsonKey(includeIfNull: false)
   final int? minLength;
@@ -38,7 +38,7 @@ final class DocumentSchemaPropertyDto {
   const DocumentSchemaPropertyDto({
     this.ref = '',
     required this.id,
-    required this.title,
+    this.title,
     this.description,
     this.minLength,
     this.maxLength,

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_section_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_section_dto.dart
@@ -22,7 +22,7 @@ final class DocumentSchemaSectionDto {
   const DocumentSchemaSectionDto({
     required this.id,
     required this.ref,
-    required this.title,
+    this.title,
     this.description,
     required this.properties,
     this.required,

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_section_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/document/schema/document_schema_section_dto.dart
@@ -11,7 +11,7 @@ final class DocumentSchemaSectionDto {
   final String id;
   @JsonKey(name: r'$ref')
   final String ref;
-  final String title;
+  final String? title;
   final String? description;
   @DocumentSchemaPropertiesDtoConverter()
   final List<DocumentSchemaPropertyDto> properties;


### PR DESCRIPTION
# Description

- Fixes tests by allowing the title to be optional on section/property level in a document.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
