### PR TITLE
fix(cat-voices): changing implementation of precache images

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/app_precache_image_assets.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_precache_image_assets.dart
@@ -1,159 +1,93 @@
 import 'package:catalyst_voices/widgets/indicators/voices_circular_progress_indicator.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-class GlobalPrecacheImages extends StatelessWidget {
+class GlobalPrecacheImages extends StatefulWidget {
   final Widget child;
 
-  const GlobalPrecacheImages({
-    super.key,
-    required this.child,
-  });
+  const GlobalPrecacheImages({super.key, required this.child});
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+  State<GlobalPrecacheImages> createState() => _GlobalPrecacheImagesState();
+}
 
-    return AppPrecacheImageAssets(
-      svgs: [
-        theme.brandAssets.brand.logo(context),
-        theme.brandAssets.brand.logoIcon(context),
-      ],
-      assets: [
-        VoicesAssets.images.comingSoonBkg,
-      ],
-      child: child,
-    );
+class ImagePrecacheService {
+  static final ImagePrecacheService _instance = ImagePrecacheService._();
+
+  static ImagePrecacheService get instance => _instance;
+  bool _isInitialized = false;
+
+  final Set<SvgGenImage> _svgs = {};
+  final Set<AssetGenImage> _assets = {};
+
+  Brightness? _lastThemeMode;
+  ImagePrecacheService._();
+
+  bool get isInitialized => _isInitialized;
+
+  Future<void> precacheAssets(
+    BuildContext context, {
+    List<SvgGenImage> svgs = const [],
+    List<AssetGenImage> assets = const [],
+  }) async {
+    if (_isInitialized) return;
+
+    _svgs.addAll(svgs);
+    _assets.addAll(assets);
+
+    await Future.wait([
+      ..._svgs.map((e) => e.cache(context: context)),
+      ..._assets.map((e) => e.cache(context: context)),
+    ]);
+
+    _isInitialized = true;
+  }
+
+  void resetCacheIfNeeded(ThemeData theme) {
+    if (_lastThemeMode != theme.brightness) {
+      _isInitialized = false;
+      _lastThemeMode = theme.brightness;
+    }
   }
 }
 
-/// A widget that pre-caches SVG and image assets before displaying its
-/// child widget.
-///
-/// This widget is useful for improving the perceived performance of your
-/// app by pre-loading any necessary image assets before they are displayed on
-/// the screen.
-/// This can help to avoid stuttering or delays when the user navigates to a
-/// new screen that requires those images.
-///
-/// [AppPrecacheImageAssets] depends on [Theme] and is trying to make
-/// as little work as possible when [Theme] is changing by caching
-/// previously loaded assets.
-class AppPrecacheImageAssets extends StatefulWidget {
-  /// List of [SvgGenImage] which should be cached.
-  final List<SvgGenImage> svgs;
-
-  /// List of [AssetGenImage] which should be cached.
-  final List<AssetGenImage> assets;
-
-  /// The child widget to be displayed once the images have been pre-cached.
-  final Widget child;
-
-  const AppPrecacheImageAssets({
-    super.key,
-    this.svgs = const [],
-    this.assets = const [],
-    required this.child,
-  });
+class _GlobalPrecacheImagesState extends State<GlobalPrecacheImages> {
+  Future<void>? _precacheFuture;
 
   @override
-  State<AppPrecacheImageAssets> createState() => _AppPrecacheImageAssetsState();
-}
-
-class _AppPrecacheImageAssetsState extends State<AppPrecacheImageAssets> {
-  final _svgs = <SvgGenImage>[];
-  final _assets = <AssetGenImage>[];
-
-  bool _hadImages = false;
-
-  late Future<void> _cacheFuture;
-
-  @override
-  void didUpdateWidget(AppPrecacheImageAssets oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    if (_areImagesDifferent()) {
-      _updateImagesCache();
-    }
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _precacheFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting &&
+            !ImagePrecacheService.instance.isInitialized) {
+          return const Center(child: VoicesCircularProgressIndicator());
+        }
+        return widget.child;
+      },
+    );
   }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    // Caching depends on context. Rebuild when changes.
-    _updateImagesCache();
+    _precacheFuture ??= Future.microtask(() async => _precacheImages());
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<void>(
-      future: _cacheFuture,
-      builder: (context, snapshot) {
-        return switch (snapshot.connectionState) {
-          // Only blocking when does did not have images eg. First run.
-          // Do not block when theme mode is changing because it will
-          // cause blinking.
-          ConnectionState.active ||
-          ConnectionState.waiting when !_hadImages =>
-            const _ProgressIndicator(),
-          ConnectionState.none ||
-          ConnectionState.waiting ||
-          ConnectionState.active ||
-          ConnectionState.done =>
-            widget.child,
-        };
-      },
+  Future<void> _precacheImages() {
+    final theme = Theme.of(context);
+
+    ImagePrecacheService.instance.resetCacheIfNeeded(theme);
+
+    return ImagePrecacheService.instance.precacheAssets(
+      context,
+      svgs: [
+        theme.brandAssets.brand.logo(context),
+        theme.brandAssets.brand.logoIcon(context),
+      ],
+      assets: [VoicesAssets.images.comingSoonBkg],
     );
-  }
-
-  void _updateImagesCache() {
-    _hadImages = _svgs.isNotEmpty || _assets.isNotEmpty;
-
-    _svgs
-      ..clear()
-      ..addAll(widget.svgs);
-    _assets
-      ..clear()
-      ..addAll(widget.assets);
-
-    // ignore: discarded_futures
-    _cacheFuture = _buildCacheFuture(svgs: _svgs, assets: _assets);
-  }
-
-  bool _areImagesDifferent() {
-    final old = [
-      ..._svgs.map((e) => e.path),
-      ..._assets.map((e) => e.path),
-    ];
-    final current = [
-      ...widget.svgs.map((e) => e.path),
-      ...widget.assets.map((e) => e.path),
-    ];
-
-    return !listEquals(old, current);
-  }
-
-  Future<void> _buildCacheFuture({
-    List<SvgGenImage> svgs = const [],
-    List<AssetGenImage> assets = const [],
-  }) {
-    final futures = <Future<void>>[
-      ...svgs.map((e) => e.cache(context: context)),
-      ...assets.map((e) => e.cache(context: context)),
-    ];
-
-    return Future.wait(futures);
-  }
-}
-
-class _ProgressIndicator extends StatelessWidget {
-  const _ProgressIndicator();
-
-  @override
-  Widget build(BuildContext context) {
-    return const Center(child: VoicesCircularProgressIndicator());
   }
 }


### PR DESCRIPTION
# Description

After investigating why app is loosing state when we use widget inspect mode from widget inspector I found out that the problem is with `GlobalPrecacheImages` selecting inspect mode triggered didChangeDependencies which resets the gorouter instance.

## Related Issue(s)

N/A

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
