### PR TITLE
test(cat-voices): Remove integration tests from nightly run

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -65,14 +65,6 @@ jobs:
             command: run
             args: ./catalyst-gateway/tests/schemathesis_tests+nightly-test-fuzzer-api
 
-      - name: Get integration tests report
-        uses: input-output-hk/catalyst-forge/actions/run@ci/v1.7.1
-        if: always()
-        continue-on-error: true
-        with:
-          command: run
-          args: ./catalyst_voices/apps/voices/integration_test+nightly-test-web-all
-
       - name: Collect and upload test reports
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
# Description

Remove integration tests from nightly run.
Tests are too flaky for CI in a current state, they can be run locally fairly quickly.
Plan is to come back to this when related flutter issue is released officially by flutter, issue [here](https://github.com/flutter/flutter/pull/159039)

## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #1, Resolves #1  Fixes #1

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #1, #1

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
