### PR TITLE
fix(cat-voices): Dart format in melos file after updating Dart 3.7

### DIFF
--- a/catalyst-gateway/tests/schemathesis_tests/Earthfile
+++ b/catalyst-gateway/tests/schemathesis_tests/Earthfile
@@ -154,12 +154,13 @@ nightly-test-draft-schemathesis:
 nightly-test-dev-schemathesis:
     FROM earthly/dind:alpine-3.19-docker-25.0.5-r0
     RUN apk update && apk add iptables-legacy curl zstd # workaround for https://github.com/earthly/earthly/issues/3784
-    COPY schemathesis-docker-compose.yml .
     LET api_spec="https://gateway.dev.projectcatalyst.io/docs/cat-gateway.json"
     ARG wait_for_schema=15
     ARG max_response_time=300
     ARG hypothesis_max_examples=1000
     ARG seed
+
+    COPY ./../+docker-compose/docker-compose.yml .
 
     WITH DOCKER \
         --load schemathesis:latest=(+package-schemathesis --api_spec=$api_spec --seed=$seed \

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -195,18 +195,18 @@ scripts:
       Run `dart_code_metrics` in all packages.
       - Note: you can also rely on your IDEs Dart Analysis / Issues window.
 
-  format-apply:
+   format-apply:
     run: |
-      melos exec -c 1 --dir-exists="lib" -- "find . -name "*.dart" ! -name "*.g.dart" ! -path '*/generated/*' ! -path './.dart_tool/*' | tr '\n' ' ' | xargs dart format --fix" &&
-      melos exec -c 1 --dir-exists="test" -- "find . -name "*.dart" ! -name "*.g.dart" ! -path '*/generated/*' ! -path './.dart_tool/*' | tr '\n' ' ' | xargs dart format --fix" &&
-      melos exec -c 1 --dir-exists="integration_test" -- "find . -name "*.dart" ! -name "*.g.dart" ! -path '*/generated/*' ! -path './.dart_tool/*' | tr '\n' ' ' | xargs dart format --fix"
+      melos exec -c 1 --dir-exists="lib" -- "find lib -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format {} +" &&
+      melos exec -c 1 --dir-exists="test" -- "find test -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format {} +" &&
+      melos exec -c 1 --dir-exists="integration_test" -- "find integration_test -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format {} +"
     description: Run `dart format` for all packages.
 
   format-check:
     run: |
-      melos exec -c 1 --dir-exists="lib" -- "find . -name "*.dart" ! -name "*.g.dart" ! -path '*/generated/*' ! -path './.dart_tool/*' | tr '\n' ' ' | xargs dart format --output none --set-exit-if-changed" &&
-      melos exec -c 1 --dir-exists="test" -- "find . -name "*.dart" ! -name "*.g.dart" ! -path '*/generated/*' ! -path './.dart_tool/*' | tr '\n' ' ' | xargs dart format --output none --set-exit-if-changed" &&
-      melos exec -c 1 --dir-exists="integration_test" -- "find . -name "*.dart" ! -name "*.g.dart" ! -path '*/generated/*' ! -path './.dart_tool/*' | tr '\n' ' ' | xargs dart format --output none --set-exit-if-changed"
+      melos exec -c 1 --dir-exists="lib" -- "find lib -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format --output none --set-exit-if-changed {} +" &&
+      melos exec -c 1 --dir-exists="test" -- "find test -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format --output none --set-exit-if-changed {} +" &&
+      melos exec -c 1 --dir-exists="integration_test" -- "find integration_test -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format --output none --set-exit-if-changed {} +"
     description: Run `dart format` checks for all packages.
 
   license-check:

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -195,7 +195,7 @@ scripts:
       Run `dart_code_metrics` in all packages.
       - Note: you can also rely on your IDEs Dart Analysis / Issues window.
 
-   format-apply:
+  format-apply:
     run: |
       melos exec -c 1 --dir-exists="lib" -- "find lib -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format {} +" &&
       melos exec -c 1 --dir-exists="test" -- "find test -name '*.dart' ! -name '*.g.dart' ! -path '*/generated/*' ! -path '*/.dart_tool/*' -exec dart format {} +" &&
@@ -242,11 +242,11 @@ scripts:
         EXIT_CODE=$? ; \
         cat $TESTS_OUTPUT_FILE | tojunit --output $JUNIT_REPORT_FILE ; \
         exit $EXIT_CODE'
-      
+
       # store the exit code after running the tests,
       # this is the exit code for the whole script
       EXIT_CODE=$?
-      
+
       # removes code coverage for generated code
       find . -name "*.lcov.info" -exec \
         lcov --remove {} -o {} --ignore-errors unused,unused \
@@ -259,10 +259,10 @@ scripts:
         '*.swagger.*.dart' \
         '*.drift.dart' \
         'lib/generated/**' \;
-      
+
       # merges all coverage reports into a single one and puts it in /coverage/lcov.info
       dart pub global run combine_coverage --repo-path=.
-      
+
       exit $EXIT_CODE
 
     description: |


### PR DESCRIPTION
# Description

In new [Dart 3.7](https://medium.com/dartlang/announcing-dart-3-7-bf864a1b195c) there was a change to `dart format --fix` this PR fixes issue with dart format being not supported any more

```
There is one breaking change as well. The formatter no longer supports dart format --fix. 
Instead, use dart fix to apply all the fixes that dart format could, and more.
```

## Related Issue(s)

N/A

## Description of Changes

-changing melos script for format-apply and format-check

## Breaking Changes

- changing melos in catalyst_voices

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
