### PR TITLE
fix(cat-voices): password not updating after account recovery

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/user_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/user_service.dart
@@ -156,7 +156,9 @@ final class UserServiceImpl implements UserService {
   Future<void> useAccount(Account account) async {
     var user = await getUser();
 
-    if (!user.hasAccount(id: account.catalystId)) {
+    if (user.hasAccount(id: account.catalystId)) {
+      user = user.updateAccount(account);
+    } else {
       user = user.addAccount(account);
     }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -99,6 +99,39 @@ void main() {
       expect(currentAccount?.isActive, isTrue);
     });
 
+    test(
+        'when using a new account with the same catalystId'
+        ' the getter returns updated account', () async {
+      // Given
+      final oldKeychainId = const Uuid().v4();
+      final newKeychainId = const Uuid().v4();
+      final catalystId = DummyCatalystIdFactory.create();
+
+      // When
+      final oldKeychain = await keychainProvider.create(oldKeychainId);
+      final oldAccount = Account.dummy(
+        catalystId: catalystId,
+        keychain: oldKeychain,
+        isActive: false,
+      );
+
+      final newKeychain = await keychainProvider.create(newKeychainId);
+      final newAccount = Account.dummy(
+        catalystId: catalystId,
+        keychain: newKeychain,
+        isActive: true,
+      );
+
+      await service.useAccount(oldAccount);
+      await service.useAccount(newAccount);
+
+      // Then
+      final currentAccount = service.user.activeAccount;
+
+      expect(currentAccount, equals(newAccount));
+      expect(currentAccount, isNot(oldAccount));
+    });
+
     test('using different account emits update in stream', () async {
       // Given
       final keychainIdOne = const Uuid().v4();


### PR DESCRIPTION
# Description

Make sure to update account after recovery to apply the latest password.

## Related Issue(s)

Closes #2150

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
