### PR TITLE
fix(dart/catalyst_cardano_serialization): correct hashCode implementation for address equality

### DIFF
--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/address.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/address.dart
@@ -115,7 +115,7 @@ class ShelleyAddress extends Equatable implements CborEncodable {
   }
 
   @override
-  int get hashCode => Object.hash(bytes, hrp);
+  int get hashCode => toBech32().hashCode;
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
# Description

Correct hashCode implementation for address equality

## Related Issue(s)
N/A

## Description of Changes

- Fixed issue where equality for `ShelleyAddress` (`==`) worked as expected (`addr1 == addr2`), but the `Set` operation didn't remove duplicates due to inconsistent `hashCode` implementation.
- Updated hashCode to be consistent with `==` by using the `toBech32().hashCode`.

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
