### PR TITLE
feat(cat-voices): integrate user proposals into drawer and overall spaces

### DIFF
--- a/catalyst_voices/apps/voices/lib/common/typedefs.dart
+++ b/catalyst_voices/apps/voices/lib/common/typedefs.dart
@@ -1,3 +1,5 @@
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 
+typedef DataVisibilityState<T> = ({bool show, T data});
+
 typedef VisibilityState = ({bool show, LocalizedException? error});

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/discovery_overview.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/discovery_overview.dart
@@ -1,10 +1,8 @@
-import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
-import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/overall_spaces/space/space_overview_header.dart';
 import 'package:catalyst_voices/pages/overall_spaces/space/space_overview_nav_tile.dart';
+import 'package:catalyst_voices/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart';
 import 'package:catalyst_voices/pages/overall_spaces/space_overview_container.dart';
 import 'package:catalyst_voices/routes/routes.dart';
-import 'package:catalyst_voices/widgets/cards/small_proposal_card.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
@@ -21,6 +19,7 @@ class DiscoveryOverview extends StatelessWidget {
   Widget build(BuildContext context) {
     return const SpaceOverviewContainer(
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SpaceOverviewHeader(Space.discovery),
           _DiscoveryDashboardTile(),
@@ -28,7 +27,7 @@ class DiscoveryOverview extends StatelessWidget {
           VoicesDivider(indent: 0, endIndent: 0, height: 16),
           Expanded(
             child: SingleChildScrollView(
-              child: _PublishedProposalSelector(1, 5),
+              child: _PublishedProposalSelector(),
             ),
           ),
         ],
@@ -81,93 +80,8 @@ class _FeedbackTile extends StatelessWidget {
   }
 }
 
-class _Header extends StatelessWidget {
-  final int currentProposals;
-  final int maxProposals;
-  const _Header({
-    required this.maxProposals,
-    required this.currentProposals,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 18)
-        ..add(
-          const EdgeInsets.only(left: 16),
-        ),
-      child: Text(
-        context.l10n.noPublishedProposalsOnMaxCount(
-          currentProposals,
-          maxProposals,
-        ),
-        style: context.textTheme.titleMedium?.copyWith(
-          color: context.colors.textOnPrimaryLevel1,
-        ),
-      ),
-    );
-  }
-}
-
-class _PublishedProposals extends StatelessWidget {
-  final int currentProposals;
-  final int maxProposals;
-  const _PublishedProposals(
-    this.currentProposals,
-    this.maxProposals,
-  );
-
-  @override
-  Widget build(BuildContext context) {
-    // TODO(LynxLynxx): replace with real data
-    final proposal = Proposal(
-      selfRef: SignedDocumentRef.generateFirstRef(),
-      title: 'Latest proposal that is making its rounds.',
-      category: 'F14: Cardano Use Cases: Concept',
-      categoryId: const SignedDocumentRef(id: 'dummy_category_id'),
-      description: 'Lorem ipsum dolor sit ',
-      fundsRequested: const Coin(100000),
-      status: ProposalStatus.draft,
-      publish: ProposalPublish.localDraft,
-      commentsCount: 0,
-      duration: 6,
-      author: 'Alex Wells',
-      updateDate: DateTime.now(),
-      versions: const [],
-    );
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _Header(
-          maxProposals: maxProposals,
-          currentProposals: currentProposals,
-        ),
-        SmallProposalCard(
-          proposal: proposal.copyWith(
-            publish: ProposalPublish.submittedProposal,
-            commentsCount: 1,
-          ),
-        ),
-        const SizedBox(height: 12),
-        SmallProposalCard(
-          proposal: proposal.copyWith(
-            publish: ProposalPublish.publishedDraft,
-            commentsCount: 12,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 class _PublishedProposalSelector extends StatelessWidget {
-  final int currentProposals;
-  final int maxProposals;
-  const _PublishedProposalSelector(
-    this.currentProposals,
-    this.maxProposals,
-  );
+  const _PublishedProposalSelector();
 
   @override
   Widget build(BuildContext context) {
@@ -178,10 +92,7 @@ class _PublishedProposalSelector extends StatelessWidget {
       builder: (context, state) {
         return Offstage(
           offstage: state,
-          child: _PublishedProposals(
-            currentProposals,
-            maxProposals,
-          ),
+          child: const DiscoveryOverviewProposalSelector(),
         );
       },
     );

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/discovery_overview_proposal_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/discovery_overview_proposal_selector.dart
@@ -1,0 +1,53 @@
+part of 'user_proposal_selectors.dart';
+
+class DiscoveryOverviewProposalSelector extends StatelessWidget {
+  const DiscoveryOverviewProposalSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Stack(
+      children: [
+        _LoadingProposalSelector(),
+        _ErrorProposalSelector(),
+        _DataProposalSelector(),
+      ],
+    );
+  }
+}
+
+class _DataProposalSelector extends StatelessWidget {
+  const _DataProposalSelector();
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: BlocSelector<WorkspaceBloc, WorkspaceState, _StateData>(
+        selector: (state) {
+          return (data: state.published, show: state.showProposals);
+        },
+        builder: (context, state) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _Header(
+                title: context.l10n.noPublishedProposalsOnMaxCount(
+                  state.data.length,
+                  5,
+                ),
+              ),
+              Offstage(
+                offstage: !state.show,
+                child: _DataProposalWidget(
+                  proposals: state.data,
+                  emptyMessage: context.l10n.noPublishedProposals,
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/discovery_overview_proposal_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/discovery_overview_proposal_selector.dart
@@ -21,7 +21,8 @@ class _DataProposalSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: BlocSelector<WorkspaceBloc, WorkspaceState, _StateData>(
+      child: BlocSelector<WorkspaceBloc, WorkspaceState,
+          DataVisibilityState<List<Proposal>>>(
         selector: (state) {
           return (data: state.published, show: state.showProposals);
         },

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart
@@ -1,0 +1,17 @@
+import 'package:catalyst_voices/common/ext/build_context_ext.dart';
+import 'package:catalyst_voices/common/typedefs.dart';
+import 'package:catalyst_voices/widgets/cards/small_proposal_card.dart';
+import 'package:catalyst_voices/widgets/indicators/voices_circular_progress_indicator.dart';
+import 'package:catalyst_voices/widgets/indicators/voices_error_indicator.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+// As widget across two overviews are almost similar and are not reusable
+// anywhere else it usefull to use as part
+part 'discovery_overview_proposal_selector.dart';
+part 'user_proposals_selector_widgets.dart';
+part 'workspace_overview_proposal_selector.dart';

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 // As widget across two overviews are almost similar and are not reusable
-// anywhere else it usefull to use as part
+// anywhere else it useful to use as part
 part 'discovery_overview_proposal_selector.dart';
 part 'user_proposals_selector_widgets.dart';
 part 'workspace_overview_proposal_selector.dart';

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposals_selector_widgets.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposals_selector_widgets.dart
@@ -1,0 +1,112 @@
+part of 'user_proposal_selectors.dart';
+
+typedef _StateData = ({bool show, List<Proposal> data});
+
+class _DataProposalWidget extends StatelessWidget {
+  final List<Proposal> proposals;
+  final String emptyMessage;
+  final bool showLatestLocal;
+
+  const _DataProposalWidget({
+    required this.proposals,
+    required this.emptyMessage,
+    this.showLatestLocal = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (proposals.isEmpty) {
+      return Text(
+        emptyMessage,
+        style: context.textTheme.bodyMedium?.copyWith(
+          color: context.colors.textOnPrimaryLevel1,
+        ),
+      );
+    }
+    return Column(
+      spacing: 12,
+      children: proposals
+          .map(
+            (e) => SmallProposalCard(
+              proposal: e,
+              showLatestLocal: showLatestLocal,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class _ErrorProposalSelector extends StatelessWidget {
+  const _ErrorProposalSelector();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<WorkspaceBloc, WorkspaceState, VisibilityState>(
+      selector: (state) {
+        return (error: state.error, show: state.showError);
+      },
+      builder: (context, state) {
+        return Offstage(
+          offstage: !state.show,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 60),
+            child: VoicesErrorIndicator(
+              message: state.error?.message(context) ??
+                  const LocalizedUnknownException().message(context),
+              onRetry: () => context
+                  .read<WorkspaceBloc>()
+                  .add(const WatchUserProposalsEvent()),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  final String title;
+
+  const _Header({
+    required this.title,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 18)
+        ..add(
+          const EdgeInsets.only(left: 16),
+        ),
+      child: Text(
+        title,
+        style: context.textTheme.titleMedium?.copyWith(
+          color: context.colors.textOnPrimaryLevel1,
+        ),
+      ),
+    );
+  }
+}
+
+class _LoadingProposalSelector extends StatelessWidget {
+  const _LoadingProposalSelector();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<WorkspaceBloc, WorkspaceState, bool>(
+      selector: (state) {
+        return state.isLoading;
+      },
+      builder: (context, isLoading) => Offstage(
+        offstage: !isLoading,
+        child: const Padding(
+          padding: EdgeInsets.only(top: 60),
+          child: Center(
+            child: VoicesCircularProgressIndicator(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposals_selector_widgets.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposals_selector_widgets.dart
@@ -1,7 +1,5 @@
 part of 'user_proposal_selectors.dart';
 
-typedef _StateData = ({bool show, List<Proposal> data});
-
 class _DataProposalWidget extends StatelessWidget {
   final List<Proposal> proposals;
   final String emptyMessage;
@@ -16,10 +14,13 @@ class _DataProposalWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (proposals.isEmpty) {
-      return Text(
-        emptyMessage,
-        style: context.textTheme.bodyMedium?.copyWith(
-          color: context.colors.textOnPrimaryLevel1,
+      return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Text(
+          emptyMessage,
+          style: context.textTheme.bodyMedium?.copyWith(
+            color: context.colors.textOnPrimaryLevel1,
+          ),
         ),
       );
     }
@@ -75,10 +76,11 @@ class _Header extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 18)
-        ..add(
-          const EdgeInsets.only(left: 16),
-        ),
+      padding: const EdgeInsets.only(
+        left: 20,
+        top: 18,
+        bottom: 18,
+      ),
       child: Text(
         title,
         style: context.textTheme.titleMedium?.copyWith(
@@ -100,10 +102,13 @@ class _LoadingProposalSelector extends StatelessWidget {
       },
       builder: (context, isLoading) => Offstage(
         offstage: !isLoading,
-        child: const Padding(
-          padding: EdgeInsets.only(top: 60),
+        child: Padding(
+          padding: const EdgeInsets.only(top: 60),
           child: Center(
-            child: VoicesCircularProgressIndicator(),
+            child: TickerMode(
+              enabled: isLoading,
+              child: const VoicesCircularProgressIndicator(),
+            ),
           ),
         ),
       ),

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/workspace_overview_proposal_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/workspace_overview_proposal_selector.dart
@@ -25,7 +25,8 @@ class _WorkspaceDataProposalSelector extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _Header(title: context.l10n.notPublishedProposals),
-        BlocSelector<WorkspaceBloc, WorkspaceState, _StateData>(
+        BlocSelector<WorkspaceBloc, WorkspaceState,
+            DataVisibilityState<List<Proposal>>>(
           selector: (state) {
             return (data: state.notPublished, show: state.showProposals);
           },

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/workspace_overview_proposal_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/workspace_overview_proposal_selector.dart
@@ -1,0 +1,46 @@
+part of 'user_proposal_selectors.dart';
+
+class WorkspaceOverviewProposalSelector extends StatelessWidget {
+  const WorkspaceOverviewProposalSelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Stack(
+      children: [
+        _LoadingProposalSelector(),
+        _ErrorProposalSelector(),
+        _WorkspaceDataProposalSelector(),
+      ],
+    );
+  }
+}
+
+class _WorkspaceDataProposalSelector extends StatelessWidget {
+  const _WorkspaceDataProposalSelector();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _Header(title: context.l10n.notPublishedProposals),
+        BlocSelector<WorkspaceBloc, WorkspaceState, _StateData>(
+          selector: (state) {
+            return (data: state.notPublished, show: state.showProposals);
+          },
+          builder: (context, state) {
+            return Offstage(
+              offstage: !state.show,
+              child: _DataProposalWidget(
+                proposals: state.data,
+                emptyMessage: context.l10n.noProposalsToPublish,
+                showLatestLocal: true,
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/workspace_overview.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/workspace_overview.dart
@@ -1,10 +1,8 @@
-import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
-import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/overall_spaces/space/space_overview_header.dart';
 import 'package:catalyst_voices/pages/overall_spaces/space/space_overview_nav_tile.dart';
+import 'package:catalyst_voices/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart';
 import 'package:catalyst_voices/pages/overall_spaces/space_overview_container.dart';
 import 'package:catalyst_voices/routes/routing/spaces_route.dart';
-import 'package:catalyst_voices/widgets/cards/small_proposal_card.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
@@ -20,6 +18,7 @@ class WorkspaceOverview extends StatelessWidget {
   Widget build(BuildContext context) {
     return const SpaceOverviewContainer(
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SpaceOverviewHeader(Space.workspace),
           _BrowseMyProposals(),
@@ -52,60 +51,6 @@ class _BrowseMyProposals extends StatelessWidget {
   }
 }
 
-class _Header extends StatelessWidget {
-  const _Header();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 18)
-        ..add(
-          const EdgeInsets.only(left: 16),
-        ),
-      child: Text(
-        context.l10n.notPublishedProposals,
-        style: context.textTheme.titleMedium?.copyWith(
-          color: context.colors.textOnPrimaryLevel1,
-        ),
-      ),
-    );
-  }
-}
-
-class _NotPublishedProposals extends StatelessWidget {
-  const _NotPublishedProposals();
-
-  @override
-  Widget build(BuildContext context) {
-    // TODO(LynxLynxx): replace with real data
-    final proposal = Proposal(
-      selfRef: SignedDocumentRef.generateFirstRef(),
-      title: 'Latest proposal that is making its rounds.',
-      category: 'F14: Cardano Use Cases: Concept',
-      categoryId: const SignedDocumentRef(id: 'dummy_category_id'),
-      description: 'Lorem ipsum dolor sit ',
-      fundsRequested: const Coin(100000),
-      status: ProposalStatus.draft,
-      publish: ProposalPublish.localDraft,
-      commentsCount: 0,
-      duration: 6,
-      author: 'Alex Wells',
-      updateDate: DateTime.now(),
-      versions: const [],
-    );
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const _Header(),
-        SmallProposalCard(
-          proposal: proposal,
-        ),
-      ],
-    );
-  }
-}
-
 class _NotPublishedProposalSelector extends StatelessWidget {
   const _NotPublishedProposalSelector();
 
@@ -118,7 +63,7 @@ class _NotPublishedProposalSelector extends StatelessWidget {
       builder: (context, state) {
         return Offstage(
           offstage: state,
-          child: const _NotPublishedProposals(),
+          child: const WorkspaceOverviewProposalSelector(),
         );
       },
     );

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/spaces_overview_list_view.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/spaces_overview_list_view.dart
@@ -23,12 +23,6 @@ class _SpacesListViewState extends State<SpacesListView> {
   final _scrollController = ScrollController();
 
   @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
     return VoicesScrollbar(
       key: const Key('SpacesListView'),
@@ -71,5 +65,17 @@ class _SpacesListViewState extends State<SpacesListView> {
         },
       ),
     );
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<WorkspaceBloc>().add(const WatchUserProposalsEvent());
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/spaces/drawer/guest_menu.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/drawer/guest_menu.dart
@@ -18,6 +18,7 @@ class GuestMenu extends StatelessWidget {
       key: const ValueKey('GuestMenuItems'),
       mainAxisSize: MainAxisSize.min,
       children: [
+        const SizedBox(height: 30),
         VoicesNavTile(
           leading: VoicesAssets.icons.home.buildIcon(),
           name: 'Home',

--- a/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
@@ -148,6 +148,12 @@ class _SpacesShellPageState extends State<SpacesShellPage> {
     super.dispose();
   }
 
+  @override
+  void initState() {
+    super.initState();
+    context.read<WorkspaceBloc>().add(const WatchUserProposalsEvent());
+  }
+
   OverlayEntry _createAdminToolsOverlay() {
     return OverlayEntry(
       builder: (BuildContext context) {

--- a/catalyst_voices/apps/voices/test/widgets/cards/small_proposal_card_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/cards/small_proposal_card_test.dart
@@ -1,0 +1,134 @@
+import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
+import 'package:catalyst_voices/widgets/cards/proposal_card_widgets.dart';
+import 'package:catalyst_voices/widgets/cards/small_proposal_card.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid_plus/uuid_plus.dart';
+
+import '../../helpers/helpers.dart';
+
+void main() {
+  group('SmallProposalCard', () {
+    late Proposal mockProposal;
+    late String proposalId;
+    late String latestVersion;
+    late String localVersion;
+    late String draftVersion;
+
+    setUpAll(() async {
+      proposalId = const Uuid().v7();
+      draftVersion = const Uuid().v7();
+      await Future.delayed(const Duration(milliseconds: 10), () {});
+      latestVersion = const Uuid().v7();
+      await Future.delayed(const Duration(milliseconds: 10), () {});
+      localVersion = const Uuid().v7();
+      mockProposal = Proposal(
+        selfRef: SignedDocumentRef(id: proposalId, version: latestVersion),
+        title: 'Test Proposal',
+        description: 'Test Description',
+        updateDate: DateTime.now(),
+        fundsRequested: const Coin(0),
+        status: ProposalStatus.inProgress,
+        publish: ProposalPublish.publishedDraft,
+        versions: [
+          ProposalVersion(
+            publish: ProposalPublish.localDraft,
+            selfRef: DraftRef(id: proposalId, version: localVersion),
+            title: 'Title ver 1',
+            createdAt: DateTime.now(),
+          ),
+          ProposalVersion(
+            publish: ProposalPublish.publishedDraft,
+            selfRef: SignedDocumentRef(id: proposalId, version: draftVersion),
+            title: 'Title ver 2',
+            createdAt: DateTime.now(),
+          ),
+        ],
+        duration: 0,
+        author: 'Alex Wells',
+        commentsCount: 0,
+        category: 'Cardano Use Cases: Concept',
+        categoryId: SignedDocumentRef.generateFirstRef(),
+      );
+    });
+
+    Future<void> pumpCard(
+      WidgetTester tester, {
+      bool showLatestLocal = false,
+    }) async {
+      await tester.pumpApp(
+        SizedBox(
+          width: 1000,
+          height: 1000,
+          child: SmallProposalCard(
+            proposal: mockProposal,
+            showLatestLocal: showLatestLocal,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders basic proposal information', (tester) async {
+      await pumpCard(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SmallProposalCard), findsOneWidget);
+      expect(find.text('Test Proposal'), findsOneWidget);
+      expect(find.text('Cardano Use Cases: Concept'), findsOneWidget);
+    });
+
+    testWidgets('shows version number', (tester) async {
+      await pumpCard(tester);
+      await tester.pumpAndSettle();
+
+      expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets(
+        'shows new iteration details when showLatestLocal '
+        'is true and has latest local draft', (tester) async {
+      await pumpCard(tester, showLatestLocal: true);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Consider publishing this newer iteration!'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('hides new iteration details when showLatestLocal is false',
+        (tester) async {
+      await pumpCard(tester, showLatestLocal: false);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Consider publishing this newer iteration!'),
+        findsNothing,
+      );
+    });
+
+    testWidgets('shows correct chip based on proposal publish status',
+        (tester) async {
+      // Test for published draft
+      mockProposal =
+          mockProposal.copyWith(publish: ProposalPublish.publishedDraft);
+      await pumpCard(tester);
+      await tester.pumpAndSettle();
+      expect(find.byType(DraftProposalChip), findsOneWidget);
+
+      // Test for submitted proposal
+      mockProposal =
+          mockProposal.copyWith(publish: ProposalPublish.submittedProposal);
+      await pumpCard(tester);
+      await tester.pumpAndSettle();
+      expect(find.byType(FinalProposalChip), findsOneWidget);
+
+      // Test for local draft
+      mockProposal = mockProposal.copyWith(publish: ProposalPublish.localDraft);
+      await pumpCard(tester);
+      await tester.pumpAndSettle();
+      expect(find.byType(PrivateProposalChip), findsOneWidget);
+    });
+  });
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_bloc.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_bloc.dart
@@ -221,6 +221,10 @@ final class WorkspaceBloc extends Bloc<WorkspaceEvent, WorkspaceState>
     WatchUserProposalsEvent event,
     Emitter<WorkspaceState> emit,
   ) async {
+    // As stream is needed in a few places we don't want to create it every time
+    if (_proposalsSubscription != null && state.error == null) {
+      return;
+    }
     _logger.info('Setup user proposals subscription');
     emit(
       state.copyWith(
@@ -228,9 +232,9 @@ final class WorkspaceBloc extends Bloc<WorkspaceEvent, WorkspaceState>
         error: const Optional.empty(),
       ),
     );
+    _logger.info('$state and ${state.showProposals}');
     await _proposalsSubscription?.cancel();
     _proposalsSubscription = null;
     _setupProposalsSubscription();
-    emit(state.copyWith(isLoading: false));
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_bloc.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_bloc.dart
@@ -236,5 +236,6 @@ final class WorkspaceBloc extends Bloc<WorkspaceEvent, WorkspaceState>
     await _proposalsSubscription?.cancel();
     _proposalsSubscription = null;
     _setupProposalsSubscription();
+    emit(state.copyWith(isLoading: false));
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_event.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_event.dart
@@ -43,9 +43,6 @@ final class ForgetProposalEvent extends WorkspaceEvent {
 
 final class GetTimelineItemsEvent extends WorkspaceEvent {
   const GetTimelineItemsEvent();
-
-  @override
-  List<Object?> get props => [];
 }
 
 final class ImportProposalEvent extends WorkspaceEvent {
@@ -77,11 +74,11 @@ final class UnlockProposalEvent extends WorkspaceEvent {
 
 final class WatchUserProposalsEvent extends WorkspaceEvent {
   const WatchUserProposalsEvent();
-
-  @override
-  List<Object?> get props => [];
 }
 
 sealed class WorkspaceEvent extends Equatable {
   const WorkspaceEvent();
+
+  @override
+  List<Object?> get props => [];
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
@@ -16,6 +16,14 @@ final class WorkspaceState extends Equatable {
     this.timelineItems = const [],
   });
 
+  List<Proposal> get notPublished => userProposals
+      .where(
+        (element) =>
+            element.versions.hasLatestLocalDraft(element.selfRef.version) ||
+            element.publish == ProposalPublish.localDraft,
+      )
+      .toList();
+
   @override
   List<Object?> get props => [
         isLoading,
@@ -24,6 +32,11 @@ final class WorkspaceState extends Equatable {
         timelineItems,
       ];
 
+  List<Proposal> get published => userProposals
+      .where(
+        (e) => (e.publish.isPublished || e.publish.isDraft),
+      )
+      .toList();
   bool get showError => error != null && !isLoading;
   bool get showLoading => isLoading;
   bool get showProposals => error == null && !isLoading;
@@ -33,6 +46,7 @@ final class WorkspaceState extends Equatable {
       )
       ?.timeline
       .to;
+  int get totalPublishedProposals => published.length;
 
   WorkspaceState copyWith({
     WorkspaceTabType? tab,

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -2483,5 +2483,13 @@
   "submitCommentErrorDialogTitle": "Unable to add Comment",
   "@submitCommentErrorDialogTitle": {
     "description": "Title for the error dialog when submitting a comment fails"
+  },
+  "noPublishedProposals": "No published proposals.",
+  "@noPublishedProposals": {
+    "description": "Text when there are no published proposals"
+  },
+  "noProposalsToPublish": "You have no proposals to publish, start a new proposal, or create a new iteration of an existing proposal to be able to publish.",
+  "@noProposalsToPublish": {
+    "description": "Text when there are no proposals to publish"
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal_version.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal_version.dart
@@ -50,6 +50,14 @@ final class ProposalVersion extends Equatable
 }
 
 extension ProposalVersionsList on List<ProposalVersion> {
+  bool hasLatestLocalDraft(String? version) {
+    if (isEmpty) return false;
+    final latestVersion = first;
+    return latestVersion.isLatestVersion(
+      version ?? '',
+    );
+  }
+
   int versionNumber(String version) {
     return length - indexWhere((element) => element.selfRef.version == version);
   }


### PR DESCRIPTION
# Description

This pr adds users proposals in proposals and overall spaces 

## Related Issue(s)

Closes #1687 

## Description of Changes

-adding two bloc selectors to tap into a stream of users proposals

## Breaking Changes

N/A

## Screenshots

<img width="551" alt="image" src="https://github.com/user-attachments/assets/ef5bb892-99ef-4f46-b123-9c9727f55406" />
<img width="670" alt="image" src="https://github.com/user-attachments/assets/26378091-c994-40f6-bbf8-9de9a644e1f4" />
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/cc6a9cc1-3dd6-4052-b5b2-2a1769e2a01a" />
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d0404c12-e048-4398-b00f-b51e30497b39" />


## Related Pull Requests

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
