### PR TITLE
fix(cat-voices): handle new versions created by the proposal builder

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/common/error_handler.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices/routes/routing/proposal_builder_route.dart';
@@ -120,7 +121,8 @@ class _CategorySelection extends StatelessWidget {
   }
 }
 
-class _CreateNewProposalDialogState extends State<CreateNewProposalDialog> {
+class _CreateNewProposalDialogState extends State<CreateNewProposalDialog>
+    with ErrorHandlerStateMixin<NewProposalCubit, CreateNewProposalDialog> {
   final FocusNode _categoryFocusNode = FocusNode();
 
   @override
@@ -183,16 +185,16 @@ class _CreateNewProposalDialogState extends State<CreateNewProposalDialog> {
   Future<void> _onOpenInEditor() async {
     final cubit = context.read<NewProposalCubit>();
     final draftRef = await cubit.createDraft();
-    if (mounted) {
+    if (draftRef != null && mounted) {
       ProposalBuilderRoute.fromRef(ref: draftRef).go(context);
     }
   }
 
   Future<void> _onSave() async {
     final cubit = context.read<NewProposalCubit>();
-    await cubit.createDraft();
+    final draftRef = await cubit.createDraft();
 
-    if (mounted) {
+    if (draftRef != null && mounted) {
       Navigator.of(context).pop();
     }
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
@@ -1,12 +1,17 @@
 import 'dart:async';
 
+import 'package:catalyst_voices_blocs/src/common/bloc_error_emitter_mixin.dart';
 import 'package:catalyst_voices_blocs/src/proposal_builder/new_proposal/new_proposal_state.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class NewProposalCubit extends Cubit<NewProposalState> {
+final _logger = Logger('NewProposalCubit');
+
+class NewProposalCubit extends Cubit<NewProposalState>
+    with BlocErrorEmitterMixin<NewProposalState> {
   final CampaignService _campaignService;
   final ProposalService _proposalService;
   final DocumentMapper _documentMapper;
@@ -23,36 +28,43 @@ class NewProposalCubit extends Cubit<NewProposalState> {
     unawaited(getCampaignCategories());
   }
 
-  Future<DraftRef> createDraft() async {
-    final title = state.title.value;
-    final categoryId = state.categoryId;
+  Future<DraftRef?> createDraft() async {
+    try {
+      final title = state.title.value;
+      final categoryId = state.categoryId;
 
-    if (categoryId == null) {
-      throw StateError('Cannot create draft, category not selected');
-    }
+      if (categoryId == null) {
+        throw StateError('Cannot create draft, category not selected');
+      }
 
-    final category = await _campaignService.getCategory(categoryId);
-    final templateRef = category.proposalTemplateRef;
-    final template = await _proposalService.getProposalTemplate(
-      ref: templateRef,
-    );
-
-    final documentBuilder = DocumentBuilder.fromSchema(schema: template.schema)
-      ..addChange(
-        DocumentValueChange(
-          nodeId: ProposalDocument.titleNodeId,
-          value: title,
-        ),
+      final category = await _campaignService.getCategory(categoryId);
+      final templateRef = category.proposalTemplateRef;
+      final template = await _proposalService.getProposalTemplate(
+        ref: templateRef,
       );
 
-    final document = documentBuilder.build();
-    final documentContent = _documentMapper.toContent(document);
+      final documentBuilder =
+          DocumentBuilder.fromSchema(schema: template.schema)
+            ..addChange(
+              DocumentValueChange(
+                nodeId: ProposalDocument.titleNodeId,
+                value: title,
+              ),
+            );
 
-    return _proposalService.createDraftProposal(
-      content: documentContent,
-      template: templateRef,
-      categoryId: categoryId,
-    );
+      final document = documentBuilder.build();
+      final documentContent = _documentMapper.toContent(document);
+
+      return await _proposalService.createDraftProposal(
+        content: documentContent,
+        template: templateRef,
+        categoryId: categoryId,
+      );
+    } catch (error, stackTrace) {
+      _logger.severe('Create draft', error, stackTrace);
+      emitError(LocalizedException.create(error));
+      return null;
+    }
   }
 
   Future<void> getCampaignCategories() async {


### PR DESCRIPTION
# Description

Proposal editor works in a way that if a signed (published) document is opened and user makes an edit a new (draft) version is created. However that (new) version was not being reflected in the version history.

This PR makes sure that the new version is added to the history.

Additionally handles errors when creating new proposals from the dialog.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
