### PR TITLE
feat(cat-voices): implement favorite proposal on discovery page

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/most_recent_proposals.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/most_recent_proposals.dart
@@ -6,10 +6,12 @@ import 'package:catalyst_voices/widgets/buttons/voices_filled_button.dart';
 import 'package:catalyst_voices/widgets/cards/pending_proposal_card.dart';
 import 'package:catalyst_voices/widgets/scrollbar/voices_slider.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class MostRecentProposals extends StatefulWidget {
@@ -85,9 +87,15 @@ class _LatestProposalsState extends State<MostRecentProposals> {
                               ).push(context),
                             );
                           },
-                          onFavoriteChanged: (value) {
-                            // TODO(LynxLynxx): add on change logic
+                          onFavoriteChanged: (value) async {
+                            final bloc = context.read<DiscoveryCubit>();
+                            if (value) {
+                              await bloc.addFavorite(ref);
+                            } else {
+                              await bloc.removeFavorite(ref);
+                            }
                           },
+                          isFavorite: proposal.isFavorite,
                         ),
                       );
                     },

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_state.dart
@@ -80,6 +80,19 @@ final class DiscoveryMostRecentProposalsState extends Equatable {
   bool get showError => !isLoading && error != null;
 
   bool get showProposals => !isLoading && proposals.isNotEmpty && error == null;
+
+  DiscoveryMostRecentProposalsState copyWith({
+    bool? isLoading,
+    LocalizedException? error,
+    List<PendingProposal>? proposals,
+    List<String>? favoritesProposalsIds,
+  }) {
+    return DiscoveryMostRecentProposalsState(
+      isLoading: isLoading ?? this.isLoading,
+      error: error ?? this.error,
+      proposals: proposals ?? this.proposals,
+    );
+  }
 }
 
 final class DiscoveryState extends Equatable {

--- a/catalyst_voices/packages/internal/catalyst_voices_brands/lib/src/themes/widgets/slider_theme.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_brands/lib/src/themes/widgets/slider_theme.dart
@@ -16,5 +16,6 @@ class VoicesSliderThemeData extends SliderThemeData {
           ),
           overlayColor: Colors.transparent,
           inactiveTickMarkColor: Colors.transparent,
+          activeTickMarkColor: Colors.transparent,
         );
 }


### PR DESCRIPTION

# Description

Adding favorites proposals funtionality to most recent proposal section in discovery page

## Related Issue(s)

N/A

## Description of Changes

- watching stream for favorites proposals 
- emitting new favorites proposals with flag if is favorite
## Breaking Changes

N/A

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
