### PR TITLE
fix(cat-gateway): Fix `cat-gateway` build.

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -104,6 +104,9 @@ poem-openapi-derive = { version = "=5.1.4" }
 # Its a transitive dependency of the "poem-openapi-derive" crate,
 # but its breaks API after version "0.20.11".
 darling = { version = "=0.20.10" }
+# Its a transitive dependency of the "orx-concurrent-vec" crate,
+# but its breaks API after version "1.3.0".
+orx-iterable = { version = "=1.2.0" }
 
 [dev-dependencies]
 
@@ -112,4 +115,4 @@ build-info-build = "0.0.39"
 
 [package.metadata.cargo-machete]
 # remove that after fixing issues with latest crates
-ignored = ["poem-openapi-derive", "darling"]
+ignored = ["poem-openapi-derive", "darling", "orx-iterable"]


### PR DESCRIPTION
# Description

A new release of the `orx-iterable` transitive crate have a breaking change, which breaks our compilation.