### PR TITLE
fix(cat-voices): Splash screen should be above mobile restriction widget

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -75,8 +75,12 @@ final class _AppContent extends StatelessWidget {
         return AppActiveStateListener(
           child: GlobalPrecacheImages(
             child: GlobalSessionListener(
-              child: AppMobileAccessRestriction(
-                child: AppSplashScreenManager(
+              // IMPORTANT: AppSplashScreenManager must be placed above all
+              // widgets that render visible UI elements. Any widget that
+              // displays content should be a descendant of
+              //AppSplashScreenManager to ensure proper splash screen behavior.
+              child: AppSplashScreenManager(
+                child: AppMobileAccessRestriction(
                   child: child ?? const SizedBox.shrink(),
                 ),
               ),

--- a/catalyst_voices/apps/voices/lib/app/view/app_mobile_access_restriction.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_mobile_access_restriction.dart
@@ -100,6 +100,7 @@ class _Background extends StatelessWidget {
       painter: BubblePainter(
         bubbles: _buildBubbles(),
         shapes: _buildShapes(),
+        backgroundColor: const Color(0xFF9BDDF7),
       ),
       size: Size.infinite,
     );


### PR DESCRIPTION
# Description

This PR changes the order of rendering the widget to make sure that the mobile restriction widget is render properly.

## Related Issue(s)

N/A

## Description of Changes

- change order of the widgets

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
