### PR TITLE
fix(cat-voices): Two lines helper text

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
@@ -544,6 +544,7 @@ class VoicesTextFieldState extends VoicesFormFieldState<String> {
           ? textTheme.bodySmall
           : textTheme.bodySmall!.copyWith(color: colors.textOnPrimaryLevel1),
       hintText: widget.decoration?.hintText,
+      helperMaxLines: 2,
       hintStyle: _getHintStyle(
         textTheme,
         theme,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
@@ -248,6 +248,9 @@ class VoicesTextFieldDecoration {
   /// [InputDecoration.helperText].
   final String? helperText;
 
+  /// [InputDecoration.helperMaxLines]
+  final int? helperMaxLines;
+
   /// [InputDecoration.hintText].
   final String? hintText;
 
@@ -303,6 +306,7 @@ class VoicesTextFieldDecoration {
     this.labelText,
     this.helper,
     this.helperText,
+    this.helperMaxLines = 2,
     this.hintText,
     this.hintStyle,
     this.errorText,
@@ -544,7 +548,7 @@ class VoicesTextFieldState extends VoicesFormFieldState<String> {
           ? textTheme.bodySmall
           : textTheme.bodySmall!.copyWith(color: colors.textOnPrimaryLevel1),
       hintText: widget.decoration?.hintText,
-      helperMaxLines: 2,
+      helperMaxLines: widget.decoration?.helperMaxLines,
       hintStyle: _getHintStyle(
         textTheme,
         theme,


### PR DESCRIPTION
# Description

Makes helper text two lines by default.

## Description of Changes

Make helper text two lines so registration email helper text is visible.

## Screenshots

<img width="912" alt="Screenshot 2025-04-28 at 09 01 16" src="https://github.com/user-attachments/assets/6574c7d1-2bdb-40d3-b43f-f14f61d6b68b" />


