### PR TITLE
feat(cat-voices): Make text selectable on Discovery and Category Page

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/category/category_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/category/category_page.dart
@@ -37,20 +37,22 @@ class _Body extends StatelessWidget {
   Widget build(BuildContext context) {
     return Skeletonizer(
       enabled: isLoading,
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: CategoryDetailView(
+      child: SelectionArea(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: CategoryDetailView(
+                category: category,
+              ),
+            ),
+            const SizedBox(width: 48),
+            _CardInformation(
               category: category,
             ),
-          ),
-          const SizedBox(width: 48),
-          _CardInformation(
-            category: category,
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/catalyst_voices/apps/voices/lib/pages/discovery/discovery_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/discovery_page.dart
@@ -44,10 +44,12 @@ class _Body extends StatelessWidget {
 class _DiscoveryPageState extends State<DiscoveryPage> {
   @override
   Widget build(BuildContext context) {
-    return const CustomScrollView(
-      slivers: [
-        _Body(),
-      ],
+    return const SelectionArea(
+      child: CustomScrollView(
+        slivers: [
+          _Body(),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION

# Description

Making text selectable on Discovery and Category Detail Page. 

## Related Issue(s)

Closes #1903 
Closes #1902 

## Description of Changes

As we don't have good approach to make whole application selectable I'm wrapping single pages into selection area.

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
