### PR TITLE
fix(cat-voices): When user locks app should be redirected to Discovery Page

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -72,16 +72,12 @@ final class _AppContent extends StatelessWidget {
       ),
       debugShowCheckedModeBanner: false,
       builder: (_, child) {
-        return Scaffold(
-          primary: false,
-          backgroundColor: Colors.transparent,
-          body: AppActiveStateListener(
-            child: GlobalPrecacheImages(
-              child: GlobalSessionListener(
-                child: AppMobileAccessRestriction(
-                  child: AppSplashScreenManager(
-                    child: child ?? const SizedBox.shrink(),
-                  ),
+        return AppActiveStateListener(
+          child: GlobalPrecacheImages(
+            child: GlobalSessionListener(
+              child: AppMobileAccessRestriction(
+                child: AppSplashScreenManager(
+                  child: child ?? const SizedBox.shrink(),
                 ),
               ),
             ),

--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -71,21 +71,26 @@ final class _AppContent extends StatelessWidget {
         brightness: Brightness.dark,
       ),
       debugShowCheckedModeBanner: false,
-      builder: (context, child) {
-        return Scaffold(
-          primary: false,
-          backgroundColor: Colors.transparent,
-          body: AppActiveStateListener(
-            child: GlobalPrecacheImages(
-              child: GlobalSessionListener(
-                child: AppMobileAccessRestriction(
-                  child: AppSplashScreenManager(
-                    child: child ?? const SizedBox.shrink(),
+      builder: (_, child) {
+        return Builder(
+          builder: (context) {
+            return Scaffold(
+              primary: false,
+              backgroundColor: Colors.transparent,
+              body: AppActiveStateListener(
+                child: GlobalPrecacheImages(
+                  child: GlobalSessionListener(
+                    routerConfig: routerConfig,
+                    child: AppMobileAccessRestriction(
+                      child: AppSplashScreenManager(
+                        child: child ?? const SizedBox.shrink(),
+                      ),
+                    ),
                   ),
                 ),
               ),
-            ),
-          ),
+            );
+          },
         );
       },
     );

--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -72,25 +72,20 @@ final class _AppContent extends StatelessWidget {
       ),
       debugShowCheckedModeBanner: false,
       builder: (_, child) {
-        return Builder(
-          builder: (context) {
-            return Scaffold(
-              primary: false,
-              backgroundColor: Colors.transparent,
-              body: AppActiveStateListener(
-                child: GlobalPrecacheImages(
-                  child: GlobalSessionListener(
-                    routerConfig: routerConfig,
-                    child: AppMobileAccessRestriction(
-                      child: AppSplashScreenManager(
-                        child: child ?? const SizedBox.shrink(),
-                      ),
-                    ),
+        return Scaffold(
+          primary: false,
+          backgroundColor: Colors.transparent,
+          body: AppActiveStateListener(
+            child: GlobalPrecacheImages(
+              child: GlobalSessionListener(
+                child: AppMobileAccessRestriction(
+                  child: AppSplashScreenManager(
+                    child: child ?? const SizedBox.shrink(),
                   ),
                 ),
               ),
-            );
-          },
+            ),
+          ),
         );
       },
     );

--- a/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices/widgets/snackbar/voices_snackbar.dart';
 import 'package:catalyst_voices/widgets/snackbar/voices_snackbar_type.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
@@ -5,24 +6,43 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 
 /// Listens globally to a session and can show different
 /// snackBars when a session changes.
-class GlobalSessionListener extends StatelessWidget {
+class GlobalSessionListener extends StatefulWidget {
   final Widget child;
+  final RouterConfig<Object> routerConfig;
 
   const GlobalSessionListener({
     super.key,
     required this.child,
+    required this.routerConfig,
   });
 
   @override
+  State<GlobalSessionListener> createState() => _GlobalSessionListenerState();
+}
+
+class _GlobalSessionListenerState extends State<GlobalSessionListener> {
+  String? _lastLocation;
+
+  @override
   Widget build(BuildContext context) {
-    return BlocListener<SessionCubit, SessionState>(
-      listenWhen: _listenToSessionChangesWhen,
-      listener: _onSessionChanged,
-      child: child,
+    return Builder(
+      builder: (newContext) {
+        return BlocListener<SessionCubit, SessionState>(
+          listenWhen: _listenToSessionChangesWhen,
+          listener: _onSessionChanged,
+          child: widget.child,
+        );
+      },
     );
+  }
+
+  @override
+  void initState() {
+    super.initState();
   }
 
   bool _listenToSessionChangesWhen(SessionState prev, SessionState next) {
@@ -32,6 +52,23 @@ class GlobalSessionListener extends StatelessWidget {
     final keychainLocked = prev.isActive && next.isGuest;
 
     return keychainUnlocked || keychainLocked;
+  }
+
+  void _onLockedKeychain(BuildContext context) {
+    VoicesSnackBar(
+      type: VoicesSnackBarType.error,
+      behavior: SnackBarBehavior.floating,
+      icon: VoicesAssets.icons.lockClosed.buildIcon(),
+      title: context.l10n.lockSnackbarTitle,
+      message: context.l10n.lockSnackbarMessage,
+    ).show(context);
+
+    final routerContext = AppRouter.rootNavigatorKey.currentContext;
+
+    if (routerContext != null) {
+      _lastLocation = GoRouter.of(routerContext).state.uri.toString();
+      routerContext.go(const DiscoveryRoute().location);
+    }
   }
 
   void _onSessionChanged(BuildContext context, SessionState state) {
@@ -50,15 +87,10 @@ class GlobalSessionListener extends StatelessWidget {
       title: context.l10n.unlockSnackbarTitle,
       message: context.l10n.unlockSnackbarMessage,
     ).show(context);
-  }
 
-  void _onLockedKeychain(BuildContext context) {
-    VoicesSnackBar(
-      type: VoicesSnackBarType.error,
-      behavior: SnackBarBehavior.floating,
-      icon: VoicesAssets.icons.lockClosed.buildIcon(),
-      title: context.l10n.lockSnackbarTitle,
-      message: context.l10n.lockSnackbarMessage,
-    ).show(context);
+    final routerContext = AppRouter.rootNavigatorKey.currentContext;
+    if (_lastLocation != null && routerContext != null) {
+      routerContext.go(_lastLocation!);
+    }
   }
 }

--- a/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
@@ -53,7 +53,6 @@ class _GlobalSessionListenerState extends State<GlobalSessionListener> {
     ).show(context);
 
     final routerContext = AppRouter.rootNavigatorKey.currentContext;
-
     if (routerContext != null) {
       _lastLocation = GoRouter.of(routerContext).state.uri.toString();
       routerContext.go(const DiscoveryRoute().location);

--- a/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
@@ -12,12 +12,10 @@ import 'package:go_router/go_router.dart';
 /// snackBars when a session changes.
 class GlobalSessionListener extends StatefulWidget {
   final Widget child;
-  final RouterConfig<Object> routerConfig;
 
   const GlobalSessionListener({
     super.key,
     required this.child,
-    required this.routerConfig,
   });
 
   @override
@@ -29,20 +27,11 @@ class _GlobalSessionListenerState extends State<GlobalSessionListener> {
 
   @override
   Widget build(BuildContext context) {
-    return Builder(
-      builder: (newContext) {
-        return BlocListener<SessionCubit, SessionState>(
-          listenWhen: _listenToSessionChangesWhen,
-          listener: _onSessionChanged,
-          child: widget.child,
-        );
-      },
+    return BlocListener<SessionCubit, SessionState>(
+      listenWhen: _listenToSessionChangesWhen,
+      listener: _onSessionChanged,
+      child: widget.child,
     );
-  }
-
-  @override
-  void initState() {
-    super.initState();
   }
 
   bool _listenToSessionChangesWhen(SessionState prev, SessionState next) {

--- a/catalyst_voices/apps/voices/lib/routes/app_router.dart
+++ b/catalyst_voices/apps/voices/lib/routes/app_router.dart
@@ -8,7 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 abstract final class AppRouter {
-  static final _rootNavigatorKey = GlobalKey<NavigatorState>(
+  static final rootNavigatorKey = GlobalKey<NavigatorState>(
     debugLabel: 'rootNavigatorKey',
   );
 
@@ -18,7 +18,7 @@ abstract final class AppRouter {
     Listenable? refreshListenable,
   }) {
     return GoRouter(
-      navigatorKey: _rootNavigatorKey,
+      navigatorKey: rootNavigatorKey,
       initialLocation: initialLocation ?? Routes.initialLocation,
       redirect: (context, state) async => _guard(context, state, guards),
       observers: [


### PR DESCRIPTION
# Description

This PR resolves issue when user lock the app and was not redirected to Discovery Page

## Related Issue(s)

Closes #2201

## Description of Changes

- making AppRoute global key public to be able to call it from GlobalStateListener

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
