### PR TITLE
chore(flutter): publish packages

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -10,7 +10,7 @@
   "ignores": [
     ".config/dictionaries/**",
     "catalyst-gateway/target/**",
-    "CHANGELOG.md",
+    "catalyst_voices/CHANGELOG.md",
     "catalyst_voices/packages/libs/**/CHANGELOG.md",
     "catalyst_voices/packages/libs/**/cargokit/**",
     "catalyst_voices/apps/voices/macos/Pods/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -14,6 +14,7 @@
     "catalyst_voices/packages/libs/**/CHANGELOG.md",
     "catalyst_voices/packages/libs/**/cargokit/**",
     "catalyst_voices/apps/voices/macos/Pods/**",
+    "catalyst_voices/apps/voices/ios/Pods/**",
     "**/node_modules/**",
     "**/.dart_tool/**"
   ],

--- a/catalyst_voices/CHANGELOG.md
+++ b/catalyst_voices/CHANGELOG.md
@@ -3,6 +3,46 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-01-13
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`catalyst_cardano` - `v0.4.0+3`](#catalyst_cardano---v0403)
+ - [`catalyst_key_derivation` - `v0.1.2`](#catalyst_key_derivation---v012)
+ - [`catalyst_cardano_serialization` - `v0.5.0+3`](#catalyst_cardano_serialization---v0503)
+ - [`catalyst_cardano_web` - `v0.4.0+3`](#catalyst_cardano_web---v0403)
+ - [`catalyst_cardano_platform_interface` - `v0.4.0+3`](#catalyst_cardano_platform_interface---v0403)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `catalyst_cardano_serialization` - `v0.5.0+3`
+ - `catalyst_cardano_web` - `v0.4.0+3`
+ - `catalyst_cardano_platform_interface` - `v0.4.0+3`
+
+---
+
+#### `catalyst_cardano` - `v0.4.0+3`
+
+ - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+
+#### `catalyst_key_derivation` - `v0.1.2`
+
+ - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+ - **FIX**: add missing dependency. ([1334cb06](https://github.com/input-output-hk/catalyst-voices/commit/1334cb066877b2507af2e469f31b6c3549181146))
+ - **FEAT**(cat-voices): Enable the 'arithmetic_side_effects' Clippy lint ([#1456](https://github.com/input-output-hk/catalyst-voices/issues/1456)). ([5a0e2f46](https://github.com/input-output-hk/catalyst-voices/commit/5a0e2f46859b44ff325d47ca0eb90d4fa904d125))
+ - **DOCS**: update pub.dev topics for catalyst_key_derivation package. ([a6d9bcfa](https://github.com/input-output-hk/catalyst-voices/commit/a6d9bcfa451cbb8d0ded9659e63fbfa290416480))
+
+
 ## 2025-01-02v2
 
 ### Changes

--- a/catalyst_voices/CHANGELOG.md
+++ b/catalyst_voices/CHANGELOG.md
@@ -11,37 +11,46 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 Packages with breaking changes:
 
- - There are no breaking changes in this release.
+* There are no breaking changes in this release.
 
 Packages with other changes:
 
- - [`catalyst_cardano` - `v0.4.0+3`](#catalyst_cardano---v0403)
- - [`catalyst_key_derivation` - `v0.1.2`](#catalyst_key_derivation---v012)
- - [`catalyst_cardano_serialization` - `v0.5.0+3`](#catalyst_cardano_serialization---v0503)
- - [`catalyst_cardano_web` - `v0.4.0+3`](#catalyst_cardano_web---v0403)
- - [`catalyst_cardano_platform_interface` - `v0.4.0+3`](#catalyst_cardano_platform_interface---v0403)
+* [`catalyst_cardano` - `v0.4.0+3`](#catalyst_cardano---v0403)
+* [`catalyst_key_derivation` - `v0.1.2`](#catalyst_key_derivation---v012)
+* `catalyst_cardano_serialization` - `v0.5.0+3`
+* `catalyst_cardano_web` - `v0.4.0+3`
+* `catalyst_cardano_platform_interface` - `v0.4.0+3`
 
 Packages with dependency updates only:
 
-> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+> Packages listed below depend on other packages in this workspace that have had changes.
+> Their versions have been incremented to bump the minimum dependency versions of the packages
+> they depend upon in this project.
 
- - `catalyst_cardano_serialization` - `v0.5.0+3`
- - `catalyst_cardano_web` - `v0.4.0+3`
- - `catalyst_cardano_platform_interface` - `v0.4.0+3`
+* `catalyst_cardano_serialization` - `v0.5.0+3`
+* `catalyst_cardano_web` - `v0.4.0+3`
+* `catalyst_cardano_platform_interface` - `v0.4.0+3`
 
 ---
 
 #### `catalyst_cardano` - `v0.4.0+3`
 
- - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+* **FIX**(general): Update cat-ci to latest version to bring in doc test fixes and latest
+rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)).
+([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
 
 #### `catalyst_key_derivation` - `v0.1.2`
 
- - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
- - **FIX**: add missing dependency. ([1334cb06](https://github.com/input-output-hk/catalyst-voices/commit/1334cb066877b2507af2e469f31b6c3549181146))
- - **FEAT**(cat-voices): Enable the 'arithmetic_side_effects' Clippy lint ([#1456](https://github.com/input-output-hk/catalyst-voices/issues/1456)). ([5a0e2f46](https://github.com/input-output-hk/catalyst-voices/commit/5a0e2f46859b44ff325d47ca0eb90d4fa904d125))
- - **DOCS**: update pub.dev topics for catalyst_key_derivation package. ([a6d9bcfa](https://github.com/input-output-hk/catalyst-voices/commit/a6d9bcfa451cbb8d0ded9659e63fbfa290416480))
-
+* **FIX**(general): Update cat-ci to latest version to bring in doc test fixes and latest
+rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)).
+([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+* **FIX**: add missing dependency.
+([1334cb06](https://github.com/input-output-hk/catalyst-voices/commit/1334cb066877b2507af2e469f31b6c3549181146))
+* **FEAT**(cat-voices): Enable the 'arithmetic_side_effects' Clippy lint
+([#1456](https://github.com/input-output-hk/catalyst-voices/issues/1456)).
+([5a0e2f46](https://github.com/input-output-hk/catalyst-voices/commit/5a0e2f46859b44ff325d47ca0eb90d4fa904d125))
+* **DOCS**: update pub.dev topics for catalyst_key_derivation package.
+([a6d9bcfa](https://github.com/input-output-hk/catalyst-voices/commit/a6d9bcfa451cbb8d0ded9659e63fbfa290416480))
 
 ## 2025-01-02v2
 
@@ -56,14 +65,18 @@ Packages with breaking changes:
 Packages with other changes:
 
 * [Change Log](#change-log)
-  * [2025-01-02v2](#2025-01-02v2)
+  * [2025-01-13](#2025-01-13)
     * [Changes](#changes)
+      * [`catalyst_cardano` - `v0.4.0+3`](#catalyst_cardano---v0403)
+      * [`catalyst_key_derivation` - `v0.1.2`](#catalyst_key_derivation---v012)
+  * [2025-01-02v2](#2025-01-02v2)
+    * [Changes](#changes-1)
       * [`catalyst_key_derivation` - `v0.1.1+1`](#catalyst_key_derivation---v0111)
   * [2025-01-02v1](#2025-01-02v1)
-    * [Changes](#changes-1)
+    * [Changes](#changes-2)
       * [`catalyst_key_derivation` - `v0.1.1`](#catalyst_key_derivation---v011)
   * [2025-01-02](#2025-01-02)
-    * [Changes](#changes-2)
+    * [Changes](#changes-3)
       * [`catalyst_cardano` - `v0.4.0`](#catalyst_cardano---v040)
       * [`catalyst_cardano_platform_interface` - `v0.4.0`](#catalyst_cardano_platform_interface---v040)
       * [`catalyst_cardano_serialization` - `v0.5.0`](#catalyst_cardano_serialization---v050)
@@ -104,14 +117,18 @@ Packages with breaking changes:
 Packages with other changes:
 
 * [Change Log](#change-log)
-  * [2025-01-02v2](#2025-01-02v2)
+  * [2025-01-13](#2025-01-13)
     * [Changes](#changes)
+      * [`catalyst_cardano` - `v0.4.0+3`](#catalyst_cardano---v0403)
+      * [`catalyst_key_derivation` - `v0.1.2`](#catalyst_key_derivation---v012)
+  * [2025-01-02v2](#2025-01-02v2)
+    * [Changes](#changes-1)
       * [`catalyst_key_derivation` - `v0.1.1+1`](#catalyst_key_derivation---v0111)
   * [2025-01-02v1](#2025-01-02v1)
-    * [Changes](#changes-1)
+    * [Changes](#changes-2)
       * [`catalyst_key_derivation` - `v0.1.1`](#catalyst_key_derivation---v011)
   * [2025-01-02](#2025-01-02)
-    * [Changes](#changes-2)
+    * [Changes](#changes-3)
       * [`catalyst_cardano` - `v0.4.0`](#catalyst_cardano---v040)
       * [`catalyst_cardano_platform_interface` - `v0.4.0`](#catalyst_cardano_platform_interface---v040)
       * [`catalyst_cardano_serialization` - `v0.5.0`](#catalyst_cardano_serialization---v050)
@@ -161,14 +178,18 @@ Packages with breaking changes:
 Packages with other changes:
 
 * [Change Log](#change-log)
-  * [2025-01-02v2](#2025-01-02v2)
+  * [2025-01-13](#2025-01-13)
     * [Changes](#changes)
+      * [`catalyst_cardano` - `v0.4.0+3`](#catalyst_cardano---v0403)
+      * [`catalyst_key_derivation` - `v0.1.2`](#catalyst_key_derivation---v012)
+  * [2025-01-02v2](#2025-01-02v2)
+    * [Changes](#changes-1)
       * [`catalyst_key_derivation` - `v0.1.1+1`](#catalyst_key_derivation---v0111)
   * [2025-01-02v1](#2025-01-02v1)
-    * [Changes](#changes-1)
+    * [Changes](#changes-2)
       * [`catalyst_key_derivation` - `v0.1.1`](#catalyst_key_derivation---v011)
   * [2025-01-02](#2025-01-02)
-    * [Changes](#changes-2)
+    * [Changes](#changes-3)
       * [`catalyst_cardano` - `v0.4.0`](#catalyst_cardano---v040)
       * [`catalyst_cardano_platform_interface` - `v0.4.0`](#catalyst_cardano_platform_interface---v040)
       * [`catalyst_cardano_serialization` - `v0.5.0`](#catalyst_cardano_serialization---v050)

--- a/catalyst_voices/apps/voices/pubspec.yaml
+++ b/catalyst_voices/apps/voices/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
 dependencies:
   animated_text_kit: ^4.2.2
   animations: ^2.0.11
-  catalyst_cardano: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
-  catalyst_key_derivation: ^0.1.1+1
+  catalyst_cardano: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
+  catalyst_key_derivation: ^0.1.2
   catalyst_voices_assets:
     path: ../../packages/internal/catalyst_voices_assets
   catalyst_voices_blocs:

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 
 dependencies:
   bloc_concurrency: ^0.2.2
-  catalyst_cardano: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
-  catalyst_key_derivation: ^0.1.1+1
+  catalyst_cardano: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
+  catalyst_key_derivation: ^0.1.2
   catalyst_voices_brands:
     path: ../catalyst_voices_brands
   catalyst_voices_models:

--- a/catalyst_voices/packages/internal/catalyst_voices_models/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   bip39: ^1.0.6
-  catalyst_cardano: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
+  catalyst_cardano: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
   catalyst_voices_shared:
     path: ../catalyst_voices_shared
   collection: ^1.18.0

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano_serialization: ^0.5.0+2
+  catalyst_cardano_serialization: ^0.5.0+3
   catalyst_voices_models:
     path: ../catalyst_voices_models
   catalyst_voices_shared:

--- a/catalyst_voices/packages/internal/catalyst_voices_services/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
-  catalyst_key_derivation: ^0.1.1+1
+  catalyst_cardano: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
+  catalyst_key_derivation: ^0.1.2
   catalyst_voices_models:
     path: ../catalyst_voices_models
   catalyst_voices_repositories:

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/pubspec.yaml
@@ -8,10 +8,10 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano_serialization: ^0.5.0+2
+  catalyst_cardano_serialization: ^0.5.0+3
   catalyst_compression: ^0.4.0
   catalyst_cose: ^0.4.0
-  catalyst_key_derivation: ^0.1.1+1
+  catalyst_key_derivation: ^0.1.2
   catalyst_voices_models:
     path: ../catalyst_voices_models
   cbor: ^6.2.0

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
+  catalyst_cardano: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
   catalyst_voices_assets:
     path: ../catalyst_voices_assets
   catalyst_voices_localization:

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+ - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+
 ## 0.4.0+2
 
  - Update a dependency to the latest release.

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.0+3
 
- - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+ - **FIX**(general): Update cat-ci to latest version to bring in doc test fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
 
 ## 0.4.0+2
 

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
+  catalyst_cardano: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
   catalyst_compression: ^0.4.0
   catalyst_compression_web: ^0.4.0
-  catalyst_key_derivation: ^0.1.1+1
+  catalyst_key_derivation: ^0.1.2
   catalyst_voices_driver:
     path: ../../../../internal/catalyst_voices_driver
   cbor: ^6.2.0

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter plugin exposing the CIP-30 and CIP-95 APIs. Allows to com
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.4.0+2
+version: 0.4.0+3
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -16,9 +16,9 @@ flutter:
         default_package: catalyst_cardano_web
 
 dependencies:
-  catalyst_cardano_platform_interface: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
-  catalyst_cardano_web: ^0.4.0+2
+  catalyst_cardano_platform_interface: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
+  catalyst_cardano_web: ^0.4.0+3
   flutter:
     sdk: flutter
 

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+ - Update a dependency to the latest release.
+
 ## 0.4.0+2
 
  - Update a dependency to the latest release.

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
@@ -3,14 +3,14 @@ description: A common platform interface for the catalyst_cardano plugin.
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.4.0+2
+version: 0.4.0+3
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano_serialization: ^0.5.0+2
+  catalyst_cardano_serialization: ^0.5.0+3
   equatable: ^2.0.7
   flutter:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0+3
+
+ - Update a dependency to the latest release.
+
 ## 0.4.0+2
 
  - Update a dependency to the latest release.

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Web platform implementation of catalyst_cardano. Allows to communic
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.4.0+2
+version: 0.4.0+3
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -21,8 +21,8 @@ flutter:
     - assets/js/
 
 dependencies:
-  catalyst_cardano_platform_interface: ^0.4.0+2
-  catalyst_cardano_serialization: ^0.5.0+2
+  catalyst_cardano_platform_interface: ^0.4.0+3
+  catalyst_cardano_serialization: ^0.5.0+3
   cbor: ^6.2.0
   convert: ^3.1.1
   flutter:

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+3
+
+ - Update a dependency to the latest release.
+
 ## 0.5.0+2
 
  - Update a dependency to the latest release.

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
@@ -3,7 +3,7 @@ description: Dart package providing serialization/deserialization for common str
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices/packages/libs/catalyst_cardano_serialization
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [blockchain, cardano, cryptocurrency, wallet]
-version: 0.5.0+2
+version: 0.5.0+3
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
@@ -15,7 +15,7 @@ dependencies:
   bip32_ed25519: ^0.6.0
   catalyst_compression: ^0.4.0
   catalyst_compression_web: ^0.4.0
-  catalyst_key_derivation: ^0.1.1+1
+  catalyst_key_derivation: ^0.1.2
   cbor: ^6.2.0
   convert: ^3.1.1
   cryptography: ^2.7.0

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.2
 
- - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+ - **FIX**(general): Update cat-ci to latest version to bring in doc test fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
  - **FIX**: add missing dependency. ([1334cb06](https://github.com/input-output-hk/catalyst-voices/commit/1334cb066877b2507af2e469f31b6c3549181146))
  - **FEAT**(cat-voices): Enable the 'arithmetic_side_effects' Clippy lint ([#1456](https://github.com/input-output-hk/catalyst-voices/issues/1456)). ([5a0e2f46](https://github.com/input-output-hk/catalyst-voices/commit/5a0e2f46859b44ff325d47ca0eb90d4fa904d125))
  - **DOCS**: update pub.dev topics for catalyst_key_derivation package. ([a6d9bcfa](https://github.com/input-output-hk/catalyst-voices/commit/a6d9bcfa451cbb8d0ded9659e63fbfa290416480))

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/CHANGELOG.md
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.2
+
+ - **FIX**(general): Update cat-ci to latest version to bring in doctest fixes and latest rust compiler ([#1462](https://github.com/input-output-hk/catalyst-voices/issues/1462)). ([6ddc4c5e](https://github.com/input-output-hk/catalyst-voices/commit/6ddc4c5ea6e5e93a0042e188982505ba25cccf76))
+ - **FIX**: add missing dependency. ([1334cb06](https://github.com/input-output-hk/catalyst-voices/commit/1334cb066877b2507af2e469f31b6c3549181146))
+ - **FEAT**(cat-voices): Enable the 'arithmetic_side_effects' Clippy lint ([#1456](https://github.com/input-output-hk/catalyst-voices/issues/1456)). ([5a0e2f46](https://github.com/input-output-hk/catalyst-voices/commit/5a0e2f46859b44ff325d47ca0eb90d4fa904d125))
+ - **DOCS**: update pub.dev topics for catalyst_key_derivation package. ([a6d9bcfa](https://github.com/input-output-hk/catalyst-voices/commit/a6d9bcfa451cbb8d0ded9659e63fbfa290416480))
+
 ## 0.1.1+1
 
  - **DOCS**: update pub.dev topics for catalyst_key_derivation package. ([a6d9bcfa](https://github.com/input-output-hk/catalyst-voices/commit/a6d9bcfa451cbb8d0ded9659e63fbfa290416480))

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter plugin exposing CIP-1852 Cardano HD Key Derivation
 repository: https://github.com/input-output-hk/catalyst-voices/tree/main/catalyst_voices/packages/libs/catalyst_key_derivation
 issue_tracker: https://github.com/input-output-hk/catalyst-voices/issues
 topics: [cryptography, encryption]
-version: 0.1.1+1
+version: 0.1.2
 
 environment:
   sdk: ">=3.5.0 <4.0.0"

--- a/catalyst_voices/utilities/uikit_example/pubspec.yaml
+++ b/catalyst_voices/utilities/uikit_example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   flutter: ">=3.24.1"
 
 dependencies:
-  catalyst_cardano_serialization: ^0.5.0+2
+  catalyst_cardano_serialization: ^0.5.0+3
   catalyst_voices:
     path: ../../
   catalyst_voices_assets:


### PR DESCRIPTION
 - catalyst_cardano@0.4.0+3
 - catalyst_key_derivation@0.1.2
 - catalyst_cardano_serialization@0.5.0+3
 - catalyst_cardano_web@0.4.0+3
 - catalyst_cardano_platform_interface@0.4.0+3

# Description

Release dart/flutter packages to pub.dev. The changelogs are automatically generated by melos from commit history.

## Related Issue(s)

#1471