### PR TITLE
fix(cat-voices): update keychain seed phrase confirmation message for clarity in instructions

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -948,7 +948,7 @@
   "createKeychainSeedPhraseExportConfirmDialogContent": "Before using this feature, please read this {link}",
   "bestPracticesFAQ": "best practices FAQ",
   "exportKey": "Export Key",
-  "createKeychainSeedPhraseStoreConfirmation": "I have written down/downloaded my 12 words",
+  "createKeychainSeedPhraseStoreConfirmation": "I have written down/exported my 12 words",
   "createKeychainSeedPhraseCheckInstructionsTitle": "Write down your Catalyst seed phrase",
   "createKeychainSeedPhraseCheckInstructionsSubtitle": "Next, we're going to make sure that you've written down your Catalyst seed phrase correctly.   \u2028\u2028We don't save your Catalyst seed phrase, so it's important \u2028to make sure you have it right. Thats why we don't trust, we verify before continuing.   \u2028\u2028It's also good practice to get familiar with using a \nseed phrase if you're new to crypto.",
   "createKeychainSeedPhraseCheckSubtitle": "Input your Catalyst seed phrase",


### PR DESCRIPTION
# Description

We switch from download keychain to export keychain for more clarity for users

## Related Issue(s)

Closes #2191

## Description of Changes

-change downloaded to exported

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
