### PR TITLE
chore(cat-voices): Making mouse on https text field as a click

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_https_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_https_text_field.dart
@@ -42,7 +42,7 @@ class _VoicesHttpsTextFieldState extends State<VoicesHttpsTextField>
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return InkWell(
       onTap: widget.enabled ? null : _launchUrl,
       child: VoicesTextField(
         controller: _effectiveController,
@@ -82,6 +82,7 @@ class _VoicesHttpsTextFieldState extends State<VoicesHttpsTextField>
         enabled: widget.enabled,
         readOnly: !widget.enabled,
         autovalidateMode: AutovalidateMode.onUserInteraction,
+        mouseCursor: widget.enabled ? null : SystemMouseCursors.click,
       ),
     );
   }

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_https_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_https_text_field.dart
@@ -42,7 +42,7 @@ class _VoicesHttpsTextFieldState extends State<VoicesHttpsTextField>
 
   @override
   Widget build(BuildContext context) {
-    return InkWell(
+    return GestureDetector(
       onTap: widget.enabled ? null : _launchUrl,
       child: VoicesTextField(
         controller: _effectiveController,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
@@ -98,6 +98,9 @@ class VoicesTextField extends StatefulWidget {
   /// [MaxLengthEnforcement]
   final MaxLengthEnforcement? maxLengthEnforcement;
 
+  /// [MouseCursor]
+  final MouseCursor? mouseCursor;
+
   final ValueChanged<VoicesTextFieldStatus>? onStatusChanged;
 
   const VoicesTextField({
@@ -132,6 +135,7 @@ class VoicesTextField extends StatefulWidget {
     this.inputFormatters,
     this.autovalidateMode,
     this.maxLengthEnforcement,
+    this.mouseCursor,
     this.onStatusChanged,
   });
 
@@ -239,6 +243,7 @@ class _VoicesTextFieldState extends State<VoicesTextField> {
           minHeight: widget.maxLines == null ? 65 : 48,
           iconBottomSpacing: widget.maxLines == null ? 18 : 0,
           child: TextFormField(
+            mouseCursor: widget.mouseCursor,
             key: const Key('VoicesTextField'),
             textAlignVertical: TextAlignVertical.top,
             autofocus: widget.autofocus,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
@@ -92,13 +92,13 @@ class VoicesTextField extends StatefulWidget {
   /// [TextField.inputFormatters]
   final List<TextInputFormatter>? inputFormatters;
 
-  /// [AutovalidateMode]
+  /// [TextFormField.autovalidateMode]
   final AutovalidateMode? autovalidateMode;
 
-  /// [MaxLengthEnforcement]
+  /// [TextField.maxLengthEnforcement]
   final MaxLengthEnforcement? maxLengthEnforcement;
 
-  /// [MouseCursor]
+  /// [TextField.mouseCursor]
   final MouseCursor? mouseCursor;
 
   final ValueChanged<VoicesTextFieldStatus>? onStatusChanged;


### PR DESCRIPTION

# Description

This just changes mouse to click if https textfield is not in edit mode for better visual that its clickable. 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
