### PR TITLE
fix(cat-voices): align COSE_SIGN ToBeSigned creation with server

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/signed_document/signed_document_manager_impl.dart
@@ -89,7 +89,7 @@ final class _CatalystSigner implements CatalystCoseSigner {
   );
 
   @override
-  StringOrInt? get alg => const IntValue(CoseValues.eddsaAlg);
+  StringOrInt? get alg => null;
 
   @override
   Future<Uint8List?> get kid async {

--- a/catalyst_voices/packages/libs/catalyst_cose/lib/src/cose_sign.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/lib/src/cose_sign.dart
@@ -179,13 +179,7 @@ final class CoseSign extends Equatable {
       payload: CborBytes(payload),
     );
 
-    return Uint8List.fromList(
-      cbor.encode(
-        CborBytes(
-          cbor.encode(sigStructure),
-        ),
-      ),
-    );
+    return Uint8List.fromList(cbor.encode(sigStructure));
   }
 
   static CborList _createCoseSignSigStructure({


### PR DESCRIPTION
# Description

Aligns the `ToBeSigned` object creation with the server according to [RFC8152](https://datatracker.ietf.org/doc/html/rfc8152)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
