### PR TITLE
fix(cat-voices): hide the button to add roles if all of them are added

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_roles_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_roles_tile.dart
@@ -42,9 +42,11 @@ class _AccountRolesTileState extends State<_AccountRolesTile> {
     return PropertyTile(
       title: context.l10n.myRoles,
       key: const Key('AddRoleTile'),
-      action: _EditButton(
-        onTap: widget.state.canAddRole ? _addAccountRole : null,
-      ),
+      action: widget.state.canAddRole
+          ? _EditButton(
+              onTap: _addAccountRole,
+            )
+          : null,
       child: _Roles(items: widget.state.items),
     );
   }


### PR DESCRIPTION
# Description

Hide the button to add roles if all of them are added

## Related Issue(s)

Closes #2182 

## Screenshots

![Screenshot 2025-04-12 at 19 59 14](https://github.com/user-attachments/assets/81f89e43-2bff-485d-a086-65481301e426)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
