### PR TITLE
feat(cat-voices): hide admin functionality

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/back_fab.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/back_fab.dart
@@ -21,9 +21,7 @@ class BackFab extends StatelessWidget {
         if (goRouter.canPop()) {
           goRouter.pop();
         } else {
-          // TODO(damian-molinski): should go to initial route later
-          // goRouter.go(Routes.initialLocation);
-          const TreasuryRoute().go(context);
+          goRouter.go(Routes.initialLocation);
         }
       },
     );

--- a/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
@@ -10,6 +10,7 @@ import 'package:catalyst_voices/pages/spaces/drawer/spaces_drawer.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -70,7 +71,8 @@ class _Shortcuts extends StatelessWidget {
           bindings: <ShortcutActivator, VoidCallback>{
             for (final entry in shortcuts.entries)
               entry.value: () => entry.key.go(context),
-            CampaignAdminToolsDialog.shortcut: onToggleAdminTools,
+            if (!kReleaseMode)
+              CampaignAdminToolsDialog.shortcut: onToggleAdminTools,
           },
           child: child,
         );
@@ -102,27 +104,23 @@ class _SpacesShellPageState extends State<SpacesShellPage> {
       },
       child: _Shortcuts(
         onToggleAdminTools: _toggleAdminTools,
-        child: BlocSelector<SessionCubit, SessionState,
-            ({bool isUnlocked, bool isVisitor})>(
-          selector: (state) => (
-            isUnlocked: state.isActive,
-            isVisitor: state.isVisitor,
-          ),
-          builder: (context, state) {
+        child: BlocSelector<SessionCubit, SessionState, bool>(
+          selector: (state) => state.isActive,
+          builder: (context, isActive) {
             return Scaffold(
               appBar: VoicesAppBar(
-                leading: state.isVisitor ? null : const DrawerToggleButton(),
+                leading: isActive ? const DrawerToggleButton() : null,
                 automaticallyImplyLeading: false,
                 actions: _getActions(widget.space),
               ),
-              drawer: state.isVisitor
-                  ? null
-                  : SpacesDrawer(
+              drawer: isActive
+                  ? SpacesDrawer(
                       space: widget.space,
                       spacesShortcutsActivators:
                           SpacesShellPage._spacesShortcutsActivators,
-                      isUnlocked: state.isUnlocked,
-                    ),
+                      isUnlocked: isActive,
+                    )
+                  : null,
               endDrawer: const OpportunitiesDrawer(),
               body: widget.child,
             );


### PR DESCRIPTION
# Description

- Makes sure campaign admin tools are disabled in release builds.
- Makes sure treasury space cannot be accessed.
- Hidden hamburger menu button when account is locked (UX request).

## Related Issue(s)

Closes #1954

## Screenshots

![Screenshot 2025-04-08 at 11 54 21](https://github.com/user-attachments/assets/df6c8543-9ad3-4ec2-8c50-37423429b89f)

![Screenshot 2025-04-08 at 11 54 02](https://github.com/user-attachments/assets/72a61d5c-01ef-4270-8b13-671769239760)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
