### PR TITLE
chore(cat-voices): update go_router to 14.8.0 in melos

### DIFF
--- a/catalyst_voices/apps/voices/pubspec.yaml
+++ b/catalyst_voices/apps/voices/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   formz: ^0.7.0
-  go_router: ^14.0.2
+  go_router: ^14.8.0
   google_fonts: ^6.2.1
   intl: ^0.19.0
   lottie: ^3.3.1

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -126,6 +126,7 @@ command:
       flutter_rust_bridge: 2.5.1
       flutter_secure_storage: ^9.2.2
       formz: ^0.7.0
+      go_router: ^14.8.0
       intl: ^0.19.0
       logging: ^1.3.0
       lottie: ^3.3.1

--- a/catalyst_voices/utilities/poc_local_storage/pubspec.yaml
+++ b/catalyst_voices/utilities/poc_local_storage/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter_secure_storage: ^9.2.2
   flutter_web_plugins:
     sdk: flutter
-  go_router: ^14.2.3
+  go_router: ^14.8.0
   pointycastle: ^3.9.1
 
 dev_dependencies:


### PR DESCRIPTION
# Description

We inspirance a little problem among different version of go_router so to resolve it we update go_router for 14.0.2 to 14.8.0.

## Related Issue(s)

N/A


## Description of Changes

- adding go_router to melos.yaml to make sure every pubspec in out repo have the same version

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
