### PR TITLE
fix(docs): Fix invalid md link

### DIFF
--- a/docs/src/architecture/08_concepts/domain-models/index.md
+++ b/docs/src/architecture/08_concepts/domain-models/index.md
@@ -57,7 +57,7 @@
 
 ## Entity Relationship (Work In Progress)
 
-[Download ER Diagram](src/architecture/08_concepts/domain-models/diagrams/entity_fund14.d2)
+[Download ER Diagram](diagrams/entity_fund14.d2)
 
 ```d2
 {{ include_file('src/architecture/08_concepts/domain-models/diagrams/entity_fund14.d2') }}


### PR DESCRIPTION
# Description

Fix the following CI `WARNING` failure
```
./docs+docs | WARNING -  Doc file 'architecture/08_concepts/domain-models/index.md' contains a link 'src/architecture/08_concepts/domain-models/diagrams/entity_fund14.d2', but the target 'architecture/08_concepts/domain-models/src/architecture/08_concepts/domain-models/diagrams/entity_fund14.d2' is not found among documentation files.
```