### PR TITLE
fix(cat-voices): create new proposal dialog - handle missing proposer role

### DIFF
--- a/catalyst_voices/apps/voices/lib/dependency/dependencies.dart
+++ b/catalyst_voices/apps/voices/lib/dependency/dependencies.dart
@@ -142,6 +142,7 @@ final class Dependencies extends DependencyProvider {
         return NewProposalCubit(
           get<CampaignService>(),
           get<ProposalService>(),
+          get<UserObserver>(),
           get<DocumentMapper>(),
         );
       })

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
@@ -40,8 +40,8 @@ class CreateNewProposalDialog extends StatefulWidget {
 }
 
 class _ActionButtons extends StatelessWidget {
-  final VoidCallback? onSave;
-  final VoidCallback? onOpenInEditor;
+  final VoidCallback onSave;
+  final VoidCallback onOpenInEditor;
 
   const _ActionButtons({
     required this.onSave,

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
@@ -83,7 +83,7 @@ class NewProposalCubit extends Cubit<NewProposalState>
 
       final newState = state.copyWith(
         isLoading: false,
-        isMissingProposerRole: account.hasRole(AccountRole.proposer),
+        isMissingProposerRole: !account.hasRole(AccountRole.proposer),
         categories: categories,
         categoryId: Optional(categories.first.id),
       );

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
@@ -14,22 +14,24 @@ class NewProposalCubit extends Cubit<NewProposalState>
     with BlocErrorEmitterMixin<NewProposalState> {
   final CampaignService _campaignService;
   final ProposalService _proposalService;
+  final UserObserver _userObserver;
   final DocumentMapper _documentMapper;
 
   NewProposalCubit(
     this._campaignService,
     this._proposalService,
+    this._userObserver,
     this._documentMapper,
   ) : super(
           const NewProposalState(
             title: ProposalTitle.pure(),
           ),
-        ) {
-    unawaited(getCampaignCategories());
-  }
+        );
 
   Future<DraftRef?> createDraft() async {
     try {
+      emit(state.copyWith(isCreatingProposal: true));
+
       final title = state.title.value;
       final categoryId = state.categoryId;
 
@@ -64,24 +66,36 @@ class NewProposalCubit extends Cubit<NewProposalState>
       _logger.severe('Create draft', error, stackTrace);
       emitError(LocalizedException.create(error));
       return null;
+    } finally {
+      emit(state.copyWith(isCreatingProposal: false));
     }
   }
 
-  Future<void> getCampaignCategories() async {
-    final categories = await _campaignService.getCampaignCategories();
-    final categoriesModel =
-        categories.map(CampaignCategoryDetailsViewModel.fromModel).toList();
-    emit(
-      state.copyWith(
-        categories: categoriesModel,
-        categoryId: Optional(categoriesModel.first.id),
-      ),
-    );
-  }
+  Future<void> load() async {
+    try {
+      emit(NewProposalState.loading());
 
-  void reset() {
-    emit(NewProposalState.reset());
-    unawaited(getCampaignCategories());
+      final account = _userObserver.user.activeAccount;
+      if (account == null) {
+        throw StateError('Account is missing');
+      }
+      final categories = await _getCategories();
+
+      final newState = state.copyWith(
+        isLoading: false,
+        isMissingProposerRole: account.hasRole(AccountRole.proposer),
+        categories: categories,
+        categoryId: Optional(categories.first.id),
+      );
+
+      emit(newState);
+    } catch (error, stackTrace) {
+      _logger.severe('Load', error, stackTrace);
+
+      // TODO(dtscalac): handle error state as dialog content,
+      // don't emit the error
+      emitError(LocalizedException.create(error));
+    }
   }
 
   void updateSelectedCategory(SignedDocumentRef? categoryId) {
@@ -90,5 +104,10 @@ class NewProposalCubit extends Cubit<NewProposalState>
 
   void updateTitle(ProposalTitle title) {
     emit(state.copyWith(title: title));
+  }
+
+  Future<List<CampaignCategoryDetailsViewModel>> _getCategories() async {
+    final categories = await _campaignService.getCampaignCategories();
+    return categories.map(CampaignCategoryDetailsViewModel.fromModel).toList();
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_state.dart
@@ -3,35 +3,54 @@ import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:equatable/equatable.dart';
 
 class NewProposalState extends Equatable {
+  final bool isLoading;
+  final bool isCreatingProposal;
+  final bool isMissingProposerRole;
   final ProposalTitle title;
   final SignedDocumentRef? categoryId;
   final List<CampaignCategoryDetailsViewModel> categories;
 
   const NewProposalState({
+    this.isLoading = false,
+    this.isCreatingProposal = false,
+    this.isMissingProposerRole = false,
     required this.title,
     this.categoryId,
     this.categories = const [],
   });
 
-  factory NewProposalState.reset() {
+  factory NewProposalState.loading() {
     return const NewProposalState(
+      isLoading: true,
       title: ProposalTitle.pure(),
-      categoryId: null,
-      categories: [],
     );
   }
 
   bool get isValid => title.isValid && categoryId != null;
 
   @override
-  List<Object?> get props => [title, categoryId, categories];
+  List<Object?> get props => [
+        isLoading,
+        isCreatingProposal,
+        isMissingProposerRole,
+        title,
+        categoryId,
+        categories,
+      ];
 
   NewProposalState copyWith({
+    bool? isLoading,
+    bool? isCreatingProposal,
+    bool? isMissingProposerRole,
     ProposalTitle? title,
     Optional<SignedDocumentRef>? categoryId,
     List<CampaignCategoryDetailsViewModel>? categories,
   }) {
     return NewProposalState(
+      isLoading: isLoading ?? this.isLoading,
+      isCreatingProposal: isCreatingProposal ?? this.isCreatingProposal,
+      isMissingProposerRole:
+          isMissingProposerRole ?? this.isMissingProposerRole,
       title: title ?? this.title,
       categoryId: categoryId.dataOr(this.categoryId),
       categories: categories ?? this.categories,

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
@@ -114,6 +114,10 @@ final class Account extends Equatable {
     );
   }
 
+  bool hasRole(AccountRole role) {
+    return roles.contains(role);
+  }
+
   bool isSameRef(Account other) => catalystId.isReferringTo(other);
 }
 


### PR DESCRIPTION
# Description

A common logic around handling missing proposer role in new proposal dialog.

The actual design for `Proposer role missing` state will be implemented later when it becomes available, the PR implements the logic part (checking whether the user has proposer role, etc).

## Related Issue(s)

Refers #2213

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
