### PR TITLE
fix(cat-voices): catalyst ID bytes length

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/catalyst_id.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/catalyst_id.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:equatable/equatable.dart';
@@ -33,7 +35,7 @@ final class CatalystId extends Equatable {
 
   /// This is the very first role 0 key used to post
   /// the registration to the network.
-  final CatalystPublicKey role0Key;
+  final Uint8List role0Key;
 
   //// Optional - This is the Role number being used.
   final AccountRole? role;
@@ -55,7 +57,12 @@ final class CatalystId extends Equatable {
     this.role,
     this.rotation,
     this.encrypt = false,
-  });
+  }) : assert(
+          role0Key.length == 32,
+          'Role0Key must be 32 bytes long. '
+          'Make sure to use plain public key, '
+          'not the extended public key.',
+        );
 
   /// Parses the [CatalystId] from [Uri].
   factory CatalystId.fromUri(Uri uri) {
@@ -88,7 +95,7 @@ final class CatalystId extends Equatable {
     String? host,
     Optional<String>? username,
     Optional<int>? nonce,
-    CatalystPublicKey? role0Key,
+    Uint8List? role0Key,
     Optional<AccountRole>? role,
     Optional<int>? rotation,
     bool? encrypt,
@@ -119,7 +126,7 @@ final class CatalystId extends Equatable {
   }
 
   String _formatPath() {
-    final encodedRole0Key = base64UrlNoPadEncode(role0Key.publicKeyBytes);
+    final encodedRole0Key = base64UrlNoPadEncode(role0Key);
     final role = this.role?.number.toString();
     final rotation = this.rotation?.toString();
 
@@ -148,7 +155,7 @@ final class CatalystId extends Equatable {
   ///
   /// Format: role0Key[/roleNumber][/rotation]
   static (
-    CatalystPublicKey role0Key,
+    Uint8List role0Key,
     AccountRole? role,
     int? rotation,
   ) _parsePath(String path) {
@@ -160,7 +167,7 @@ final class CatalystId extends Equatable {
     final rotation = int.tryParse(parts.elementAtOrNull(2) ?? '');
 
     final decodedRole0Key = base64UrlNoPadDecode(role0Key);
-    final catalystRole0Key = CatalystPublicKey.factory.create(decodedRole0Key);
+    final catalystRole0Key = decodedRole0Key;
     final accountRole = role != null ? AccountRole.fromNumber(role) : null;
 
     return (catalystRole0Key, accountRole, rotation);

--- a/catalyst_voices/packages/internal/catalyst_voices_models/test/user/catalyst_id_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/test/user/catalyst_id_test.dart
@@ -1,24 +1,17 @@
-import 'package:catalyst_voices_models/src/crypto/catalyst_key_factory.dart';
-import 'package:catalyst_voices_models/src/crypto/catalyst_public_key.dart';
 import 'package:catalyst_voices_models/src/user/account_role.dart';
 import 'package:catalyst_voices_models/src/user/catalyst_id.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
-import 'package:test/fake.dart';
 import 'package:test/test.dart';
 
 /* cSpell:disable */
 void main() {
   group(CatalystId, () {
-    late CatalystPublicKey role0Key;
+    late Uint8List role0Key;
 
     setUpAll(() {
-      CatalystPublicKey.factory = _FakeCatalystPublicKeyFactory();
-
-      final role0KeyBytes =
+      role0Key =
           base64UrlNoPadDecode('FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE');
-      role0Key = CatalystPublicKey.factory.create(role0KeyBytes);
     });
 
     test('should create CatalystId instance correctly', () {
@@ -159,32 +152,4 @@ void main() {
   });
 }
 
-@immutable
-class _FakeCatalystPublicKey extends Fake implements CatalystPublicKey {
-  @override
-  final Uint8List bytes;
-
-  _FakeCatalystPublicKey({required this.bytes});
-
-  @override
-  int get hashCode => const DeepCollectionEquality().hash(bytes);
-
-  @override
-  Uint8List get publicKeyBytes => bytes;
-
-  @override
-  bool operator ==(Object other) {
-    if (other is! _FakeCatalystPublicKey) return false;
-
-    return const DeepCollectionEquality().equals(other.bytes, bytes);
-  }
-}
-
-class _FakeCatalystPublicKeyFactory extends Fake
-    implements CatalystPublicKeyFactory {
-  @override
-  CatalystPublicKey create(Uint8List bytes) {
-    return _FakeCatalystPublicKey(bytes: bytes);
-  }
-}
 /* cSpell:enable */

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
@@ -116,7 +116,9 @@ final class _CatalystVerifier implements CatalystCoseVerifier {
     // to the private key which generated the signature and use
     // it for verification, most likely the role0Key is not the correct one.
     final catalystSignature = CatalystSignature.factory.create(signature);
-    return _catalystId.role0Key.verify(data, signature: catalystSignature);
+    return CatalystPublicKey.factory
+        .create(_catalystId.role0Key)
+        .verify(data, signature: catalystSignature);
   }
 }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/signed_document/signed_document_manager_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/signed_document/signed_document_manager_test.dart
@@ -52,7 +52,7 @@ const _metadata = SignedDocumentMetadata(
 
 final _catalystId = CatalystId(
   host: CatalystIdHost.cardanoPreprod.host,
-  role0Key: _publicKey,
+  role0Key: _publicKey.publicKeyBytes,
 );
 
 final _privateKey = _FakeCatalystPrivateKey(bytes: _privateKeyBytes);

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/auth/auth_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/auth/auth_service.dart
@@ -44,7 +44,7 @@ final class AuthServiceImpl implements AuthService {
 
     return CatalystId(
       host: _blockchainConfig.host.host,
-      role0Key: keyPair.publicKey,
+      role0Key: keyPair.publicKey.publicKeyBytes,
       nonce: dateTime.millisecondsSinceEpoch ~/ Duration.millisecondsPerSecond,
     );
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/proposal/proposal_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/proposal/proposal_service.dart
@@ -232,7 +232,7 @@ final class ProposalServiceImpl implements ProposalService {
     // TODO(dtscalac): catalyst id should come from the profile
     final catalystId = CatalystId(
       host: _blockchainConfig.host.host,
-      role0Key: role0KeyPair.publicKey,
+      role0Key: role0KeyPair.publicKey.publicKeyBytes,
       role: AccountRole.proposer,
       rotation: 0,
     );

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
@@ -236,7 +236,7 @@ final class RegistrationServiceImpl implements RegistrationService {
       final catalystId = CatalystId(
         host: _blockchainConfig.host.host,
         username: displayName,
-        role0Key: role0key,
+        role0Key: role0key.publicKeyBytes,
       );
 
       return Account(
@@ -281,7 +281,7 @@ final class RegistrationServiceImpl implements RegistrationService {
     final catalystId = CatalystId(
       host: _blockchainConfig.host.host,
       username: 'Dummy',
-      role0Key: role0key,
+      role0Key: role0key.publicKeyBytes,
     );
 
     return Account(

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/lib/src/user/dummy_catalyst_id_factory.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/lib/src/user/dummy_catalyst_id_factory.dart
@@ -24,7 +24,7 @@ final class DummyCatalystIdFactory {
     return CatalystId(
       host: host.host,
       username: username,
-      role0Key: role0Key,
+      role0Key: role0Key.publicKeyBytes,
       role: role,
       nonce: nonce ?? Random().nextInt(50000),
     );


### PR DESCRIPTION
# Description

Fixes role0Key bytes in CatalystId to make sure it uses 32 bytes public key and not the extended public key (64 bytes).

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
