### PR TITLE
feat(cat-voices): extract catalyst id from signed document

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/signed_document/signed_document.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/signed_document/signed_document.dart
@@ -22,6 +22,9 @@ abstract interface class SignedDocument<T extends SignedDocumentPayload> {
   /// A getter that returns a parsed document payload.
   T get payload;
 
+  /// Returns a list of [CatalystId] that signed the document.
+  List<CatalystId> get signers;
+
   /// Converts the document into binary representation.
   Uint8List toBytes();
 

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
@@ -25,7 +25,6 @@ final class SignedDocumentManagerImpl implements SignedDocumentManager {
     final metadata = _SignedDocumentMetadataExt.fromCose(
       protectedHeaders: coseSign.protectedHeaders,
       unprotectedHeaders: coseSign.unprotectedHeaders,
-      signatures: coseSign.signatures,
     );
 
     return _CoseSignedDocument(
@@ -230,7 +229,6 @@ extension _SignedDocumentMetadataExt on SignedDocumentMetadata {
   static SignedDocumentMetadata fromCose({
     required CoseHeaders protectedHeaders,
     required CoseHeaders unprotectedHeaders,
-    required List<CoseSignature> signatures,
   }) {
     final type = protectedHeaders.type?.value;
     final ref = protectedHeaders.ref;

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/signed_document/signed_document_manager_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/signed_document/signed_document_manager_test.dart
@@ -41,6 +41,7 @@ void main() {
       );
 
       expect(parsedDocument, equals(signedDocument));
+      expect(parsedDocument.signers, [_catalystId]);
     });
   });
 }


### PR DESCRIPTION
# Description

Extracts the CatalystID from COSE_SIGN signature protected headers (kid).

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
