### PR TITLE
fix(cat-gateway): Fix `catalyst_key_derivation` build

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.3.1 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.3.1 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.3.1 AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:feat/bump-flutter-rust-bridge AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:feat/bump-flutter-rust-bridge AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:feat/bump-flutter-rust-bridge AS postgresql-ci
 
 FROM debian:stable-slim
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:feat/bump-flutter-rust-bridge AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:feat/bump-flutter-rust-bridge AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:feat/bump-flutter-rust-bridge AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.3.2 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.3.2 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.3.2 AS postgresql-ci
 
 FROM debian:stable-slim
 

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.3.1 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/bump-flutter-rust-bridge AS rust-ci
 IMPORT ../ AS repo-ci
 
 #cspell: words rustfmt toolsets USERARCH stdcfgs

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/bump-flutter-rust-bridge AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.3.2 AS rust-ci
 IMPORT ../ AS repo-ci
 
 #cspell: words rustfmt toolsets USERARCH stdcfgs

--- a/catalyst-gateway/event-db/Earthfile
+++ b/catalyst-gateway/event-db/Earthfile
@@ -3,7 +3,7 @@
 # the database and its associated software.
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.3.1 AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:feat/bump-flutter-rust-bridge AS postgresql-ci
 
 # cspell: words
 

--- a/catalyst-gateway/event-db/Earthfile
+++ b/catalyst-gateway/event-db/Earthfile
@@ -3,7 +3,7 @@
 # the database and its associated software.
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:feat/bump-flutter-rust-bridge AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.3.2 AS postgresql-ci
 
 # cspell: words
 

--- a/catalyst-gateway/tests/Earthfile
+++ b/catalyst-gateway/tests/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.8
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/spectral:v3.3.1 AS spectral-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/spectral:feat/bump-flutter-rust-bridge AS spectral-ci
 IMPORT .. AS gateway
 
 docker-compose:

--- a/catalyst-gateway/tests/Earthfile
+++ b/catalyst-gateway/tests/Earthfile
@@ -1,5 +1,5 @@
 VERSION 0.8
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/spectral:feat/bump-flutter-rust-bridge AS spectral-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/spectral:v3.3.2 AS spectral-ci
 IMPORT .. AS gateway
 
 docker-compose:

--- a/catalyst-gateway/tests/api_tests/Earthfile
+++ b/catalyst-gateway/tests/api_tests/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.3.1 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:feat/bump-flutter-rust-bridge AS python-ci
 IMPORT github.com/input-output-hk/catalyst-libs/rust:r20250330-00 AS cat-libs-rust
 
 builder:

--- a/catalyst-gateway/tests/api_tests/Earthfile
+++ b/catalyst-gateway/tests/api_tests/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:feat/bump-flutter-rust-bridge AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.3.2 AS python-ci
 IMPORT github.com/input-output-hk/catalyst-libs/rust:r20250330-00 AS cat-libs-rust
 
 builder:

--- a/catalyst_voices/Earthfile
+++ b/catalyst_voices/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../catalyst-gateway AS catalyst-gateway
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.1 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
 
 # repo-catalyst-voices - Creates artifacts of all configuration files,
 # packages and folders related to catalyst_voices frontend.

--- a/catalyst_voices/Earthfile
+++ b/catalyst_voices/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../catalyst-gateway AS catalyst-gateway
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.2 AS flutter-ci
 
 # repo-catalyst-voices - Creates artifacts of all configuration files,
 # packages and folders related to catalyst_voices frontend.

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/wallet-automation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/wallet-automation/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.1 AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/playwright:v3.3.1 AS playwright-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/playwright:feat/bump-flutter-rust-bridge AS playwright-ci
 
 deps:
     DO playwright-ci+SETUP --workdir=/wallet-automation

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/wallet-automation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/wallet-automation/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/playwright:feat/bump-flutter-rust-bridge AS playwright-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.2 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/playwright:v3.3.2 AS playwright-ci
 
 deps:
     DO playwright-ci+SETUP --workdir=/wallet-automation

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:feat/bump-flutter-rust-bridge AS flutter_rust_bridge
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.2 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:v3.3.2 AS flutter_rust_bridge
 
 builder:
     FROM flutter_rust_bridge+builder

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.1 AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:v3.3.1 AS flutter_rust_bridge
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:feat/bump-flutter-rust-bridge AS flutter_rust_bridge
 
 builder:
     FROM flutter_rust_bridge+builder

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
@@ -12,7 +12,6 @@ code-generator:
     ARG local = false
     FROM +builder
     DO flutter_rust_bridge+CODE_GENERATOR_WEB
-    RUN echo something
 
     IF [ $local = true ]
         SAVE ARTIFACT ./assets/js AS LOCAL ./assets/js

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
@@ -12,6 +12,7 @@ code-generator:
     ARG local = false
     FROM +builder
     DO flutter_rust_bridge+CODE_GENERATOR_WEB
+    RUN echo something
 
     IF [ $local = true ]
         SAVE ARTIFACT ./assets/js AS LOCAL ./assets/js

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   equatable: ^2.0.7
   flutter:
     sdk: flutter
-  flutter_rust_bridge: 2.5.1
+  flutter_rust_bridge: 2.9.0
   plugin_platform_interface: ^2.1.7
 
 dev_dependencies:

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Cargo.toml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-flutter_rust_bridge = "=2.5.1"
+flutter_rust_bridge = "=2.9.0"
 ed25519-bip32 = "0.4.1"
 hmac = "0.12.1"
 pbkdf2 = "0.12.2"

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/bump-flutter-rust-bridge AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.3.2 AS rust-ci
 IMPORT ../ AS flutter-rust-bridge
 
 # builder : Setup the builder

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.3.1 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:feat/bump-flutter-rust-bridge AS rust-ci
 IMPORT ../ AS flutter-rust-bridge
 
 # builder : Setup the builder

--- a/catalyst_voices/utilities/uikit_example/Earthfile
+++ b/catalyst_voices/utilities/uikit_example/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../../ AS catalyst-voices
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.2 AS flutter-ci
 
 # local-build-web - build web version of UIKit example.
 # Prefixed by "local" to make sure it's not auto triggered, the target was

--- a/catalyst_voices/utilities/uikit_example/Earthfile
+++ b/catalyst_voices/utilities/uikit_example/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../../ AS catalyst-voices
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.3.1 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:feat/bump-flutter-rust-bridge AS flutter-ci
 
 # local-build-web - build web version of UIKit example.
 # Prefixed by "local" to make sure it's not auto triggered, the target was

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.1 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/bump-flutter-rust-bridge AS docs-ci
 
 IMPORT .. AS repo
 IMPORT ../catalyst-gateway AS catalyst-gateway

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/bump-flutter-rust-bridge AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.2 AS docs-ci
 
 IMPORT .. AS repo
 IMPORT ../catalyst-gateway AS catalyst-gateway

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/bump-flutter-rust-bridge AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.2 AS docs-ci
 
 
 # update-docs-dev-script: get the latest docs dev script from CI.

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.3.1 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:feat/bump-flutter-rust-bridge AS docs-ci
 
 
 # update-docs-dev-script: get the latest docs dev script from CI.


### PR DESCRIPTION
# Description

Bumping `flutter_rust_bridge` to the most recent one to fix the following compiling issue
```
Compiling catalyst_key_derivation v0.1.0 (/work/rust)
  flutter-rust-bridge+code-generator *failed* | error: this function definition involves an argument of type `()` which is affected by the wasm ABI transition
  flutter-rust-bridge+code-generator *failed* |     --> src/frb_generated.rs:1677:5
  flutter-rust-bridge+code-generator *failed* |      |
  flutter-rust-bridge+code-generator *failed* | 1677 |     flutter_rust_bridge::frb_generated_boilerplate_web!();
  flutter-rust-bridge+code-generator *failed* |      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  flutter-rust-bridge+code-generator *failed* |      |
  flutter-rust-bridge+code-generator *failed* |      = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  flutter-rust-bridge+code-generator *failed* |      = note: for more information, see issue #138762 <https://github.com/rust-lang/rust/issues/138762>
  flutter-rust-bridge+code-generator *failed* |      = help: the "C" ABI Rust uses on wasm32-unknown-unknown will change to align with the standard "C" ABI for this target
  flutter-rust-bridge+code-generator *failed* |      = note: `-D wasm-c-abi` implied by `-D warnings`
  flutter-rust-bridge+code-generator *failed* |      = help: to override `-D warnings` add `#[allow(wasm_c_abi)]`
  flutter-rust-bridge+code-generator *failed* |      = note: this error originates in the attribute macro `wasm_bindgen` which comes from the expansion of the macro `flutter_rust_bridge::frb_generated_boilerplate_web` (in Nightly builds, run with -Z macro-backtrace for more info)
  ```