### PR TITLE
fix(cat-voices): most recent proposal stream

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/current_campaign.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/current_campaign.dart
@@ -44,7 +44,7 @@ class CurrentCampaign extends StatelessWidget {
           ),
         ),
         Padding(
-          padding: const EdgeInsets.only(top: 32, bottom: 160),
+          padding: const EdgeInsets.only(top: 32, bottom: 100),
           child: CampaignTimeline(
             timelineItems: CampaignTimelineViewModelX.mockData,
             placement: CampaignTimelinePlacement.discovery,

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/most_recent_proposals_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/most_recent_proposals_selector.dart
@@ -49,15 +49,15 @@ class _MostRecentProposalsError extends StatelessWidget {
     return BlocSelector<DiscoveryCubit, DiscoveryState, VisibilityState>(
       selector: (state) {
         return (
-          show: state.currentCampaign.showError,
-          error: state.currentCampaign.error,
+          show: state.mostRecentProposals.showError,
+          error: state.mostRecentProposals.error,
         );
       },
       builder: (context, state) {
         final errorMessage = state.error?.message(context);
         return Offstage(
           key: const Key('MostRecentError'),
-          offstage: state.show,
+          offstage: !state.show,
           child: Padding(
             padding: const EdgeInsets.all(16),
             child: Center(

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
@@ -14,7 +14,7 @@ class DiscoveryCubit extends Cubit<DiscoveryState> {
   // ignore: unused_field
   final CampaignService _campaignService;
   final ProposalService _proposalService;
-  late StreamSubscription<List<Proposal>>? _proposalsSubscription;
+  StreamSubscription<List<Proposal>>? _proposalsSubscription;
 
   DiscoveryCubit(
     this._campaignService,
@@ -151,6 +151,12 @@ class DiscoveryCubit extends Cubit<DiscoveryState> {
           ),
         );
       },
+    );
+    emit(
+      state.copyWith(
+        mostRecentProposals:
+            const DiscoveryMostRecentProposalsState(isLoading: false),
+      ),
     );
   }
 }


### PR DESCRIPTION
# Description

Keyword late throw an exception if stream subscription was not set before subscribing to it!

## Related Issue(s)

N/A

## Description of Changes

- remove keyword late
- making sure that loading state is disabled

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
