### PR TITLE
feat(cat-gateway): Remove unneeded patch of `orx-pseudo-default`

### DIFF
--- a/catalyst-gateway/Cargo.toml
+++ b/catalyst-gateway/Cargo.toml
@@ -50,7 +50,3 @@ unchecked_duration_subtraction = "deny"
 unreachable = "deny"
 missing_docs_in_private_items = "deny"
 arithmetic_side_effects = "deny"
-
-# https://github.com/orxfun/orx-pseudo-default/issues/11
-[patch.crates-io]
-orx-pseudo-default = { git = "https://github.com/orxfun/orx-pseudo-default?rev=1.4.0", tag = "1.4.0" }


### PR DESCRIPTION
# Description

Removed unneeded patch of `orx-pseudo-default` as https://github.com/orxfun/orx-pseudo-default/issues/11 resolved