### PR TITLE
fix(cat-gateway): Move `ADDRESS` and `SERVER_NAME` settings to be only configured from env vars

### DIFF
--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -74,6 +74,7 @@ build:
         --docs="true"
 
     # Generate the OpenAPI doc from the cat-gateway executable itself.
+    ENV API_HOST_NAMES "https://gateway.dev.projectcatalyst.io"
     RUN ./target/release/cat-gateway docs ./target/doc/cat-gateway-api.json
 
     SAVE ARTIFACT target/doc doc

--- a/catalyst-gateway/bin/src/cli.rs
+++ b/catalyst-gateway/bin/src/cli.rs
@@ -1,5 +1,5 @@
 //! CLI interpreter for the service
-use std::io::Write;
+use std::{io::Write, path::PathBuf};
 
 use clap::Parser;
 use tracing::{error, info};
@@ -11,7 +11,7 @@ use crate::{
         self, started,
         utilities::health::{is_live, live_counter_reset},
     },
-    settings::{DocsSettings, ServiceSettings, Settings},
+    settings::{ServiceSettings, Settings},
 };
 
 #[derive(Parser)]
@@ -21,7 +21,10 @@ pub(crate) enum Cli {
     /// Run the service
     Run(ServiceSettings),
     /// Build API docs of the service in the JSON format
-    Docs(DocsSettings),
+    Docs {
+        /// The output path to the generated docs file, if omitted prints to stdout.
+        output: Option<PathBuf>,
+    },
 }
 
 impl Cli {
@@ -79,9 +82,9 @@ impl Cli {
 
                 info!("Catalyst Gateway - Shut Down");
             },
-            Self::Docs(settings) => {
+            Self::Docs { output } => {
                 let docs = service::get_app_docs();
-                match settings.output {
+                match output {
                     Some(path) => {
                         let mut docs_file = std::fs::File::create(path)?;
                         docs_file.write_all(docs.as_bytes())?;

--- a/catalyst-gateway/bin/src/service/api/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/mod.rs
@@ -73,7 +73,9 @@ pub(crate) fn mk_api() -> OpenApiService<(HealthApi, CardanoApi, ConfigApi, Docu
         service = set_localhost_addresses(service);
     } else {
         for host in &hosts {
-            service = service.server(ServerObject::new(host).description("Server host staging/production location."));
+            service = service.server(
+                ServerObject::new(host).description("Server host staging/production location."),
+            );
         }
     }
 

--- a/catalyst-gateway/bin/src/service/api/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn mk_api() -> OpenApiService<(HealthApi, CardanoApi, ConfigApi, Docu
         service = set_localhost_addresses(service);
     } else {
         for host in &hosts {
-            service = service.server(ServerObject::new(host).description("Server host location."));
+            service = service.server(ServerObject::new(host).description("Server host staging/production location."));
         }
     }
 

--- a/catalyst-gateway/bin/src/service/api/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/mod.rs
@@ -69,15 +69,23 @@ pub(crate) fn mk_api() -> OpenApiService<(HealthApi, CardanoApi, ConfigApi, Docu
 
     let hosts = Settings::api_host_names();
 
-    for host in hosts {
-        service = service.server(ServerObject::new(host).description("Server host location."));
+    if hosts.is_empty() {
+        service = set_localhost_addresses(service);
+    } else {
+        for host in &hosts {
+            service = service.server(ServerObject::new(host).description("Server host location."));
+        }
     }
 
     // Add server name if it is set
     if let Some(name) = Settings::server_name() {
         service = service.server(ServerObject::new(name).description("Server at server name."));
     }
+    service
+}
 
+/// Set the localhost addresses descriptions.
+fn set_localhost_addresses<T>(mut service: OpenApiService<T, ()>) -> OpenApiService<T, ()> {
     let port = Settings::bound_address().port();
 
     // Get localhost name

--- a/catalyst-gateway/bin/src/service/api/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/mod.rs
@@ -70,7 +70,7 @@ pub(crate) fn mk_api() -> OpenApiService<(HealthApi, CardanoApi, ConfigApi, Docu
     let hosts = Settings::api_host_names();
 
     for host in hosts {
-        service = service.server(ServerObject::new(host).description("API Host"));
+        service = service.server(ServerObject::new(host).description("Server host location."));
     }
 
     // Add server name if it is set

--- a/catalyst-gateway/bin/src/settings/cassandra_db.rs
+++ b/catalyst-gateway/bin/src/settings/cassandra_db.rs
@@ -88,7 +88,7 @@ impl EnvVars {
             tls,
             tls_cert: StringEnvVar::new_optional(&format!("CASSANDRA_{name}_TLS_CERT"), false),
             compression,
-            max_batch_size: StringEnvVar::new_as(
+            max_batch_size: StringEnvVar::new_as_int(
                 &format!("CASSANDRA_{name}_BATCH_SIZE"),
                 MAX_BATCH_SIZE_DEFAULT,
                 MIN_BATCH_SIZE,

--- a/catalyst-gateway/bin/src/settings/chain_follower.rs
+++ b/catalyst-gateway/bin/src/settings/chain_follower.rs
@@ -61,14 +61,14 @@ impl EnvVars {
     /// Create a config for a cassandra cluster, identified by a default namespace.
     pub(super) fn new() -> Self {
         let chain = StringEnvVar::new_as_enum("CHAIN_NETWORK", DEFAULT_NETWORK, false);
-        let sync_tasks: u16 = StringEnvVar::new_as(
+        let sync_tasks: u16 = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_SYNC_TASKS",
             DEFAULT_SYNC_TASKS,
             1,
             MAX_SYNC_TASKS,
         );
 
-        let sync_slots: u64 = StringEnvVar::new_as(
+        let sync_slots: u64 = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_SYNC_MAX_SLOTS",
             DEFAULT_SYNC_MAX_SLOTS,
             MIN_SYNC_MAX_SLOTS,
@@ -78,7 +78,7 @@ impl EnvVars {
         let cfg = ChainSyncConfig::default_for(chain);
         let mut dl_config = cfg.mithril_cfg.dl_config.clone().unwrap_or_default();
 
-        let workers = StringEnvVar::new_as(
+        let workers = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_DL_CONNECTIONS",
             dl_config.workers,
             1,
@@ -88,7 +88,7 @@ impl EnvVars {
 
         let default_dl_chunk_size = min(1, dl_config.chunk_size / ONE_MEGABYTE);
 
-        let chunk_size = StringEnvVar::new_as(
+        let chunk_size = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_DL_CHUNK_SIZE",
             default_dl_chunk_size,
             1,
@@ -101,7 +101,7 @@ impl EnvVars {
         });
         dl_config = dl_config.with_chunk_size(chunk_size);
 
-        let queue_ahead = StringEnvVar::new_as(
+        let queue_ahead = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_DL_QUEUE_AHEAD",
             dl_config.queue_ahead,
             1,
@@ -113,7 +113,7 @@ impl EnvVars {
             Some(timeout) => timeout.as_secs(),
             None => 0,
         };
-        let dl_connect_timeout = StringEnvVar::new_as(
+        let dl_connect_timeout = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_DL_CONNECT_TIMEOUT",
             default_dl_connect_timeout,
             0,
@@ -129,7 +129,7 @@ impl EnvVars {
             Some(timeout) => timeout.as_secs(),
             None => 0,
         };
-        let dl_data_timeout = StringEnvVar::new_as(
+        let dl_data_timeout = StringEnvVar::new_as_int(
             "CHAIN_FOLLOWER_DL_DATA_TIMEOUT",
             default_dl_data_timeout,
             0,

--- a/catalyst-gateway/bin/src/settings/mod.rs
+++ b/catalyst-gateway/bin/src/settings/mod.rs
@@ -504,7 +504,9 @@ mod tests {
     #[test]
     fn configured_hosts_default() {
         let configured_hosts = Settings::api_host_names();
-        assert_eq!(configured_hosts, Vec::<String>::new());
+        assert_eq!(configured_hosts, vec![
+            "https://gateway.dev.projectcatalyst.io"
+        ]);
     }
 
     #[test]

--- a/catalyst-gateway/bin/src/settings/mod.rs
+++ b/catalyst-gateway/bin/src/settings/mod.rs
@@ -491,9 +491,7 @@ mod tests {
     #[test]
     fn configured_hosts_default() {
         let configured_hosts = Settings::api_host_names();
-        assert_eq!(configured_hosts, vec![
-            "https://gateway.dev.projectcatalyst.io"
-        ]);
+        assert!(configured_hosts.is_empty());
     }
 
     #[test]

--- a/catalyst-gateway/bin/src/settings/mod.rs
+++ b/catalyst-gateway/bin/src/settings/mod.rs
@@ -184,7 +184,7 @@ static ENV_VARS: LazyLock<EnvVars> = LazyLock::new(|| {
         }).unwrap_or(ADDRESS_DEFAULT);
 
     let purge_slot_buffer =
-        StringEnvVar::new_as("PURGE_SLOT_BUFFER", PURGE_SLOT_BUFFER_DEFAULT, 0, u64::MAX);
+        StringEnvVar::new_as_int("PURGE_SLOT_BUFFER", PURGE_SLOT_BUFFER_DEFAULT, 0, u64::MAX);
 
     EnvVars {
         github_repo_owner: StringEnvVar::new("GITHUB_REPO_OWNER", GITHUB_REPO_OWNER_DEFAULT.into()),
@@ -229,7 +229,7 @@ static ENV_VARS: LazyLock<EnvVars> = LazyLock::new(|| {
             "SERVICE_LIVE_TIMEOUT_INTERVAL",
             SERVICE_LIVE_TIMEOUT_INTERVAL_DEFAULT,
         ),
-        service_live_counter_threshold: StringEnvVar::new_as(
+        service_live_counter_threshold: StringEnvVar::new_as_int(
             "SERVICE_LIVE_COUNTER_THRESHOLD",
             SERVICE_LIVE_COUNTER_THRESHOLD_DEFAULT,
             0,

--- a/catalyst-gateway/bin/src/settings/str_env_var.rs
+++ b/catalyst-gateway/bin/src/settings/str_env_var.rs
@@ -193,7 +193,7 @@ impl StringEnvVar {
     }
 
     /// Convert an Envvar into an integer in the bounded range.
-    pub(super) fn new_as<T>(var_name: &str, default: T, min: T, max: T) -> T
+    pub(super) fn new_as_int<T>(var_name: &str, default: T, min: T, max: T) -> T
     where
         T: FromStr + Display + PartialOrd + tracing::Value,
         <T as std::str::FromStr>::Err: std::fmt::Display,

--- a/catalyst-gateway/bin/src/settings/str_env_var.rs
+++ b/catalyst-gateway/bin/src/settings/str_env_var.rs
@@ -174,8 +174,9 @@ impl StringEnvVar {
     }
 
     /// Convert an Envvar into the required Duration type.
-    pub(crate) fn new_as_duration(var_name: &str, default: &str) -> Duration {
+    pub(crate) fn new_as_duration(var_name: &str, default: Duration) -> Duration {
         let choices = "A value in the format of `[0-9]+(ns|us|ms|[smhdwy])`";
+        let default = DurationString::new(default);
 
         let raw_value = StringEnvVar::new(
             var_name,
@@ -183,27 +184,12 @@ impl StringEnvVar {
         )
         .as_string();
 
-        match DurationString::try_from(raw_value.clone()) {
-            Ok(duration) => duration.into(),
-            Err(error) => {
-                error!(
-                    "Invalid Duration: {} : {}. Defaulting to {}.",
-                    raw_value, error, default
-                );
-
-                match DurationString::try_from(default.to_string()) {
-                    Ok(duration) => duration.into(),
-                    // The error from parsing the default value must not happen
-                    Err(error) => {
-                        error!(
-                            "Invalid Default Duration: {} : {}. Defaulting to 1s.",
-                            default, error
-                        );
-                        Duration::from_secs(1)
-                    },
-                }
-            },
-        }
+        DurationString::try_from(raw_value.clone())
+            .inspect(|err| {
+                error!("Invalid Duration: {raw_value} : {err}. Defaulting to {default}.",);
+            })
+            .unwrap_or(default)
+            .into()
     }
 
     /// Convert an Envvar into an integer in the bounded range.


### PR DESCRIPTION
# Description

Cleanup service settings, fix an issue when calling `cat-gateway docs` cli option service address in OpenAPI docs set incorrectly.
- Moved definitions of `ADDRESS` and `SERVER_NAME` under the `EnvVars` structure as the rest of the service settings.
- Improved definition of duration based settings.
- Renamed `new_as` to `new_as_int`, to improve clarity what does this function do.