### PR TITLE
fix(cat-voices): Lock analyzer version to prevent migration issues

### DIFF
--- a/catalyst_voices/apps/voices/pubspec.yaml
+++ b/catalyst_voices/apps/voices/pubspec.yaml
@@ -89,9 +89,6 @@ dependencies:
   win32: ^5.5.4
 
 dev_dependencies:
-  # TODO(dtscalac): locked version until the migration is possible:
-  # https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
-  # Currently many of the packages have not been migrated yet therefore we cannot use newer analyzer in our project.
   analyzer: 7.3.0
   build_runner: ^2.4.12
   build_verify: ^3.1.0

--- a/catalyst_voices/apps/voices/pubspec.yaml
+++ b/catalyst_voices/apps/voices/pubspec.yaml
@@ -89,6 +89,10 @@ dependencies:
   win32: ^5.5.4
 
 dev_dependencies:
+  # TODO(dtscalac): locked version until the migration is possible:
+  # https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
+  # Currently many of the packages have not been migrated yet therefore we cannot use newer analyzer in our project.
+  analyzer: 7.3.0
   build_runner: ^2.4.12
   build_verify: ^3.1.0
   catalyst_analysis: ^3.0.0

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -161,6 +161,10 @@ command:
       web: ^1.1.0
       webdriver: ^3.0.3
     dev_dependencies:
+      # TODO(dtscalac): locked version until the migration is possible:
+      # https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
+      # Currently many of the packages have not been migrated yet therefore we cannot use newer analyzer in our project.
+      analyzer: 7.3.0
       test: ^1.24.9
       build_runner: ^2.4.12
       chopper_generator: ^8.0.4

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -164,6 +164,7 @@ command:
       # TODO(dtscalac): locked version until the migration is possible:
       # https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md
       # Currently many of the packages have not been migrated yet therefore we cannot use newer analyzer in our project.
+      # After the packages are migrated we can remove the direct dependency on analyzer and let it be a transitive dependency.
       analyzer: 7.3.0
       test: ^1.24.9
       build_runner: ^2.4.12

--- a/catalyst_voices/packages/internal/catalyst_voices_assets/example/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_assets/example/pubspec.yaml
@@ -15,3 +15,5 @@ dependencies:
 
 flutter:
   uses-material-design: true
+dev_dependencies:
+  analyzer: 7.3.0

--- a/catalyst_voices/packages/internal/catalyst_voices_assets/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_assets/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   lottie: ^3.3.1
 
 dev_dependencies:
+  analyzer: 7.3.0
   build_runner: ^2.4.12
   catalyst_analysis: ^3.0.0
   flutter_gen_runner: ^5.10.0

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   bloc_test: ^9.1.4
   catalyst_analysis: ^3.0.0
   flutter_test:

--- a/catalyst_voices/packages/internal/catalyst_voices_brands/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_brands/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   google_fonts: ^6.2.1
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   catalyst_voices_blocs:
     path: ../catalyst_voices_blocs

--- a/catalyst_voices/packages/internal/catalyst_voices_driver/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_driver/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   webdriver: ^3.0.3
 
 dev_dependencies:
+  analyzer: 7.3.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
-  analyzer: 7.3.0

--- a/catalyst_voices/packages/internal/catalyst_voices_driver/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_driver/pubspec.yaml
@@ -19,3 +19,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  analyzer: 7.3.0

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   intl: ^0.19.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/internal/catalyst_voices_models/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   build_runner: ^2.4.12
   catalyst_analysis: ^3.0.0
   flutter_test:

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
-  analyzer: 7.3.0
   build_runner: ^2.4.12
   catalyst_analysis: ^3.0.0
   chopper_generator: ^8.0.4

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   build_runner: ^2.4.12
   catalyst_analysis: ^3.0.0
   chopper_generator: ^8.0.4

--- a/catalyst_voices/packages/internal/catalyst_voices_services/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   webdriver: ^3.0.3
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   mocktail: ^1.0.1
   shared_preferences_platform_interface: ^2.4.1

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   web: ^1.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/pubspec.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_analysis/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/example/pubspec.yaml
@@ -9,3 +9,4 @@ environment:
 dev_dependencies:
   catalyst_analysis:
     path: ../
+  analyzer: 7.3.0

--- a/catalyst_voices/packages/libs/catalyst_analysis/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/example/pubspec.yaml
@@ -7,6 +7,6 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis:
     path: ../
-  analyzer: 7.3.0

--- a/catalyst_voices/packages/libs/catalyst_analysis/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/pubspec.yaml
@@ -7,5 +7,6 @@ topics: [lints, analyzer, analysis]
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
+  
 dev_dependencies:
   analyzer: 7.3.0

--- a/catalyst_voices/packages/libs/catalyst_analysis/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/pubspec.yaml
@@ -7,3 +7,5 @@ topics: [lints, analyzer, analysis]
 
 environment:
   sdk: ">=3.5.0 <4.0.0"
+dev_dependencies:
+  analyzer: 7.3.0

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
@@ -31,8 +31,8 @@ dependencies:
   webdriver: ^3.0.3
 
 dev_dependencies:
-  catalyst_analysis: ^3.0.0
   analyzer: 7.3.0
+  catalyst_analysis: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
 
 dev_dependencies:
   catalyst_analysis: ^3.0.0
+  analyzer: 7.3.0
 
 flutter:
   uses-material-design: true

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_platform_interface/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   plugin_platform_interface: ^2.1.7
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano_web/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   web: ^1.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   build_runner: ^2.4.12
   catalyst_analysis: ^3.0.0
   flutter_test:

--- a/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression_platform_interface/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression_platform_interface/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   plugin_platform_interface: ^2.1.7
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression_web/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_compression/catalyst_compression_web/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   web: ^1.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_cose/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_cose/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   uuid_plus: ^0.1.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/cargokit/build_tool/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/cargokit/build_tool/pubspec.yaml
@@ -29,5 +29,6 @@ dependencies:
   toml: 0.14.0
 
 dev_dependencies:
+  analyzer: 7.3.0
   lints: ^2.1.0
   test: ^1.24.9

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/example/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   flutter_test:
     sdk: flutter

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   plugin_platform_interface: ^2.1.7
 
 dev_dependencies:
+  analyzer: 7.3.0
   catalyst_analysis: ^3.0.0
   ffi: ^2.1.0
   ffigen: ^11.0.0

--- a/catalyst_voices/utilities/poc_local_storage/pubspec.yaml
+++ b/catalyst_voices/utilities/poc_local_storage/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
 
 dev_dependencies:
   catalyst_analysis: ^3.0.0
+  analyzer: 7.3.0
 
 dependency_overrides:
   flutter_secure_storage_web: ^2.0.0-beta.1

--- a/catalyst_voices/utilities/poc_local_storage/pubspec.yaml
+++ b/catalyst_voices/utilities/poc_local_storage/pubspec.yaml
@@ -20,8 +20,8 @@ dependencies:
   pointycastle: ^3.9.1
 
 dev_dependencies:
-  catalyst_analysis: ^3.0.0
   analyzer: 7.3.0
+  catalyst_analysis: ^3.0.0
 
 dependency_overrides:
   flutter_secure_storage_web: ^2.0.0-beta.1

--- a/catalyst_voices/utilities/remote_widgets/example/pubspec.yaml
+++ b/catalyst_voices/utilities/remote_widgets/example/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   rfw: ^1.0.26
 
 dev_dependencies:
-  catalyst_analysis: ^3.0.0
   analyzer: 7.3.0
+  catalyst_analysis: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/catalyst_voices/utilities/remote_widgets/example/pubspec.yaml
+++ b/catalyst_voices/utilities/remote_widgets/example/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
 
 dev_dependencies:
   catalyst_analysis: ^3.0.0
+  analyzer: 7.3.0
 
 flutter:
   uses-material-design: true

--- a/catalyst_voices/utilities/remote_widgets/pubspec.yaml
+++ b/catalyst_voices/utilities/remote_widgets/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 
 dev_dependencies:
   catalyst_analysis: ^3.0.0
+  analyzer: 7.3.0
 
 flutter:
   uses-material-design: true

--- a/catalyst_voices/utilities/remote_widgets/pubspec.yaml
+++ b/catalyst_voices/utilities/remote_widgets/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
   rfw: ^1.0.26
 
 dev_dependencies:
-  catalyst_analysis: ^3.0.0
   analyzer: 7.3.0
+  catalyst_analysis: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/catalyst_voices/utilities/uikit_example/pubspec.yaml
+++ b/catalyst_voices/utilities/uikit_example/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
       ref: 532172254c3cee957bbdbb08be922f2c870b7fff
 
 dev_dependencies:
+  analyzer: 7.3.0
   build_runner: ^2.4.12
   catalyst_analysis: ^3.0.0
   flutter_gen_runner: ^5.10.0


### PR DESCRIPTION
# Description

[The latest (7.4.0) analyzer](https://pub.dev/packages/analyzer/changelog) release introduced breaking changes that require manual migration. Most of the packages we're depending on are not yet migrated therefore our project is not compatible with the latest analyzer version.

Migration guide: https://github.com/dart-lang/sdk/blob/main/pkg/analyzer/doc/element_model_migration_guide.md

Pinning the version to the one before which worked stable until the packages we depend on get migrated.

## Error logs

When trying to build the project on the newest analyzer version you might face the following errors:

```sd
./catalyst_voices+code-generator *failed* | [INFO] Precompiling build script......
./catalyst_voices+code-generator *failed* | [WARNING] /root/.pub-cache/hosted/pub.dev/json_serializable-6.9.4/lib/src/decode_helper.dart:65:23: Error: The getter 'augmented' isn't defined for the class 'ClassElement'.
./catalyst_voices+code-generator *failed* |  - 'ClassElement' is from 'package:analyzer/dart/element/element.dart' ('/root/.pub-cache/hosted/pub.dev/analyzer-7.4.0/lib/dart/element/element.dart').
./catalyst_voices+code-generator *failed* | Try correcting the name to the name of an existing getter, or defining a getter or field named 'augmented'.
./catalyst_voices+code-generator *failed* |               element.augmented
./catalyst_voices+code-generator *failed* |                       ^^^^^^^^^
./catalyst_voices+code-generator *failed* | /root/.pub-cache/hosted/pub.dev/json_serializable-6.9.4/lib/src/field_helpers.dart:84:52: Error: The argument type 'ClassElement' can't be assigned to the parameter type 'InterfaceElementImpl'.
./catalyst_voices+code-generator *failed* |  - 'ClassElement' is from 'package:analyzer/dart/element/element.dart' ('/root/.pub-cache/hosted/pub.dev/analyzer-7.4.0/lib/dart/element/element.dart').
./catalyst_voices+code-generator *failed* |  - 'InterfaceElementImpl' is from 'package:analyzer/src/dart/element/element.dart' ('/root/.pub-cache/hosted/pub.dev/analyzer-7.4.0/lib/src/dart/element/element.dart').
./catalyst_voices+code-generator *failed* |   for (final v in manager.getInheritedConcreteMap2(element).values) {
./catalyst_voices+code-generator *failed* |                                                    ^
./catalyst_voices+code-generator *failed* | /root/.pub-cache/hosted/pub.dev/json_serializable-6.9.4/lib/src/field_helpers.dart:90:43: Error: The getter 'isGetter' isn't defined for the class 'ExecutableElementOrMember'.
./catalyst_voices+code-generator *failed* |  - 'ExecutableElementOrMember' is from 'package:analyzer/src/dart/element/element.dart' ('/root/.pub-cache/hosted/pub.dev/analyzer-7.4.0/lib/src/dart/element/element.dart').
./catalyst_voices+code-generator *failed* | Try correcting the name to the name of an existing getter, or defining a getter or field named 'isGetter'.
./catalyst_voices+code-generator *failed* |     if (v is PropertyAccessorElement && v.isGetter) {
./catalyst_voices+code-generator *failed* |                                           ^^^^^^^^
./catalyst_voices+code-generator *failed* | /root/.pub-cache/hosted/pub.dev/json_serializable-6.9.4/lib/src/field_helpers.dart:91:16: Error: The getter 'variable2' isn't defined for the class 'ExecutableElementOrMember'.
./catalyst_voices+code-generator *failed* |  - 'ExecutableElementOrMember' is from 'package:analyzer/src/dart/element/element.dart' ('/root/.pub-cache/hosted/pub.dev/analyzer-7.4.0/lib/src/dart/element/element.dart').
./catalyst_voices+code-generator *failed* | Try correcting the name to the name of an existing getter, or defining a getter or field named 'variable2'.
./catalyst_voices+code-generator *failed* |       assert(v.variable2 is FieldElement);
./catalyst_voices+code-generator *failed* |                ^^^^^^^^^
./catalyst_voices+code-generator *failed* | /root/.pub-cache/hosted/pub.dev/json_serializable-6.9.4/lib/src/field_helpers.dart:92:26: Error: The getter 'variable2' isn't defined for the class 'ExecutableElementOrMember'.
./catalyst_voices+code-generator *failed* |  - 'ExecutableElementOrMember' is from 'package:analyzer/src/dart/element/element.dart' ('/root/.pub-cache/hosted/pub.dev/analyzer-7.4.0/lib/src/dart/element/element.dart').
./catalyst_voices+code-generator *failed* | Try correcting the name to the name of an existing getter, or defining a getter or field named 'variable2'.
./catalyst_voices+code-generator *failed* |       final variable = v.variable2 as FieldElement;
```

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
