### PR TITLE
fix(cat-gateway): lock local-ip-address to `0.6.3`

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -49,7 +49,7 @@ tokio-postgres = { version = "0.7.12", features = [
 ] }
 tokio = { version = "1.41.0", features = ["rt", "macros", "rt-multi-thread"] }
 dotenvy = "0.15.7"
-local-ip-address = "0.6.3"
+local-ip-address = "=0.6.3"
 gethostname = "0.5.0"
 hex = "0.4.3"
 handlebars = "6.2.0"


### PR DESCRIPTION
# Description

[`local-ip-address`](https://crates.io/crates/local-ip-address) just release a new version `0.6.4` which has some breaking changes. Lock the version to `0.6.3`