### PR TITLE
feat(cat-gateway): Bump cat-libs version

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -15,12 +15,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-cardano-chain-follower = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250317-00" }
-rbac-registration = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250317-00" }
-catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250317-00" }
-cardano-blockchain-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250317-00" }
-catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250317-00" }
-c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250317-00" }
+cardano-chain-follower = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250325-00" }
+rbac-registration = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250325-00" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250325-00" }
+cardano-blockchain-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250325-00" }
+catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250325-00" }
+c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250325-00" }
 
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 pallas-traverse = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }

--- a/catalyst-gateway/bin/src/service/api/documents/templates/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/mod.rs
@@ -93,7 +93,6 @@ fn build_signed_doc(data: &SignedDocData, sk: &SigningKey) -> (Uuid, CatalystSig
     const KID_NETWORK: &str = "cardano";
 
     let metadata = serde_json::json!({
-        "alg": catalyst_signed_doc::Algorithm::EdDSA.to_string(),
         "type": data.doc_type,
         "id": data.id,
         "ver": data.ver,

--- a/catalyst-gateway/bin/src/service/common/auth/rbac/scheme.rs
+++ b/catalyst-gateway/bin/src/service/common/auth/rbac/scheme.rs
@@ -240,12 +240,11 @@ async fn last_signing_key(
         .data()
         .signing_key()
         .context("Missing signing key")?;
-    let key_offset = usize::try_from(key_ref.key_offset).context("Invalid signing key offset")?;
     match key_ref.local_ref {
         LocalRefInt::X509Certs => {
             let cert = &chain
                 .x509_certs()
-                .get(&key_offset)
+                .get(&key_ref.key_offset)
                 .context("Missing X509 role 0 certificate")?
                 .last()
                 .and_then(|p| p.data().as_ref())
@@ -255,7 +254,7 @@ async fn last_signing_key(
         LocalRefInt::C509Certs => {
             let cert = &chain
                 .c509_certs()
-                .get(&key_offset)
+                .get(&key_ref.key_offset)
                 .context("Missing C509 role 0 certificate")?
                 .last()
                 .and_then(|p| p.data().as_ref())


### PR DESCRIPTION
# Description

Bump cat-libs version to most recent one.
- It removes unused and unneeded Catalyst Signed Docs metadata `alg` field
- It also allows to submit tagged and untagged Catalyst Signed Docs encoded bytes