### PR TITLE
fix(cat-gateway): Set a strict version of the `base64ct` transitive dep

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -75,9 +75,6 @@ poem-openapi = { version = "=5.1.5", features = [
     "url",
     "chrono",
 ] }
-# Its a transitive dependency of the "poem-openapi" crate,
-# but its breaks API after version "5.1.8".
-poem-openapi-derive = { version = "=5.1.4"}
 uuid = { version = "1.12.1", features = ["v4", "v7", "serde"] }
 ulid = { version = "1.1.3", features = ["serde", "uuid"] }
 blake2b_simd = "1.0.2"
@@ -103,6 +100,13 @@ memory-stats = "1.0.0"
 derive_more = { version = "2.0.1", default-features = false, features = ["from", "into"] }
 rayon = "1.10"
 
+# Its a transitive dependency of the "poem-openapi" crate,
+# but its breaks API after version "5.1.8".
+poem-openapi-derive = { version = "=5.1.4"}
+# Its a transitive dependency which fails to build on higher version with our current compiler 1.83
+base64ct = { version = "=1.6.0" }
+
+
 [dev-dependencies]
 x509-cert = { version = "0.2.5", features = ["builder"] }
 
@@ -110,5 +114,5 @@ x509-cert = { version = "0.2.5", features = ["builder"] }
 build-info-build = "0.0.39"
 
 [package.metadata.cargo-machete]
-# remove that after fixing issues with latest "poem-openapi-derive" crate
-ignored = ["poem-openapi-derive"]
+# remove that after fixing issues with latest crates
+ignored = ["poem-openapi-derive", "base64ct"]

--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -106,7 +106,6 @@ poem-openapi-derive = { version = "=5.1.4"}
 # Its a transitive dependency which fails to build on higher version with our current compiler 1.83
 base64ct = { version = "=1.6.0" }
 
-
 [dev-dependencies]
 x509-cert = { version = "0.2.5", features = ["builder"] }
 


### PR DESCRIPTION
# Description

`base64ct` crate just released a new version which requires a latest compiler `1.85` which does not work in our case.
Set a strict version of the `base64ct` transitive dep. 