### PR TITLE
fix(cat-gateway): Fix hypothesis.HealthCheck.nested_given error

### DIFF
--- a/catalyst-gateway/tests/schemathesis_tests/hooks/hooks.py
+++ b/catalyst-gateway/tests/schemathesis_tests/hooks/hooks.py
@@ -2,7 +2,7 @@ import schemathesis
 import random
 import time
 import os
-import hypothesis
+from hypothesis import given, strategies as st
 import cbor2
 
 
@@ -24,10 +24,12 @@ class MyAuth:
         return 1
 
     def set(self, case, data, context):
+        self.set_impl(case)
+
+    @given(data=st.data())
+    def set_impl(self, case, data):
         security_definitions = case.operation.definition.raw.get("security", [])
-        # randomly choose what kind of authentication would be applied
-        choosen_auth_st = hypothesis.strategies.sampled_from(security_definitions)
-        choosen_auth = hypothesis.find(choosen_auth_st, lambda x: True)
+        choosen_auth = data.draw(st.sampled_from(security_definitions), label="choosen_auth")
         if "NoAuthorization" in choosen_auth:
             case.headers.pop("Authorization", None)
             case.headers.pop("X-API-Key", None)


### PR DESCRIPTION
# Description

Fixing schemathesis CI failure causing by [`hypothesis.HealthCheck.nested_given`](https://hypothesis.readthedocs.io/en/latest/reference/api.html#hypothesis.HealthCheck)
```
./c/t/schemathesis_tests+test-ci-schemathesis |     hypothesis.errors.FailedHealthCheck: Nesting @given tests results in quadratic generation and shrinking behavior and can usually be more cleanly expressed by replacing the inner function with an st.data() parameter on the outer @given.
  ./c/t/schemathesis_tests+test-ci-schemathesis |     See https://hypothesis.readthedocs.io/en/latest/reference/api.html#health-checks for more information about this. If you want to disable just this health check, add HealthCheck.nested_given to the suppress_health_check settings for this test.
 ```