### PR TITLE
feat(cat-voices): add list length picker widget

### DIFF
--- a/catalyst_voices/apps/voices/lib/common/ext/document_property_schema_ext.dart
+++ b/catalyst_voices/apps/voices/lib/common/ext/document_property_schema_ext.dart
@@ -5,4 +5,8 @@ extension DocumentPropertySchemaExt on DocumentPropertySchema {
   String get formattedTitle {
     return title.starred(isEnabled: isRequired);
   }
+
+  String get formattedDescriptionOrTitle {
+    return (description?.data ?? title).starred(isEnabled: isRequired);
+  }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/document_token_value_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/document_token_value_widget.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/common/ext/document_property_schema_ext.dart';
 import 'package:catalyst_voices/common/ext/string_ext.dart';
 import 'package:catalyst_voices/widgets/text_field/token_field.dart';
 import 'package:catalyst_voices/widgets/text_field/voices_int_field.dart';
@@ -64,14 +65,13 @@ class _DocumentTokenValueWidgetState extends State<DocumentTokenValueWidget> {
   @override
   Widget build(BuildContext context) {
     final schema = widget.schema;
-    final label = schema.title;
 
     return TokenField(
       controller: _controller,
       focusNode: _focusNode,
       onFieldSubmitted: _notifyChangeListener,
       validator: _validate,
-      labelText: label.starred(isEnabled: schema.isRequired),
+      labelText: schema.formattedTitle,
       range: schema.numRange,
       currency: widget.currency,
       showHelper: widget.isEditMode,

--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/list_item_count_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/list_item_count_widget.dart
@@ -1,0 +1,71 @@
+import 'package:catalyst_voices/common/ext/document_property_schema_ext.dart';
+import 'package:catalyst_voices/widgets/dropdown/voices_dropdown.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:flutter/material.dart';
+
+class ListLengthPickerWidget extends StatelessWidget {
+  final DocumentListProperty list;
+  final bool isEditMode;
+  final ValueChanged<List<DocumentChange>> onChanged;
+
+  const ListLengthPickerWidget({
+    super.key,
+    required this.list,
+    required this.isEditMode,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final range = list.schema.itemsRange;
+    final minCount = range?.min ?? 0;
+    final maxCount = range?.max ?? 100;
+    final currentCount = list.properties.length;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          list.schema.formattedDescriptionOrTitle,
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
+        const SizedBox(height: 8),
+        SingleSelectDropdown(
+          items: [
+            for (int i = minCount; i <= maxCount; i++)
+              DropdownMenuEntry(
+                value: i,
+                // TODO(dtscalac): how to format as a plural?
+                label: '$i ${list.schema.itemsSchema.title}',
+              ),
+          ],
+          enabled: isEditMode,
+          onSelected: _onSelected,
+          initialValue: currentCount,
+          hintText: list.schema.placeholder,
+        ),
+      ],
+    );
+  }
+
+  void _onSelected(int? newCount) {
+    final currentCount = list.properties.length;
+    if (newCount == null || newCount == currentCount) {
+      return;
+    }
+
+    if (newCount > currentCount) {
+      final remainingCount = newCount - currentCount;
+      final change = DocumentAddListItemChange(nodeId: list.nodeId);
+      final changes = List.filled(remainingCount, change);
+      onChanged(changes);
+    } else {
+      final remainingCount = currentCount - newCount;
+      final changes = list.properties.reversed
+          .take(remainingCount)
+          .map((e) => DocumentRemoveListItemChange(nodeId: e.nodeId))
+          .toList();
+      onChanged(changes);
+    }
+  }
+}

--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/single_dropdown_selection_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/single_dropdown_selection_widget.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/common/ext/document_property_schema_ext.dart';
 import 'package:catalyst_voices/common/ext/text_editing_controller_ext.dart';
 import 'package:catalyst_voices/widgets/dropdown/voices_dropdown.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
@@ -70,7 +71,7 @@ class _SingleDropdownSelectionWidgetState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          widget.schema.title,
+          widget.schema.formattedTitle,
           style: Theme.of(context).textTheme.titleSmall,
         ),
         const SizedBox(height: 8),

--- a/catalyst_voices/apps/voices/lib/widgets/tiles/document_builder_section_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/tiles/document_builder_section_tile.dart
@@ -1,5 +1,6 @@
 import 'package:catalyst_voices/widgets/document_builder/agreement_confirmation_widget.dart';
 import 'package:catalyst_voices/widgets/document_builder/document_token_value_widget.dart';
+import 'package:catalyst_voices/widgets/document_builder/list_item_count_widget.dart';
 import 'package:catalyst_voices/widgets/document_builder/multiline_text_entry_markdown_widget.dart';
 import 'package:catalyst_voices/widgets/document_builder/simple_text_entry_widget.dart';
 import 'package:catalyst_voices/widgets/document_builder/single_dropdown_selection_widget.dart';
@@ -83,16 +84,17 @@ class _DocumentBuilderSectionTileState
               isEditMode: _isEditMode,
               onToggleEditMode: _toggleEditMode,
             ),
+            const SizedBox(height: 24),
             _PropertyBuilder(
-              key: ValueKey(_editedSection.schema.nodeId),
+              key: ValueKey(_editedSection.nodeId),
               property: _editedSection,
               isEditMode: _isEditMode,
               onChanged: _handlePropertyChanges,
             ),
             if (_isEditMode) ...[
-              const SizedBox(height: 12),
+              const SizedBox(height: 24),
               _Footer(
-                isValid: _editedSection.isValid,
+                isValid: _editedSection.isValidExcludingSubsections,
                 onSave: _saveChanges,
               ),
             ],
@@ -244,18 +246,24 @@ class _PropertyListBuilder extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
-      children: list.properties
-          .whereNot((child) => child.schema.isSubsection)
-          .map<Widget>((child) {
-            return _PropertyBuilder(
-              key: ValueKey(child.schema.nodeId),
-              property: child,
-              isEditMode: isEditMode,
-              onChanged: onChanged,
-            );
-          })
-          .separatedBy(const SizedBox(height: 24))
-          .toList(),
+      children: [
+        ListLengthPickerWidget(
+          key: ValueKey(list.nodeId),
+          list: list,
+          isEditMode: isEditMode,
+          onChanged: onChanged,
+        ),
+        ...list.properties
+            .whereNot((child) => child.schema.isSubsection)
+            .map<Widget>((child) {
+          return _PropertyBuilder(
+            key: ValueKey(child.nodeId),
+            property: child,
+            isEditMode: isEditMode,
+            onChanged: onChanged,
+          );
+        }),
+      ].separatedBy(const SizedBox(height: 24)).toList(),
     );
   }
 }
@@ -294,7 +302,7 @@ class _PropertyObjectBuilder extends StatelessWidget {
               .whereNot((child) => child.schema.isSubsection)
               .map<Widget>((child) {
                 return _PropertyBuilder(
-                  key: ValueKey(child.schema.nodeId),
+                  key: ValueKey(child.nodeId),
                   property: child,
                   isEditMode: isEditMode,
                   onChanged: onChanged,

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document.dart
@@ -69,6 +69,10 @@ sealed class DocumentProperty extends Equatable implements DocumentNode {
   /// false otherwise.
   bool get isValid;
 
+  /// Return true if the property (including children properties but excluding
+  /// children which are standalone sections) are valid, false otherwise.
+  bool get isValidExcludingSubsections;
+
   /// Returns the value related to this property.
   ///
   /// [DocumentListProperty] - returns a list of values.
@@ -111,6 +115,20 @@ final class DocumentListProperty extends DocumentProperty {
     }
 
     return properties.every((e) => e.isValid);
+  }
+
+  @override
+  bool get isValidExcludingSubsections {
+    if (validationResult.isInvalid) {
+      return false;
+    }
+
+    for (final property in properties) {
+      if (property.schema.isSubsection) continue;
+      if (!property.isValidExcludingSubsections) return false;
+    }
+
+    return true;
   }
 
   @override
@@ -177,6 +195,20 @@ final class DocumentObjectProperty extends DocumentProperty {
 
     for (final property in properties) {
       if (!property.isValid) return false;
+    }
+
+    return true;
+  }
+
+  @override
+  bool get isValidExcludingSubsections {
+    if (validationResult.isInvalid) {
+      return false;
+    }
+
+    for (final property in properties) {
+      if (property.schema.isSubsection) continue;
+      if (!property.isValidExcludingSubsections) return false;
     }
 
     return true;
@@ -251,6 +283,11 @@ final class DocumentValueProperty<T extends Object> extends DocumentProperty {
 
   @override
   bool get isValid {
+    return validationResult.isValid;
+  }
+
+  @override
+  bool get isValidExcludingSubsections {
     return validationResult.isValid;
   }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/schema/property/document_list_schema.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/schema/property/document_list_schema.dart
@@ -65,7 +65,7 @@ sealed class DocumentListSchema extends DocumentPropertySchema {
 
   /// The title of the child created from [itemsSchema].
   String getChildItemTitle(int index) {
-    return '${itemsSchema.title} ${index + 1}';
+    return '${itemsSchema.title} #${index + 1}';
   }
 
   @override


### PR DESCRIPTION
# Description

Adds a picker for document list property for deciding how many elements the list should contain.

## Related Issue(s)

List the issue numbers related to this pull request.

Closes #1654
Closes #1658 

## Screenshots

![Screenshot 2025-01-29 at 15 14 05](https://github.com/user-attachments/assets/076cf8e4-5a42-421a-aa2f-5a3399d80a56)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
