### PR TITLE
fix(cat-voices): proper cancel workflow for update keychain

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/registration/upload_seed_phrase_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/upload_seed_phrase_dialog.dart
@@ -7,7 +7,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 class UploadSeedPhraseDialog {
-  static Future<List<SeedPhraseWord>> show(BuildContext context) async {
+  static Future<List<SeedPhraseWord>?> show(BuildContext context) async {
     final file = await VoicesUploadFileDialog.show(
       context,
       routeSettings: const RouteSettings(name: '/upload-seed-phrase'),
@@ -17,17 +17,17 @@ class UploadSeedPhraseDialog {
       allowedExtensions: ['txt'],
     );
 
-    final bytes = file?.bytes;
-    if (bytes != null) {
-      final decodedText = utf8.decode(bytes);
-      final words = decodedText
-          .split(' ')
-          .mapIndexed((i, e) => SeedPhraseWord(e, nr: i + 1))
-          .toList();
-
-      return words;
-    } else {
-      return [];
+    if (file == null) {
+      return null;
     }
+
+    final bytes = file.bytes;
+    final decodedText = utf8.decode(bytes);
+    final words = decodedText
+        .split(' ')
+        .mapIndexed((i, e) => SeedPhraseWord(e, nr: i + 1))
+        .toList();
+
+    return words;
   }
 }


### PR DESCRIPTION
# Description

This pr make proper workflow for close button in upload keychain dialog (earlier when user cancel, then invalid keychain dialog happen when user just wanted to stop the action) 

## Related Issue(s)

Closes #2220

## Description of Changes

N/A

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
