### PR TITLE
feat(cat-voices): remove alg and tag from cose sign structure

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
@@ -84,7 +84,7 @@ final class _CatalystSigner implements CatalystCoseSigner {
   );
 
   @override
-  StringOrInt? get alg => const IntValue(CoseValues.eddsaAlg);
+  StringOrInt? get alg => null;
 
   @override
   Future<Uint8List?> get kid async {
@@ -144,7 +144,7 @@ final class _CoseSignedDocument<T extends SignedDocumentPayload>
 
   @override
   Uint8List toBytes() {
-    final bytes = cbor.encode(_coseSign.toCbor());
+    final bytes = cbor.encode(_coseSign.toCbor(tagged: false));
     return Uint8List.fromList(bytes);
   }
 

--- a/catalyst_voices/packages/libs/catalyst_cose/lib/src/cose_sign.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/lib/src/cose_sign.dart
@@ -138,7 +138,7 @@ final class CoseSign extends Equatable {
   }
 
   /// Serializes the type as cbor.
-  CborValue toCbor() {
+  CborValue toCbor({bool tagged = true}) {
     return CborList(
       [
         protectedHeaders.toCbor(),
@@ -148,7 +148,9 @@ final class CoseSign extends Equatable {
           for (final signature in signatures) signature.toCbor(),
         ]),
       ],
-      tags: [CoseTags.coseSign],
+      tags: [
+        if (tagged) CoseTags.coseSign,
+      ],
     );
   }
 

--- a/catalyst_voices/packages/libs/catalyst_cose/lib/src/cose_sign1.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/lib/src/cose_sign1.dart
@@ -121,7 +121,7 @@ final class CoseSign1 extends Equatable {
   }
 
   /// Serializes the type as cbor.
-  CborValue toCbor() {
+  CborValue toCbor({bool tagged = true}) {
     return CborList(
       [
         protectedHeaders.toCbor(),
@@ -129,7 +129,9 @@ final class CoseSign1 extends Equatable {
         CborBytes(payload),
         CborBytes(signature),
       ],
-      tags: [CoseTags.coseSign1],
+      tags: [
+        if (tagged) CoseTags.coseSign1,
+      ],
     );
   }
 


### PR DESCRIPTION
# Description

cat-gateway will allow to skip COSE_SIGN tag and alg header and will assume default values for signed documents. The PR removes these from the signed documents that frontend generates to save data transfer/storage.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
