### PR TITLE
fix(cat-gateway): Fix `ContentErrorDetail` OpenApi definition

### DIFF
--- a/catalyst-gateway/bin/src/service/common/responses/code_412_precondition_failed.rs
+++ b/catalyst-gateway/bin/src/service/common/responses/code_412_precondition_failed.rs
@@ -68,16 +68,19 @@ impl Example for ContentErrorDetailList {
 /// request.
 pub(crate) struct ContentErrorDetail {
     /// The location of the error
-    #[oai(nullable)]
+    #[oai(skip_serializing_if_is_none)]
     loc: Option<common::types::generic::error_list::ErrorList>,
     /// The error message.
-    #[oai(validator(max_length = "1000", pattern = "^[0-9a-zA-Z].*$"), nullable)]
+    #[oai(
+        validator(max_length = "1000", pattern = "^[0-9a-zA-Z].*$"),
+        skip_serializing_if_is_none
+    )]
     msg: Option<common::types::generic::error_msg::ErrorMessage>,
     /// The type of error
     #[oai(
         rename = "type",
         validator(max_length = "1000", pattern = "^[0-9a-zA-Z].*$"),
-        nullable
+        skip_serializing_if_is_none
     )]
     err_type: Option<common::types::generic::error_msg::ErrorMessage>,
 }


### PR DESCRIPTION
# Description

Fix `ContentErrorDetail`  OpenApi definition, replace using `nullable` with `skip_serializing_if_is_none`