### PR TITLE
refactor(cat-voices): export flutter bloc

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/app.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices/dependency/dependencies.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final class App extends StatefulWidget {
   final RouterConfig<Object> routerConfig;

--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_localized_locales/flutter_localized_locales.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 

--- a/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_session_listener.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 /// Listens globally to a session and can show different

--- a/catalyst_voices/apps/voices/lib/common/error_handler.dart
+++ b/catalyst_voices/apps/voices/lib/common/error_handler.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices/widgets/snackbar/voices_snackbar_type.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// An interface of an abstract error handler.
 abstract interface class ErrorHandler {

--- a/catalyst_voices/apps/voices/lib/common/signal_handler.dart
+++ b/catalyst_voices/apps/voices/lib/common/signal_handler.dart
@@ -4,7 +4,6 @@ import 'dart:async';
 
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// An interface of an abstract signal handler.
 abstract interface class SignalHandler<Signal extends Object> {

--- a/catalyst_voices/apps/voices/lib/pages/account/account_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/account_page.dart
@@ -17,7 +17,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final class AccountPage extends StatefulWidget {
   const AccountPage({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/unlock_keychain_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/unlock_keychain_dialog.dart
@@ -12,7 +12,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// A dialog which allows to unlock the session (keychain).
 class UnlockKeychainDialog extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_action_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_action_tile.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountActionTile extends StatelessWidget {
   const AccountActionTile({

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_email_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_email_tile.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountEmailTile extends StatefulWidget {
   const AccountEmailTile({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_header_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_header_tile.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountHeaderTile extends StatelessWidget {
   const AccountHeaderTile({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_keychain_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_keychain_tile.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountKeychainTile extends StatefulWidget {
   const AccountKeychainTile({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_public_verification_status_chip.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_public_verification_status_chip.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountPublicVerificationStatusChip extends StatelessWidget {
   const AccountPublicVerificationStatusChip({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_re_send_verification_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_re_send_verification_button.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountReSendVerificationButton extends StatelessWidget {
   const AccountReSendVerificationButton({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_roles_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_roles_tile.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountRolesTile extends StatelessWidget {
   const AccountRolesTile({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_status_banner.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_status_banner.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountStatusBanner extends StatelessWidget {
   const AccountStatusBanner({

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_username_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_username_tile.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountUsernameTile extends StatefulWidget {
   const AccountUsernameTile({

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -10,7 +10,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// A draggable [CampaignAdminToolsDialog],
 /// should be used as a child of a [Stack].

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_events.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_events.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// The "events" tab of the [CampaignAdminToolsDialog].
 class CampaignAdminToolsEventsTab extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_views.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_views.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// The "views" tab of the [CampaignAdminToolsDialog].
 class CampaignAdminToolsViewsTab extends StatelessWidget {

--- a/catalyst_voices/apps/voices/lib/pages/campaign/details/campaign_details_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/details/campaign_details_dialog.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices/pages/campaign/details/widgets/campaign_sections
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CampaignDetailsDialog extends StatefulWidget {
   final String id;

--- a/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_header.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/widgets/modals/details/voices_details_dialog_hea
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CampaignHeader extends StatelessWidget {
   const CampaignHeader({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_management.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_management.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CampaignManagement extends StatefulWidget {
   const CampaignManagement({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_management_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_management_dialog.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CampaignManagementDialog extends StatefulWidget {
   final CampaignPublish? initialValue;

--- a/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_sections_list_view.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/details/widgets/campaign_sections_list_view.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices/pages/campaign/details/widgets/campaign_details_
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CampaignSectionsListView extends StatelessWidget {
   const CampaignSectionsListView({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/campaign/stage/error_proposal_submission_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/stage/error_proposal_submission_page.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices/widgets/indicators/voices_error_indicator.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ErrorProposalSubmissionPage extends StatelessWidget {
   const ErrorProposalSubmissionPage({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/campaign/stage/pre_proposal_submission_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/stage/pre_proposal_submission_page.dart
@@ -11,7 +11,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PreProposalSubmissionPage extends StatelessWidget {
   final DateTime? startDate;

--- a/catalyst_voices/apps/voices/lib/pages/category/category_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/category/category_page.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 typedef _StateData = ({bool show, CampaignCategoryDetailsViewModel data});

--- a/catalyst_voices/apps/voices/lib/pages/category/change_category_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/category/change_category_button.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart'
     hide PopupMenuItem;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ChangeCategoryButton extends StatefulWidget {
   const ChangeCategoryButton({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/discovery/discovery_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/discovery_page.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices/pages/discovery/state_selectors/current_campaign
 import 'package:catalyst_voices/pages/discovery/state_selectors/most_recent_proposals_selector.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class DiscoveryPage extends StatefulWidget {
   const DiscoveryPage({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/campaign_hero.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/campaign_hero.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CampaignHeroSection extends StatelessWidget {
   const CampaignHeroSection({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/most_recent_proposals.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/most_recent_proposals.dart
@@ -11,7 +11,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 class MostRecentProposals extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class StayInvolved extends StatelessWidget {
   const StayInvolved({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/campaign_categories_state_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/campaign_categories_state_selector.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef _ListItems = List<CampaignCategoryDetailsViewModel>;
 

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/current_campaign_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/current_campaign_selector.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CurrentCampaignSelector extends StatelessWidget {
   const CurrentCampaignSelector({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/most_recent_proposals_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/most_recent_proposals_selector.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef _ListItems = List<PendingProposal>;
 

--- a/catalyst_voices/apps/voices/lib/pages/discovery/toggle_state_text.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/toggle_state_text.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 // Note. This widget will be removed so its not localized
 class ToggleStateText extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/discovery_overview.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/discovery_overview.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 class DiscoveryOverview extends StatelessWidget {

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/user_proposal_selectors.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 // As widget across two overviews are almost similar and are not reusable
 // anywhere else it useful to use as part

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/workspace_overview.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/workspace_overview.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class WorkspaceOverview extends StatelessWidget {
   const WorkspaceOverview({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/spaces_overview_list_view.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/spaces_overview_list_view.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SpacesListView extends StatefulWidget {
   const SpacesListView({

--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_content.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_content.dart
@@ -12,7 +12,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ProposalContent extends StatelessWidget {

--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_error.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_error.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalError extends StatelessWidget {
   const ProposalError({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_loading.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_loading.dart
@@ -1,7 +1,6 @@
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalLoading extends StatelessWidget {
   const ProposalLoading({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
@@ -18,7 +18,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ProposalPage extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/proposal/snack_bar/viewing_older_version_snack_bar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/snack_bar/viewing_older_version_snack_bar.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final class ViewingOlderVersionSnackBar extends VoicesSnackBar {
   factory ViewingOlderVersionSnackBar(BuildContext context) {

--- a/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_comment_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_comment_tile.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/widgets/comment/proposal_comment_with_replies_ca
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalCommentTile extends StatelessWidget {
   final CommentWithReplies comment;

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_favorite_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_favorite_button.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:catalyst_voices/widgets/buttons/voices_buttons.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalFavoriteButton extends StatelessWidget {
   const ProposalFavoriteButton({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_header.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalHeader extends StatelessWidget {
   const ProposalHeader({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_share_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_share_button.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalShareButton extends StatelessWidget {
   const ProposalShareButton({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_version.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_version.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalVersion extends StatelessWidget {
   final bool readOnly;

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/appbar/proposal_builder_status_action.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/appbar/proposal_builder_status_action.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart'
     show DocumentVersion, ProposalMenuItemAction;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderStatusAction extends StatelessWidget {
   const ProposalBuilderStatusAction({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/appbar/widget/proposal_builder_menu_item.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/appbar/widget/proposal_builder_menu_item.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderMenuItem extends StatelessWidget {
   final ProposalMenuItemAction item;

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_changing.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_changing.dart
@@ -1,7 +1,6 @@
 import 'package:catalyst_voices/widgets/indicators/voices_loading_overlay.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderChangingOverlay extends StatelessWidget {
   final Widget child;

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_error.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_error.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderErrorSelector extends StatelessWidget {
   final VoidCallback onRetryTap;

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_guidance.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_guidance.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderGuidanceSelector extends StatelessWidget {
   const ProposalBuilderGuidanceSelector({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_loading.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_loading.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderLoadingSelector extends StatelessWidget {
   const ProposalBuilderLoadingSelector({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_navigation_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_navigation_panel.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderNavigationPanel extends StatelessWidget {
   const ProposalBuilderNavigationPanel({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_page.dart
@@ -28,7 +28,6 @@ import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class ProposalBuilderPage extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_segments.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_segments.dart
@@ -10,7 +10,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 part 'proposal_builder_document_widgets.dart';

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_setup_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_setup_panel.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderSetupPanel extends StatefulWidget {
   const ProposalBuilderSetupPanel({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/tiles/proposal_builder_comment_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/tiles/proposal_builder_comment_tile.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/widgets/comment/proposal_comment_with_replies_ca
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalBuilderCommentTile extends StatelessWidget {
   final CommentWithReplies comment;

--- a/catalyst_voices/apps/voices/lib/pages/proposals/proposals_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/proposals_page.dart
@@ -13,7 +13,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalsPage extends StatefulWidget {
   final SignedDocumentRef? categoryId;

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/category_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/category_selector.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CategorySelector extends StatelessWidget {
   const CategorySelector({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_campaign_details_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_campaign_details_button.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalsCampaignDetailsButton extends StatelessWidget {
   const ProposalsCampaignDetailsButton({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_pagination_empty_state.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_pagination_empty_state.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices/widgets/empty_state/empty_state.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalsPaginationEmptyState extends StatelessWidget {
   const ProposalsPaginationEmptyState({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_pagination_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_pagination_tile.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices/widgets/cards/proposal/proposal_card.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalsPaginationTile extends StatelessWidget {
   final ProposalViewModel proposal;

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_search.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_search.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalsSearch extends StatefulWidget {
   const ProposalsSearch({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_tabs.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_tabs.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalsTabs extends StatelessWidget {
   final TabController controller;

--- a/catalyst_voices/apps/voices/lib/pages/registration/account_completed/account_completed_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/account_completed/account_completed_panel.dart
@@ -10,7 +10,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AccountCompletedPanel extends StatelessWidget {
   const AccountCompletedPanel({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/create_keychain/stage/unlock_password_panel.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices/pages/registration/widgets/unlock_password_form.
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class UnlockPasswordPanel extends StatefulWidget {
   const UnlockPasswordPanel({

--- a/catalyst_voices/apps/voices/lib/pages/registration/get_started/get_started_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/get_started/get_started_panel.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class GetStartedPanel extends StatelessWidget {
   const GetStartedPanel({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/registration/no_wallet_found_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/no_wallet_found_dialog.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class NoWalletFoundDialog extends StatelessWidget {
   const NoWalletFoundDialog({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/recover/seed_phrase/unlock_password_panel.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices/pages/registration/widgets/unlock_password_form.
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class UnlockPasswordPanel extends StatefulWidget {
   const UnlockPasswordPanel({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/registration/registration_details_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/registration_details_panel.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices/pages/registration/wallet_link/wallet_link_panel
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class RegistrationDetailsPanel extends StatelessWidget {
   const RegistrationDetailsPanel({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/registration/registration_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/registration_dialog.dart
@@ -10,7 +10,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 // TODO(damian-molinski): refactor it to AccountSetupDialog.
 class RegistrationDialog extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/registration/registration_info_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/registration_info_panel.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class RegistrationInfoPanel extends StatelessWidget with LaunchUrlMixin {
   const RegistrationInfoPanel({

--- a/catalyst_voices/apps/voices/lib/pages/registration/wallet_link/stage/rbac_transaction_panel.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/wallet_link/stage/rbac_transaction_panel.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:result_type/result_type.dart';
 
 class RbacTransactionPanel extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_avatar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_avatar.dart
@@ -1,7 +1,6 @@
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionAccountAvatar extends StatelessWidget {
   final VoidCallback? onTap;

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_display_name.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_display_name.dart
@@ -1,7 +1,6 @@
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionAccountDisplayName extends StatelessWidget {
   const SessionAccountDisplayName({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_popup_catalyst_id.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_popup_catalyst_id.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionAccountPopupCatalystId extends StatelessWidget {
   const SessionAccountPopupCatalystId({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_popup_menu.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_popup_menu.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionAccountPopupMenu extends StatefulWidget {
   const SessionAccountPopupMenu({

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_lock_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_lock_button.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionLockButton extends StatelessWidget {
   const SessionLockButton({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_theme_menu_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_theme_menu_tile.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionThemeMenuTile extends StatelessWidget {
   const SessionThemeMenuTile({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_timezone_menu_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_timezone_menu_tile.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SessionTimezoneMenuTile extends StatelessWidget {
   const SessionTimezoneMenuTile({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/session_action_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/session_action_header.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Displays current session action and toggling to next when clicked.
 class SessionActionHeader extends StatelessWidget {

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/session_state_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/session_state_header.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Displays current session state.
 class SessionStateHeader extends StatelessWidget {

--- a/catalyst_voices/apps/voices/lib/pages/spaces/drawer/opportunities_drawer.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/drawer/opportunities_drawer.dart
@@ -13,7 +13,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class OpportunitiesDrawer extends StatelessWidget {
   const OpportunitiesDrawer({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/spaces_shell_page.dart
@@ -13,7 +13,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SpacesShellPage extends StatefulWidget {
   static final Map<Space, ShortcutActivator> _spacesShortcutsActivators = {

--- a/catalyst_voices/apps/voices/lib/pages/treasury/sections/treasury_campaign_stages_edit_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/treasury/sections/treasury_campaign_stages_edit_tile.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class TreasuryCampaignStagesEditTile extends StatelessWidget {
   final TreasurySection data;

--- a/catalyst_voices/apps/voices/lib/pages/treasury/sections/treasury_campaign_stages_view_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/treasury/sections/treasury_campaign_stages_view_tile.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class TreasuryCampaignStagesViewTile extends StatelessWidget {
   final TreasurySection data;

--- a/catalyst_voices/apps/voices/lib/pages/voting/voting_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/voting/voting_page.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _favoriteProposals = ValueNotifier<List<PendingProposal>>([]);
 

--- a/catalyst_voices/apps/voices/lib/pages/workspace/header/workspace_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/header/workspace_header.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart'
     show ProposalDocument, Space;
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'create_proposal_button.dart';
 part 'import_proposal_button.dart';

--- a/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_error.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_error.dart
@@ -3,7 +3,6 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class WorkspaceErrorSelector extends StatelessWidget {
   const WorkspaceErrorSelector({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_loading.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_loading.dart
@@ -1,7 +1,6 @@
 import 'package:catalyst_voices/widgets/indicators/voices_loading_overlay.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class WorkspaceLoadingSelector extends StatelessWidget {
   final Widget child;

--- a/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_page.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class WorkspacePage extends StatefulWidget {
   const WorkspacePage({super.key});

--- a/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_user_proposals.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/page/workspace_user_proposals.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices/pages/workspace/user_proposals/user_proposals.da
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef UserProposalsSelectorState = ({bool show, List<Proposal> proposals});
 

--- a/catalyst_voices/apps/voices/lib/pages/workspace/proposal_menu_action_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/proposal_menu_action_button.dart
@@ -15,7 +15,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart'
     hide PopupMenuItem;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalMenuActionButton extends StatefulWidget {
   final DocumentRef ref;

--- a/catalyst_voices/apps/voices/lib/routes/guards/proposal_submission_guard.dart
+++ b/catalyst_voices/apps/voices/lib/routes/guards/proposal_submission_guard.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices/routes/routing/campaign_stage_route.dart';
 import 'package:catalyst_voices/routes/routing/routing.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 final class ProposalSubmissionGuard implements RouteGuard {

--- a/catalyst_voices/apps/voices/lib/routes/guards/session_unlocked_guard.dart
+++ b/catalyst_voices/apps/voices/lib/routes/guards/session_unlocked_guard.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices/routes/guards/route_guard.dart';
 import 'package:catalyst_voices/routes/routing/routing.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 /// A guard which redirects to the discovery page

--- a/catalyst_voices/apps/voices/lib/routes/guards/user_access_guard.dart
+++ b/catalyst_voices/apps/voices/lib/routes/guards/user_access_guard.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices/routes/guards/route_guard.dart';
 import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 final class UserAccessGuard implements RouteGuard {

--- a/catalyst_voices/apps/voices/lib/routes/routing/campaign_stage_route.dart
+++ b/catalyst_voices/apps/voices/lib/routes/routing/campaign_stage_route.dart
@@ -8,7 +8,6 @@ import 'package:catalyst_voices/routes/routing/routes.dart';
 import 'package:catalyst_voices/routes/routing/transitions/fade_page_transition_mixin.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 part 'campaign_stage_route.g.dart';

--- a/catalyst_voices/apps/voices/lib/widgets/cards/proposal/pending_proposal_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/proposal/pending_proposal_card.dart
@@ -11,7 +11,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Displays a proposal in pending state on a card.
 class PendingProposalCard extends StatefulWidget {

--- a/catalyst_voices/apps/voices/lib/widgets/cards/proposal_iteration_history_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/proposal_iteration_history_card.dart
@@ -12,7 +12,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class ProposalIterationHistory extends StatefulWidget {
   final Proposal proposal;

--- a/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_builder.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_builder.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart'
     hide DocumentPropertyBuilder;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef OnSubmitProposalComment = Future<void> Function({
   required Document document,

--- a/catalyst_voices/apps/voices/lib/widgets/drawer/voices_drawer_space_chooser.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/drawer/voices_drawer_space_chooser.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef _AccessSpaces = ({
   List<Space> canAccessSpaces,

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
@@ -14,7 +14,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef _SelectedCategoryData = ({
   List<CampaignCategoryDetailsViewModel> categories,

--- a/catalyst_voices/apps/voices/lib/widgets/text/timezone_date_time_text.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text/timezone_date_time_text.dart
@@ -4,7 +4,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 typedef TimezoneDateTimeTextFormatter = String Function(
   BuildContext context,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
@@ -544,6 +544,7 @@ class VoicesTextFieldState extends VoicesFormFieldState<String> {
           ? textTheme.bodySmall
           : textTheme.bodySmall!.copyWith(color: colors.textOnPrimaryLevel1),
       hintText: widget.decoration?.hintText,
+      helperMaxLines: 2,
       hintStyle: _getHintStyle(
         textTheme,
         theme,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_text_field.dart
@@ -248,6 +248,9 @@ class VoicesTextFieldDecoration {
   /// [InputDecoration.helperText].
   final String? helperText;
 
+  /// [InputDecoration.helperMaxLines]
+  final int? helperMaxLines;
+
   /// [InputDecoration.hintText].
   final String? hintText;
 
@@ -303,6 +306,7 @@ class VoicesTextFieldDecoration {
     this.labelText,
     this.helper,
     this.helperText,
+    this.helperMaxLines = 2,
     this.hintText,
     this.hintStyle,
     this.errorText,
@@ -544,7 +548,7 @@ class VoicesTextFieldState extends VoicesFormFieldState<String> {
           ? textTheme.bodySmall
           : textTheme.bodySmall!.copyWith(color: colors.textOnPrimaryLevel1),
       hintText: widget.decoration?.hintText,
-      helperMaxLines: 2,
+      helperMaxLines: widget.decoration?.helperMaxLines,
       hintStyle: _getHintStyle(
         textTheme,
         theme,

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/catalyst_voices_blocs.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/catalyst_voices_blocs.dart
@@ -1,3 +1,5 @@
 library catalyst_voices_blocs;
 
+export 'package:flutter_bloc/flutter_bloc.dart';
+
 export 'src/catalyst_voices_blocs.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/account/account_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/account/account_cubit.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final class AccountCubit extends Cubit<AccountState>
     with

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/campaign/info/campaign_info_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/campaign/info/campaign_info_cubit.dart
@@ -5,7 +5,6 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 /// Gets the campaign info.
 final class CampaignInfoCubit extends Cubit<CampaignInfoState> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/category/category_detail_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/category/category_detail_cubit.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CategoryDetailCubit extends Cubit<CategoryDetailState> {
   final CampaignService _campaignService;

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
@@ -6,7 +6,6 @@ import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:equatable/equatable.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'discovery_state.dart';
 

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _logger = Logger('ProposalBloc');
 

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _logger = Logger('ProposalsCubit');
 

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/base_profile_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/base_profile_cubit.dart
@@ -2,7 +2,6 @@ import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 abstract interface class BaseProfileManager {
   void updateUsername(Username value);

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/keychain_creation_cubit.dart
@@ -9,7 +9,6 @@ import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _logger = Logger('KeychainCreationCubit');
 

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/recover_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/recover_cubit.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:result_type/result_type.dart';
 
 const _testWords = [

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:collection/collection.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:result_type/result_type.dart';
 
 final _logger = Logger('WalletLinkCubit');

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/registration_cubit.dart
@@ -11,7 +11,6 @@ import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:result_type/result_type.dart';
 
 final _logger = Logger('RegistrationCubit');

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_base_profile_selector.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_base_profile_selector.dart
@@ -1,5 +1,4 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BlocBaseProfileSelector<T>
     extends BlocSelector<RegistrationCubit, RegistrationState, T> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_recover_selector.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_recover_selector.dart
@@ -1,5 +1,4 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BlocRecoverSelector<T>
     extends BlocSelector<RegistrationCubit, RegistrationState, T> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_registration_selector.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_registration_selector.dart
@@ -1,5 +1,4 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BlocRegistrationSelector<T>
     extends BlocSelector<RegistrationCubit, RegistrationState, T> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_seed_phrase_selector.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_seed_phrase_selector.dart
@@ -1,5 +1,4 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BlocSeedPhraseSelector<T>
     extends BlocSelector<RegistrationCubit, RegistrationState, T> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_unlock_password_selector.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_unlock_password_selector.dart
@@ -1,5 +1,4 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BlocUnlockPasswordSelector<T>
     extends BlocSelector<RegistrationCubit, RegistrationState, T> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_wallet_link_selector.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/selectors/bloc_wallet_link_selector.dart
@@ -1,5 +1,4 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BlocWalletLinkSelector<T>
     extends BlocSelector<RegistrationCubit, RegistrationState, T> {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/session/session_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/session/session_cubit.dart
@@ -7,7 +7,6 @@ import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rxdart/rxdart.dart';
 
 bool _alwaysAllowRegistration = kDebugMode;


### PR DESCRIPTION
# Description

Make `blocs` package export `flutter_bloc` so it we don't have to import it by hand every time we want interact with blocs

## Description of Changes

`catalyst_voices_blocs` exports `flutter_bloc`

For reviewer:

added export line [here](https://github.com/input-output-hk/catalyst-voices/pull/2355/files#diff-fe0f64fd2b4578c2831b4927bd3798f320dcc1f8cb28f4205fd18dfec101b64e) the rest is result of calling

```bash
melos exec -- "dart fix --apply --code=unnecessary_import"
```

## Related PRs

#2354 must be merged first



