### PR TITLE
fix(cat-voices): Hide close button on recovery success screen

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/registration/registration_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/registration_dialog.dart
@@ -58,7 +58,15 @@ class _RegistrationDialogState extends State<RegistrationDialog>
           );
         },
         child: BlocSelector<RegistrationCubit, RegistrationState, bool>(
-          selector: (state) => state.step is! AccountCompletedStep,
+          selector: (state) {
+            final isAccountCompleted = state.step is AccountCompletedStep;
+            final isRecovered = state.step ==
+                const RecoverWithSeedPhraseStep(
+                  stage: RecoverWithSeedPhraseStage.success,
+                );
+
+            return !isAccountCompleted && !isRecovered;
+          },
           builder: (context, showCloseButton) {
             return VoicesTwoPaneDialog(
               key: const Key('RegistrationDialog'),


### PR DESCRIPTION
# Description

Hides dialog close button on recovery success screen.

## Related Issue(s)

Closes #2224

## Screenshots

![Screenshot 2025-04-16 at 21 26 22](https://github.com/user-attachments/assets/551b6407-73cc-456c-8919-b6f1e3ecf1a7)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
