### PR TITLE
chore(cat-voices): make dropdown not editable

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/dropdown/voices_dropdown.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/dropdown/voices_dropdown.dart
@@ -88,6 +88,7 @@ class SingleSelectDropdown<T> extends VoicesFormField<T> {
             return ConstrainedBox(
               constraints: const BoxConstraints(),
               child: DropdownMenu(
+                requestFocusOnTap: false,
                 controller: state._controller,
                 focusNode: focusNode,
                 expandedInsets: EdgeInsets.zero,
@@ -112,7 +113,6 @@ class SingleSelectDropdown<T> extends VoicesFormField<T> {
                   ),
                   focusColor: Colors.tealAccent,
                 ),
-
                 errorText: field.errorText,
                 // using visibility so that the widget reserves
                 // the space for the icon, otherwise when widget changes


### PR DESCRIPTION
# Description

This PR makes dropdown menu in the proposal builder not editable

## Related Issue(s)

Closes #2221 

## Description of Changes

setting `requestFocusOnTap` to `false`

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
