### PR TITLE
fix(cat-voices): Final keyword in _border and padding in campaign timeline

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/campaign_hero.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/campaign_hero.dart
@@ -96,6 +96,7 @@ class _DiscoveryMyProposalsButton extends StatelessWidget {
             },
             style: OutlinedButton.styleFrom(
               backgroundColor: ThemeBuilder.buildTheme().colorScheme.primary,
+              foregroundColor: ThemeBuilder.buildTheme().colorScheme.onPrimary,
             ),
             child: Text(context.l10n.myProposals),
           ),

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/current_campaign.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/current_campaign.dart
@@ -47,6 +47,7 @@ class CurrentCampaign extends StatelessWidget {
           child: CampaignTimeline(
             timelineItems: CampaignTimelineViewModelX.mockData,
             placement: CampaignTimelinePlacement.discovery,
+            horizontalPadding: const SizedBox(width: 120),
           ),
         ),
       ],

--- a/catalyst_voices/apps/voices/lib/widgets/campaign_timeline/campaign_timeline.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/campaign_timeline/campaign_timeline.dart
@@ -6,12 +6,14 @@ class CampaignTimeline extends StatefulWidget {
   final List<CampaignTimelineViewModel> timelineItems;
   final CampaignTimelinePlacement placement;
   final ValueChanged<bool>? onExpandedChanged;
+  final SizedBox horizontalPadding;
 
   const CampaignTimeline({
     super.key,
     required this.timelineItems,
     required this.placement,
     this.onExpandedChanged,
+    this.horizontalPadding = const SizedBox.shrink(),
   });
 
   @override
@@ -41,6 +43,7 @@ class CampaignTimelineState extends State<CampaignTimeline> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                widget.horizontalPadding,
                 ...widget.timelineItems.asMap().entries.map(
                       (entry) => CampaignTimelineCard(
                         timelineItem: entry.value,
@@ -50,6 +53,7 @@ class CampaignTimelineState extends State<CampaignTimeline> {
                         },
                       ),
                     ),
+                widget.horizontalPadding,
               ],
             ),
           ),

--- a/catalyst_voices/apps/voices/lib/widgets/cards/pending_proposal_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/pending_proposal_card.dart
@@ -30,43 +30,114 @@ class PendingProposalCard extends StatefulWidget {
   State<PendingProposalCard> createState() => _PendingProposalCardState();
 }
 
-class _PendingProposalCardState extends State<PendingProposalCard> {
-  late final WidgetStatesController _statesController;
-  late final _ProposalBorderColor _border;
+class _Author extends StatelessWidget {
+  final String author;
+
+  const _Author({
+    required this.author,
+  });
 
   @override
-  void initState() {
-    super.initState();
-    _statesController = WidgetStatesController();
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _border = _ProposalBorderColor(
-      publishStage: widget.proposal.publishStage,
-      colorScheme: context.colorScheme,
-      colors: context.colors,
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          VoicesAvatar(
+            icon: Text(author[0]),
+            backgroundColor: context.colors.primaryContainer,
+            foregroundColor: context.colors.textOnPrimaryWhite,
+          ),
+          const SizedBox(width: 8),
+          Text(
+            author,
+            style: context.textTheme.titleSmall?.copyWith(
+              color: context.colors.textOnPrimaryLevel1,
+            ),
+          ),
+        ],
+      ),
     );
   }
+}
+
+class _Category extends StatelessWidget {
+  final String category;
+
+  const _Category({
+    required this.category,
+  });
 
   @override
-  void didUpdateWidget(PendingProposalCard oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.proposal.publishStage != oldWidget.proposal.publishStage) {
-      _border = _ProposalBorderColor(
-        publishStage: widget.proposal.publishStage,
-        colors: context.colors,
-        colorScheme: context.colorScheme,
-      );
-    }
+  Widget build(BuildContext context) {
+    return Text(
+      category,
+      style: context.textTheme.labelMedium?.copyWith(
+        color: context.colors.textDisabled,
+      ),
+    );
   }
+}
+
+class _Description extends StatelessWidget {
+  final String text;
+
+  const _Description({required this.text});
 
   @override
-  void dispose() {
-    _statesController.dispose();
-    super.dispose();
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: Theme.of(context).colors.textOnPrimaryLevel0,
+          ),
+      maxLines: 5,
+      overflow: TextOverflow.ellipsis,
+    );
   }
+}
+
+class _FundsAndDuration extends StatelessWidget {
+  final String funds;
+  final int duration;
+
+  const _FundsAndDuration({
+    required this.funds,
+    required this.duration,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: SizedBox(
+        width: double.infinity,
+        child: Wrap(
+          alignment: WrapAlignment.spaceBetween,
+          children: [
+            _PropertyValue(
+              title: context.l10n.fundsRequested,
+              formattedValue: funds,
+            ),
+            _PropertyValue(
+              title: context.l10n.duration,
+              formattedValue: context.l10n.valueMonths(duration),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PendingProposalCardState extends State<PendingProposalCard> {
+  late final WidgetStatesController _statesController;
+  late _ProposalBorderColor _border;
 
   bool isHovered = false;
 
@@ -131,186 +202,39 @@ class _PendingProposalCardState extends State<PendingProposalCard> {
       ),
     );
   }
-}
-
-final class _ProposalBorderColor extends WidgetStateColor {
-  final ProposalPublish publishStage;
-  final VoicesColorScheme colors;
-  final ColorScheme colorScheme;
-
-  _ProposalBorderColor({
-    required this.publishStage,
-    required this.colors,
-    required this.colorScheme,
-  }) : super(colors.outlineBorder.toARGB32());
 
   @override
-  Color resolve(Set<WidgetState> states) {
-    if (states.contains(WidgetState.hovered)) {
-      return switch (publishStage) {
-        ProposalPublish.draft => colorScheme.secondary,
-        ProposalPublish.published => colorScheme.primary,
-      };
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _border = _ProposalBorderColor(
+      publishStage: widget.proposal.publishStage,
+      colorScheme: context.colorScheme,
+      colors: context.colors,
+    );
+  }
+
+  @override
+  void didUpdateWidget(PendingProposalCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.proposal.publishStage != oldWidget.proposal.publishStage) {
+      _border = _ProposalBorderColor(
+        publishStage: widget.proposal.publishStage,
+        colors: context.colors,
+        colorScheme: context.colorScheme,
+      );
     }
-
-    return colors.elevationsOnSurfaceNeutralLv1White;
   }
-}
-
-class _Topbar extends StatelessWidget {
-  final bool showStatus;
-  final bool isFavorite;
-  final ValueChanged<bool>? onFavoriteChanged;
-
-  const _Topbar({
-    required this.showStatus,
-    required this.isFavorite,
-    required this.onFavoriteChanged,
-  });
 
   @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        const Spacer(),
-        VoicesIconButton.filled(
-          onTap: () {},
-          style: _buttonStyle(context),
-          child: VoicesAssets.icons.share.buildIcon(
-            color: context.colorScheme.primary,
-          ),
-        ),
-        if (onFavoriteChanged != null) ...[
-          const SizedBox(width: 4),
-          VoicesIconButton.filled(
-            onTap: () => onFavoriteChanged?.call(!isFavorite),
-            style: _buttonStyle(context),
-            child: CatalystSvgIcon.asset(
-              isFavorite
-                  ? VoicesAssets.icons.starFilled.path
-                  : VoicesAssets.icons.starOutlined.path,
-              color: context.colorScheme.primary,
-            ),
-          ),
-        ],
-      ],
-    );
+  void dispose() {
+    _statesController.dispose();
+    super.dispose();
   }
-
-  ButtonStyle _buttonStyle(BuildContext context) {
-    return IconButton.styleFrom(
-      padding: const EdgeInsets.all(10),
-      backgroundColor: context.colors.onSurfacePrimary08,
-      foregroundColor: context.colorScheme.primary,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-      ),
-      iconSize: 18,
-    );
-  }
-}
-
-class _Category extends StatelessWidget {
-  final String category;
-
-  const _Category({
-    required this.category,
-  });
 
   @override
-  Widget build(BuildContext context) {
-    return Text(
-      category,
-      style: context.textTheme.labelMedium?.copyWith(
-        color: context.colors.textDisabled,
-      ),
-    );
-  }
-}
-
-class _Title extends StatelessWidget {
-  final String text;
-
-  const _Title({required this.text});
-
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      text,
-      style: Theme.of(context).textTheme.titleLarge,
-      maxLines: 2,
-      overflow: TextOverflow.ellipsis,
-    );
-  }
-}
-
-class _Author extends StatelessWidget {
-  final String author;
-
-  const _Author({
-    required this.author,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 12),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          VoicesAvatar(
-            icon: Text(author[0]),
-            backgroundColor: context.colors.primaryContainer,
-            foregroundColor: context.colors.textOnPrimaryWhite,
-          ),
-          const SizedBox(width: 8),
-          Text(
-            author,
-            style: context.textTheme.titleSmall?.copyWith(
-              color: context.colors.textOnPrimaryLevel1,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _FundsAndDuration extends StatelessWidget {
-  final String funds;
-  final int duration;
-
-  const _FundsAndDuration({
-    required this.funds,
-    required this.duration,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: SizedBox(
-        width: double.infinity,
-        child: Wrap(
-          alignment: WrapAlignment.spaceBetween,
-          children: [
-            _PropertyValue(
-              title: context.l10n.fundsRequested,
-              formattedValue: funds,
-            ),
-            _PropertyValue(
-              title: context.l10n.duration,
-              formattedValue: context.l10n.valueMonths(duration),
-            ),
-          ],
-        ),
-      ),
-    );
+  void initState() {
+    super.initState();
+    _statesController = WidgetStatesController();
   }
 }
 
@@ -347,21 +271,27 @@ class _PropertyValue extends StatelessWidget {
   }
 }
 
-class _Description extends StatelessWidget {
-  final String text;
+final class _ProposalBorderColor extends WidgetStateColor {
+  final ProposalPublish publishStage;
+  final VoicesColorScheme colors;
+  final ColorScheme colorScheme;
 
-  const _Description({required this.text});
+  _ProposalBorderColor({
+    required this.publishStage,
+    required this.colors,
+    required this.colorScheme,
+  }) : super(colors.outlineBorder.toARGB32());
 
   @override
-  Widget build(BuildContext context) {
-    return Text(
-      text,
-      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-            color: Theme.of(context).colors.textOnPrimaryLevel0,
-          ),
-      maxLines: 5,
-      overflow: TextOverflow.ellipsis,
-    );
+  Color resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.hovered)) {
+      return switch (publishStage) {
+        ProposalPublish.draft => colorScheme.secondary,
+        ProposalPublish.published => colorScheme.primary,
+      };
+    }
+
+    return colors.elevationsOnSurfaceNeutralLv1White;
   }
 }
 
@@ -447,5 +377,75 @@ class _ProposalInfo extends StatelessWidget {
     final dt = DateFormatter.formatDateTimeParts(lastUpdate, includeYear: true);
 
     return context.l10n.publishedOn(dt.date, dt.time);
+  }
+}
+
+class _Title extends StatelessWidget {
+  final String text;
+
+  const _Title({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.titleLarge,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+
+class _Topbar extends StatelessWidget {
+  final bool showStatus;
+  final bool isFavorite;
+  final ValueChanged<bool>? onFavoriteChanged;
+
+  const _Topbar({
+    required this.showStatus,
+    required this.isFavorite,
+    required this.onFavoriteChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Spacer(),
+        VoicesIconButton.filled(
+          onTap: () {},
+          style: _buttonStyle(context),
+          child: VoicesAssets.icons.share.buildIcon(
+            color: context.colorScheme.primary,
+          ),
+        ),
+        if (onFavoriteChanged != null) ...[
+          const SizedBox(width: 4),
+          VoicesIconButton.filled(
+            onTap: () => onFavoriteChanged?.call(!isFavorite),
+            style: _buttonStyle(context),
+            child: CatalystSvgIcon.asset(
+              isFavorite
+                  ? VoicesAssets.icons.starFilled.path
+                  : VoicesAssets.icons.starOutlined.path,
+              color: context.colorScheme.primary,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  ButtonStyle _buttonStyle(BuildContext context) {
+    return IconButton.styleFrom(
+      padding: const EdgeInsets.all(10),
+      backgroundColor: context.colors.onSurfacePrimary08,
+      foregroundColor: context.colorScheme.primary,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+      ),
+      iconSize: 18,
+    );
   }
 }


### PR DESCRIPTION

# Description

Final keyword in _border for proposal_cards throws an exception while changing a theme so its needed to be deleted. 
Also added optional horizontal padding in the timeline campaign because its wasn't working on discovery page.
Minor change to foreground color in MyProposals discovery page

## Related Issue(s)

N/A

## Description of Changes

- remove final keyword in _border for proposals_card
- adding optional horizontal padding
- changing foreground color for MyProposals button in discovery Page.

## Breaking Changes

N/A 

## Screenshots
Before
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/ccf5011e-9c46-4cb5-b463-132209c0d9f6" />
After
<img width="1408" alt="image" src="https://github.com/user-attachments/assets/c5d4f418-cc1a-4e0c-8469-630ebce57411" />


## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
