### PR TITLE
fix(cat-voices): cancel button text

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/registration/widgets/export_catalyst_key_confirm_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/widgets/export_catalyst_key_confirm_dialog.dart
@@ -49,7 +49,7 @@ class _ExportCatalystKeyConfirmDialogState
           };
         },
       ),
-      negativeText: l10n.cancelAnyways,
+      negativeText: l10n.cancelButtonText,
       positiveText: l10n.exportKey,
     );
   }


### PR DESCRIPTION
# Description

Changes "Cancel anyway" to "Cancel" in a dialog for exporting seed phrase.

## Related Issue(s)

Closes #2188

## Screenshots

![Screenshot 2025-04-12 at 20 06 11](https://github.com/user-attachments/assets/71bc6c6f-1054-43e5-9004-4e6caccebc30)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
