### PR TITLE
chore(cat-gateway): rm auth k8s health check

### DIFF
--- a/catalyst-gateway/bin/src/service/api/health/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/health/mod.rs
@@ -1,7 +1,10 @@
 //! Health Endpoints
 use poem_openapi::{param::Query, OpenApi};
 
-use crate::service::common::{auth::api_key::InternalApiKeyAuthorization, tags::ApiTags};
+use crate::service::common::{
+    auth::{api_key::InternalApiKeyAuthorization, none::NoAuthorization},
+    tags::ApiTags,
+};
 
 mod inspection_get;
 mod live_get;
@@ -28,7 +31,7 @@ impl HealthApi {
         method = "get",
         operation_id = "healthStarted"
     )]
-    async fn started_get(&self, _auth: InternalApiKeyAuthorization) -> started_get::AllResponses {
+    async fn started_get(&self, _auth: NoAuthorization) -> started_get::AllResponses {
         started_get::endpoint().await
     }
 
@@ -46,7 +49,7 @@ impl HealthApi {
         method = "get",
         operation_id = "healthReady"
     )]
-    async fn ready_get(&self, _auth: InternalApiKeyAuthorization) -> ready_get::AllResponses {
+    async fn ready_get(&self, _auth: NoAuthorization) -> ready_get::AllResponses {
         ready_get::endpoint().await
     }
 
@@ -59,7 +62,7 @@ impl HealthApi {
     /// *This endpoint is for internal use of the service deployment infrastructure.
     /// It may not be exposed publicly. Refer to []*
     #[oai(path = "/v1/health/live", method = "get", operation_id = "healthLive")]
-    async fn live_get(&self, _auth: InternalApiKeyAuthorization) -> live_get::AllResponses {
+    async fn live_get(&self, _auth: NoAuthorization) -> live_get::AllResponses {
         live_get::endpoint().await
     }
 

--- a/catalyst-gateway/bin/src/service/api/health/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/health/mod.rs
@@ -1,10 +1,7 @@
 //! Health Endpoints
 use poem_openapi::{param::Query, OpenApi};
 
-use crate::service::common::{
-    auth::{api_key::InternalApiKeyAuthorization, none::NoAuthorization},
-    tags::ApiTags,
-};
+use crate::service::common::{auth::none::NoAuthorization, tags::ApiTags};
 
 mod inspection_get;
 mod live_get;
@@ -49,7 +46,7 @@ impl HealthApi {
         method = "get",
         operation_id = "healthReady"
     )]
-    async fn ready_get(&self, _auth: InternalApiKeyAuthorization) -> ready_get::AllResponses {
+    async fn ready_get(&self, _auth: NoAuthorization) -> ready_get::AllResponses {
         ready_get::endpoint().await
     }
 
@@ -87,7 +84,7 @@ impl HealthApi {
         /// Enable or disable Verbose Query inspection in the logs.  Used to find query
         /// performance issues.
         query_inspection: Query<Option<inspection_get::DeepQueryInspectionFlag>>,
-        _auth: InternalApiKeyAuthorization,
+        _auth: NoAuthorization,
     ) -> inspection_get::AllResponses {
         inspection_get::endpoint(log_level.0, query_inspection.0).await
     }

--- a/catalyst-gateway/bin/src/service/api/health/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/health/mod.rs
@@ -49,7 +49,7 @@ impl HealthApi {
         method = "get",
         operation_id = "healthReady"
     )]
-    async fn ready_get(&self, _auth: NoAuthorization) -> ready_get::AllResponses {
+    async fn ready_get(&self, _auth: InternalApiKeyAuthorization) -> ready_get::AllResponses {
         ready_get::endpoint().await
     }
 

--- a/catalyst-gateway/bin/src/service/api/health/ready_get.rs
+++ b/catalyst-gateway/bin/src/service/api/health/ready_get.rs
@@ -35,6 +35,7 @@ pub(crate) type AllResponses = WithErrorResponses<Responses>;
 /// and is not able to properly service requests while it is occurring.
 /// This would let the load balancer shift traffic to other instances of this
 /// service that are ready.
+#[allow(clippy::unused_async)]
 pub(crate) async fn endpoint() -> AllResponses {
     // TODO: fix schema version check
     Responses::NoContent.into()

--- a/catalyst-gateway/bin/src/service/api/health/ready_get.rs
+++ b/catalyst-gateway/bin/src/service/api/health/ready_get.rs
@@ -1,11 +1,7 @@
 //! Implementation of the GET /health/ready endpoint
 use poem_openapi::ApiResponse;
-use tracing::{debug, error};
 
-use crate::{
-    db::event::{schema_check::MismatchedSchemaError, EventDB},
-    service::common::responses::WithErrorResponses,
-};
+use crate::service::common::responses::WithErrorResponses;
 
 /// Endpoint responses.
 #[derive(ApiResponse)]
@@ -14,6 +10,7 @@ pub(crate) enum Responses {
     #[oai(status = 204)]
     NoContent,
     /// Service is not ready, do not send other requests.
+    #[allow(dead_code)]
     #[oai(status = 503)]
     ServiceUnavailable,
 }
@@ -39,15 +36,17 @@ pub(crate) type AllResponses = WithErrorResponses<Responses>;
 /// This would let the load balancer shift traffic to other instances of this
 /// service that are ready.
 pub(crate) async fn endpoint() -> AllResponses {
-    match EventDB::schema_version_check().await {
-        Ok(_) => {
-            debug!("DB schema version status ok");
-            Responses::NoContent.into()
-        },
-        Err(err) if err.is::<MismatchedSchemaError>() => {
-            error!(id="health_ready_mismatch_schema", error=?err, "DB schema version mismatch");
-            Responses::ServiceUnavailable.into()
-        },
-        Err(err) => AllResponses::handle_error(&err),
-    }
+    // TODO: fix schema version check
+    Responses::NoContent.into()
+    // match EventDB::schema_version_check().await {
+    // Ok(_) => {
+    // debug!("DB schema version status ok");
+    // Responses::NoContent.into()
+    // },
+    // Err(err) if err.is::<MismatchedSchemaError>() => {
+    // error!(id="health_ready_mismatch_schema", error=?err, "DB schema version
+    // mismatch"); Responses::ServiceUnavailable.into()
+    // },
+    // Err(err) => AllResponses::handle_error(&err),
+    // }
 }


### PR DESCRIPTION
rm auth for k8s health checks and temporarily rm schema version check until we fix it.