### PR TITLE
refactor(cat-voices): adding onSubmitted method on confirm password in registration dialog

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
@@ -6,6 +6,7 @@ import 'package:catalyst_voices/pages/registration/widgets/unlock_password_form.
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class UnlockPasswordPanel extends StatefulWidget {
   const UnlockPasswordPanel({
@@ -97,7 +98,19 @@ class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
           child: _BlocUnlockPasswordForm(
             passwordController: _passwordController,
             confirmPasswordController: _confirmPasswordController,
-            onSubmitted: (_) => _createKeychain(),
+            onSubmitted: (_) {
+              final isNextEnabled = context
+                  .read<RegistrationCubit>()
+                  .state
+                  .recoverStateData
+                  .unlockPasswordState
+                  .isNextEnabled;
+              if (isNextEnabled) {
+                _createKeychain();
+              } else {
+                return;
+              }
+            },
           ),
         ),
         const SizedBox(height: 22),

--- a/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
@@ -16,99 +16,40 @@ class UnlockPasswordPanel extends StatefulWidget {
   State<UnlockPasswordPanel> createState() => _UnlockPasswordPanelState();
 }
 
-class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
-  late final TextEditingController _passwordController;
-  late final TextEditingController _confirmPasswordController;
+class _BlocNavigation extends StatelessWidget {
+  final VoidCallback onNextTap;
+  final VoidCallback onBackTap;
 
-  @override
-  void initState() {
-    super.initState();
-
-    final unlockPasswordState = RegistrationCubit.of(context)
-        .state
-        .keychainStateData
-        .unlockPasswordState;
-
-    final password = unlockPasswordState.password.value;
-    final confirmPassword = unlockPasswordState.confirmPassword.value;
-
-    final passwordValue = TextEditingValueExt.collapsedAtEndOf(password);
-    final confirmPasswordValue =
-        TextEditingValueExt.collapsedAtEndOf(confirmPassword);
-
-    _passwordController = TextEditingController.fromValue(passwordValue)
-      ..addListener(_onPasswordChanged);
-
-    _confirmPasswordController =
-        TextEditingController.fromValue(confirmPasswordValue)
-          ..addListener(_onConfirmPasswordChanged);
-  }
-
-  @override
-  void dispose() {
-    _passwordController.dispose();
-    _confirmPasswordController.dispose();
-    super.dispose();
-  }
+  const _BlocNavigation({
+    required this.onNextTap,
+    required this.onBackTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const SizedBox(height: 24),
-        const SizedBox(height: 12),
-        Expanded(
-          child: _BlocUnlockPasswordForm(
-            passwordController: _passwordController,
-            confirmPasswordController: _confirmPasswordController,
-          ),
-        ),
-        const SizedBox(height: 22),
-        _BlocNavigation(
-          onNextTap: _createKeychain,
-          onBackTap: _clearPasswordAndGoBack,
-        ),
-      ],
+    return BlocUnlockPasswordSelector<bool>(
+      stateSelector: (state) => state.keychainStateData.unlockPasswordState,
+      selector: (state) => state.isNextEnabled,
+      builder: (context, state) {
+        return RegistrationBackNextNavigation(
+          isNextEnabled: state,
+          onNextTap: onNextTap,
+          onBackTap: onBackTap,
+        );
+      },
     );
-  }
-
-  void _createKeychain() {
-    unawaited(RegistrationCubit.of(context).createKeychain());
-  }
-
-  void _onPasswordChanged() {
-    final password = _passwordController.text;
-
-    RegistrationCubit.of(context).keychainCreation.setPassword(password);
-  }
-
-  void _onConfirmPasswordChanged() {
-    final confirmPassword = _confirmPasswordController.text;
-
-    RegistrationCubit.of(context)
-        .keychainCreation
-        .setConfirmPassword(confirmPassword);
-  }
-
-  void _clearPasswordAndGoBack() {
-    final registration = RegistrationCubit.of(context);
-
-    registration.keychainCreation
-      ..setPassword('')
-      ..setConfirmPassword('');
-
-    registration.previousStep();
   }
 }
 
 class _BlocUnlockPasswordForm extends StatelessWidget {
   final TextEditingController passwordController;
   final TextEditingController confirmPasswordController;
+  final ValueChanged<String>? onSubmitted;
 
   const _BlocUnlockPasswordForm({
     required this.passwordController,
     required this.confirmPasswordController,
+    this.onSubmitted,
   });
 
   @override
@@ -134,33 +75,96 @@ class _BlocUnlockPasswordForm extends StatelessWidget {
           showError: state.showError,
           passwordStrength: state.passwordStrength,
           showPasswordStrength: state.showPasswordStrength,
+          onSubmitted: onSubmitted,
         );
       },
     );
   }
 }
 
-class _BlocNavigation extends StatelessWidget {
-  final VoidCallback onNextTap;
-  final VoidCallback onBackTap;
-
-  const _BlocNavigation({
-    required this.onNextTap,
-    required this.onBackTap,
-  });
+class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
+  late final TextEditingController _passwordController;
+  late final TextEditingController _confirmPasswordController;
 
   @override
   Widget build(BuildContext context) {
-    return BlocUnlockPasswordSelector<bool>(
-      stateSelector: (state) => state.keychainStateData.unlockPasswordState,
-      selector: (state) => state.isNextEnabled,
-      builder: (context, state) {
-        return RegistrationBackNextNavigation(
-          isNextEnabled: state,
-          onNextTap: onNextTap,
-          onBackTap: onBackTap,
-        );
-      },
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 24),
+        const SizedBox(height: 12),
+        Expanded(
+          child: _BlocUnlockPasswordForm(
+            passwordController: _passwordController,
+            confirmPasswordController: _confirmPasswordController,
+            onSubmitted: (_) => _createKeychain(),
+          ),
+        ),
+        const SizedBox(height: 22),
+        _BlocNavigation(
+          onNextTap: _createKeychain,
+          onBackTap: _clearPasswordAndGoBack,
+        ),
+      ],
     );
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    final unlockPasswordState = RegistrationCubit.of(context)
+        .state
+        .keychainStateData
+        .unlockPasswordState;
+
+    final password = unlockPasswordState.password.value;
+    final confirmPassword = unlockPasswordState.confirmPassword.value;
+
+    final passwordValue = TextEditingValueExt.collapsedAtEndOf(password);
+    final confirmPasswordValue =
+        TextEditingValueExt.collapsedAtEndOf(confirmPassword);
+
+    _passwordController = TextEditingController.fromValue(passwordValue)
+      ..addListener(_onPasswordChanged);
+
+    _confirmPasswordController =
+        TextEditingController.fromValue(confirmPasswordValue)
+          ..addListener(_onConfirmPasswordChanged);
+  }
+
+  void _clearPasswordAndGoBack() {
+    final registration = RegistrationCubit.of(context);
+
+    registration.keychainCreation
+      ..setPassword('')
+      ..setConfirmPassword('');
+
+    registration.previousStep();
+  }
+
+  void _createKeychain() {
+    unawaited(RegistrationCubit.of(context).createKeychain());
+  }
+
+  void _onConfirmPasswordChanged() {
+    final confirmPassword = _confirmPasswordController.text;
+
+    RegistrationCubit.of(context)
+        .keychainCreation
+        .setConfirmPassword(confirmPassword);
+  }
+
+  void _onPasswordChanged() {
+    final password = _passwordController.text;
+
+    RegistrationCubit.of(context).keychainCreation.setPassword(password);
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
@@ -107,8 +107,6 @@ class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
                   .isNextEnabled;
               if (isNextEnabled) {
                 _createKeychain();
-              } else {
-                return;
               }
             },
           ),

--- a/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
@@ -12,103 +12,40 @@ class UnlockPasswordPanel extends StatefulWidget {
   State<UnlockPasswordPanel> createState() => _UnlockPasswordPanelState();
 }
 
-class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
-  late final TextEditingController _passwordController;
-  late final TextEditingController _confirmPasswordController;
+class _BlocNavigation extends StatelessWidget {
+  final VoidCallback onNextTap;
+  final VoidCallback onBackTap;
 
-  @override
-  void initState() {
-    super.initState();
-
-    final unlockPasswordState = RegistrationCubit.of(context)
-        .state
-        .recoverStateData
-        .unlockPasswordState;
-
-    final password = unlockPasswordState.password.value;
-    final confirmPassword = unlockPasswordState.confirmPassword.value;
-
-    final passwordValue = TextEditingValueExt.collapsedAtEndOf(password);
-    final confirmPasswordValue =
-        TextEditingValueExt.collapsedAtEndOf(confirmPassword);
-
-    _passwordController = TextEditingController.fromValue(passwordValue)
-      ..addListener(_onPasswordChanged);
-
-    _confirmPasswordController =
-        TextEditingController.fromValue(confirmPasswordValue)
-          ..addListener(_onConfirmPasswordChanged);
-  }
-
-  @override
-  void dispose() {
-    _passwordController.dispose();
-    _confirmPasswordController.dispose();
-    super.dispose();
-  }
+  const _BlocNavigation({
+    required this.onNextTap,
+    required this.onBackTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const SizedBox(height: 24),
-        const SizedBox(height: 12),
-        Expanded(
-          child: _BlocUnlockPasswordForm(
-            passwordController: _passwordController,
-            confirmPasswordController: _confirmPasswordController,
-          ),
-        ),
-        const SizedBox(height: 22),
-        _BlocNavigation(
-          onNextTap: _createKeychain,
-          onBackTap: _clearPasswordAndGoBack,
-        ),
-      ],
+    return BlocUnlockPasswordSelector<bool>(
+      stateSelector: (state) => state.recoverStateData.unlockPasswordState,
+      selector: (state) => state.isNextEnabled,
+      builder: (context, state) {
+        return RegistrationBackNextNavigation(
+          isNextEnabled: state,
+          onNextTap: onNextTap,
+          onBackTap: onBackTap,
+        );
+      },
     );
-  }
-
-  void _onPasswordChanged() {
-    final password = _passwordController.text;
-
-    RegistrationCubit.of(context).recover.setPassword(password);
-  }
-
-  void _onConfirmPasswordChanged() {
-    final confirmPassword = _confirmPasswordController.text;
-
-    RegistrationCubit.of(context).recover.setConfirmPassword(confirmPassword);
-  }
-
-  Future<void> _createKeychain() async {
-    final cubit = RegistrationCubit.of(context);
-
-    final success = await cubit.recover.setupKeychain();
-
-    if (success) {
-      cubit.nextStep();
-    }
-  }
-
-  void _clearPasswordAndGoBack() {
-    final registration = RegistrationCubit.of(context);
-
-    registration.recover
-      ..setPassword('')
-      ..setConfirmPassword('');
-
-    registration.previousStep();
   }
 }
 
 class _BlocUnlockPasswordForm extends StatelessWidget {
   final TextEditingController passwordController;
   final TextEditingController confirmPasswordController;
+  final ValueChanged<String>? onSubmitted;
 
   const _BlocUnlockPasswordForm({
     required this.passwordController,
     required this.confirmPasswordController,
+    this.onSubmitted,
   });
 
   @override
@@ -134,33 +71,100 @@ class _BlocUnlockPasswordForm extends StatelessWidget {
           showError: state.showError,
           passwordStrength: state.passwordStrength,
           showPasswordStrength: state.showPasswordStrength,
+          onSubmitted: onSubmitted,
         );
       },
     );
   }
 }
 
-class _BlocNavigation extends StatelessWidget {
-  final VoidCallback onNextTap;
-  final VoidCallback onBackTap;
-
-  const _BlocNavigation({
-    required this.onNextTap,
-    required this.onBackTap,
-  });
+class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
+  late final TextEditingController _passwordController;
+  late final TextEditingController _confirmPasswordController;
 
   @override
   Widget build(BuildContext context) {
-    return BlocUnlockPasswordSelector<bool>(
-      stateSelector: (state) => state.recoverStateData.unlockPasswordState,
-      selector: (state) => state.isNextEnabled,
-      builder: (context, state) {
-        return RegistrationBackNextNavigation(
-          isNextEnabled: state,
-          onNextTap: onNextTap,
-          onBackTap: onBackTap,
-        );
-      },
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 24),
+        const SizedBox(height: 12),
+        Expanded(
+          child: _BlocUnlockPasswordForm(
+            passwordController: _passwordController,
+            confirmPasswordController: _confirmPasswordController,
+            onSubmitted: (_) async => _createKeychain(),
+          ),
+        ),
+        const SizedBox(height: 22),
+        _BlocNavigation(
+          onNextTap: _createKeychain,
+          onBackTap: _clearPasswordAndGoBack,
+        ),
+      ],
     );
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    final unlockPasswordState = RegistrationCubit.of(context)
+        .state
+        .recoverStateData
+        .unlockPasswordState;
+
+    final password = unlockPasswordState.password.value;
+    final confirmPassword = unlockPasswordState.confirmPassword.value;
+
+    final passwordValue = TextEditingValueExt.collapsedAtEndOf(password);
+    final confirmPasswordValue =
+        TextEditingValueExt.collapsedAtEndOf(confirmPassword);
+
+    _passwordController = TextEditingController.fromValue(passwordValue)
+      ..addListener(_onPasswordChanged);
+
+    _confirmPasswordController =
+        TextEditingController.fromValue(confirmPasswordValue)
+          ..addListener(_onConfirmPasswordChanged);
+  }
+
+  void _clearPasswordAndGoBack() {
+    final registration = RegistrationCubit.of(context);
+
+    registration.recover
+      ..setPassword('')
+      ..setConfirmPassword('');
+
+    registration.previousStep();
+  }
+
+  Future<void> _createKeychain() async {
+    final cubit = RegistrationCubit.of(context);
+
+    final success = await cubit.recover.setupKeychain();
+
+    if (success) {
+      cubit.nextStep();
+    }
+  }
+
+  void _onConfirmPasswordChanged() {
+    final confirmPassword = _confirmPasswordController.text;
+
+    RegistrationCubit.of(context).recover.setConfirmPassword(confirmPassword);
+  }
+
+  void _onPasswordChanged() {
+    final password = _passwordController.text;
+
+    RegistrationCubit.of(context).recover.setPassword(password);
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
@@ -4,6 +4,7 @@ import 'package:catalyst_voices/pages/registration/widgets/unlock_password_form.
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class UnlockPasswordPanel extends StatefulWidget {
   const UnlockPasswordPanel({super.key});
@@ -93,7 +94,19 @@ class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
           child: _BlocUnlockPasswordForm(
             passwordController: _passwordController,
             confirmPasswordController: _confirmPasswordController,
-            onSubmitted: (_) async => _createKeychain(),
+            onSubmitted: (_) async {
+              final isNextEnabled = context
+                  .read<RegistrationCubit>()
+                  .state
+                  .recoverStateData
+                  .unlockPasswordState
+                  .isNextEnabled;
+              if (isNextEnabled) {
+                return _createKeychain();
+              } else {
+                return;
+              }
+            },
           ),
         ),
         const SizedBox(height: 22),

--- a/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
@@ -103,8 +103,6 @@ class _UnlockPasswordPanelState extends State<UnlockPasswordPanel> {
                   .isNextEnabled;
               if (isNextEnabled) {
                 return _createKeychain();
-              } else {
-                return;
               }
             },
           ),

--- a/catalyst_voices/apps/voices/lib/pages/registration/widgets/unlock_password_form.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/widgets/unlock_password_form.dart
@@ -11,7 +11,6 @@ class UnlockPasswordForm extends StatelessWidget {
   final bool showPasswordStrength;
   final ValueChanged<String>? onSubmitted;
 
-
   const UnlockPasswordForm({
     super.key,
     required this.passwordController,

--- a/catalyst_voices/apps/voices/lib/pages/registration/widgets/unlock_password_form.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/widgets/unlock_password_form.dart
@@ -9,6 +9,8 @@ class UnlockPasswordForm extends StatelessWidget {
   final bool showError;
   final PasswordStrength passwordStrength;
   final bool showPasswordStrength;
+  final ValueChanged<String>? onSubmitted;
+
 
   const UnlockPasswordForm({
     super.key,
@@ -17,6 +19,7 @@ class UnlockPasswordForm extends StatelessWidget {
     this.showError = false,
     this.passwordStrength = PasswordStrength.weak,
     this.showPasswordStrength = false,
+    this.onSubmitted,
   });
 
   @override
@@ -33,6 +36,7 @@ class UnlockPasswordForm extends StatelessWidget {
           controller: confirmPasswordController,
           showError: showError,
           minimumLength: PasswordStrength.minimumLength,
+          onSubmitted: onSubmitted,
         ),
         const Spacer(),
         const SizedBox(height: 22),
@@ -69,11 +73,13 @@ class _ConfirmUnlockPasswordTextField extends StatelessWidget {
   final TextEditingController controller;
   final bool showError;
   final int minimumLength;
+  final ValueChanged<String>? onSubmitted;
 
   const _ConfirmUnlockPasswordTextField({
     required this.controller,
     this.showError = false,
     required this.minimumLength,
+    this.onSubmitted,
   });
 
   @override
@@ -86,6 +92,7 @@ class _ConfirmUnlockPasswordTextField extends StatelessWidget {
         helperText: context.l10n.xCharactersMinimum(minimumLength),
         errorText: showError ? context.l10n.passwordDoNotMatch : null,
       ),
+      onSubmitted: onSubmitted,
     );
   }
 }


### PR DESCRIPTION
# Description

Adding onSubmitted method in confirm passowrd to trigger next step in registration process

## Related Issue(s)

Closes #2204

## Description of Changes

N/A

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
