### PR TITLE
feat(cat-gateway): docker-compose healthcheck for the `cat-gateway`

### DIFF
--- a/catalyst-gateway/tests/docker-compose.yml
+++ b/catalyst-gateway/tests/docker-compose.yml
@@ -35,6 +35,11 @@ services:
   cat-gateway-with-scylla:
     image: cat-gateway-with-scylla:latest
     container_name: cat-gateway-with-scylla
+    healthcheck:
+      test: "curl -s -i http://100.76.226.39:3030/api/v1/health/live | head -n 1 | grep 200"
+      interval: 10s
+      timeout: 5s
+      retries: 10
     environment:
       - EVENT_DB_URL=postgres://catalyst-event-dev:CHANGE_ME@event-db/CatalystEventDev
       - CASSANDRA_PERSISTENT_URL=localhost:9042


### PR DESCRIPTION
# Description

- Added `healthcheck` section for the docker-compose `cat-gateway` setup
- Removed redundant and unnecessary `sleep` inside our integration tests for the cat-gateway