### PR TITLE
feat(cat-voices): Hero section - discovery page

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/discovery/discovery_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/discovery_page.dart
@@ -140,52 +140,6 @@ class _CampaignBrief extends StatelessWidget {
   }
 }
 
-class _CampaignBrief extends StatelessWidget {
-  const _CampaignBrief();
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          context.l10n.heroSectionTitle,
-          style: Theme.of(context).textTheme.displaySmall?.copyWith(
-                color: Theme.of(context).colorScheme.primary,
-              ),
-        ),
-        const SizedBox(height: 32),
-        Text(
-          context.l10n.projectCatalystDescription,
-          style: Theme.of(context).textTheme.bodyLarge,
-        ),
-        const SizedBox(height: 32),
-        Row(
-          children: [
-            VoicesFilledButton(
-              onTap: () {
-                // TODO(LynxxLynx): implement redirect to current campaign
-              },
-              child: Text(context.l10n.viewCurrentCampaign),
-            ),
-            const SizedBox(width: 8),
-            Offstage(
-              offstage: true,
-              child: VoicesOutlinedButton(
-                onTap: () {
-                  // TODO(LynxxLynx): implement redirect to my proposals
-                },
-                child: Text(context.l10n.myProposals),
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-}
-
 class _CampaignCategories extends StatelessWidget {
   const _CampaignCategories();
 

--- a/catalyst_voices/apps/voices/lib/widgets/heroes/section_hero.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/heroes/section_hero.dart
@@ -71,6 +71,7 @@ class _HeroSectionState extends State<HeroSection>
   Future<void> dispose() async {
     await _controller?.dispose();
     _controller = null;
+    super.dispose();
   }
 
   @override
@@ -109,6 +110,7 @@ class _Background extends StatelessWidget {
   const _Background({
     required this.controller,
   });
+  @override
   Widget build(BuildContext context) {
     return controller.value.isInitialized
         ? ConstrainedBox(
@@ -116,7 +118,6 @@ class _Background extends StatelessWidget {
             child: FittedBox(
               fit: BoxFit.cover,
               child: SizedBox(
-
                 width: controller.value.size.width,
                 height: controller.value.size.height,
                 child: VideoPlayer(controller),


### PR DESCRIPTION
# Description

Creating a hero section widget with video as a background for discovery page. Should video assets be cache somewhere?

## Related Issue(s)

Closes #1546 

## Description of Changes

- adding new hero section widget
- adding new types of assets `videos`

Should videos assets be somewhere cached? 

## Screenshots

https://github.com/user-attachments/assets/458e1634-cff8-4233-a45e-176c6c9d08a4

## Related Pull Requests

Depends on #1551 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
