### PR TITLE
feat(cat-voices): cant edit when new local iteration is created

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/workspace/proposal_menu_action_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/proposal_menu_action_button.dart
@@ -8,6 +8,8 @@ import 'package:catalyst_voices/widgets/modals/proposals/forget_proposal_dialog.
 import 'package:catalyst_voices/widgets/modals/proposals/proposal_builder_delete_confirmation_dialog.dart';
 import 'package:catalyst_voices/widgets/modals/proposals/share_proposal_dialog.dart';
 import 'package:catalyst_voices/widgets/modals/proposals/unlock_edit_proposal.dart';
+import 'package:catalyst_voices/widgets/snackbar/voices_snackbar.dart';
+import 'package:catalyst_voices/widgets/snackbar/voices_snackbar_type.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
@@ -22,6 +24,7 @@ class ProposalMenuActionButton extends StatefulWidget {
   final ProposalPublish proposalPublish;
   final int version;
   final String title;
+  final bool hasNewerLocalIteration;
 
   const ProposalMenuActionButton({
     super.key,
@@ -29,6 +32,7 @@ class ProposalMenuActionButton extends StatefulWidget {
     required this.proposalPublish,
     required this.version,
     required this.title,
+    required this.hasNewerLocalIteration,
   });
 
   @override
@@ -134,6 +138,8 @@ class _ProposalMenuActionButtonState extends State<ProposalMenuActionButton> {
       if (edit && mounted) {
         context.read<WorkspaceBloc>().add(UnlockProposalEvent(widget.ref));
       }
+    } else if (widget.hasNewerLocalIteration) {
+      return _showLatestLocalProposalWarningSnackbar();
     } else if (mounted) {
       unawaited(
         ProposalBuilderRoute.fromRef(ref: widget.ref).push(context),
@@ -186,6 +192,18 @@ class _ProposalMenuActionButtonState extends State<ProposalMenuActionButton> {
   void _shareProposal() {
     final url = ProposalRoute.fromRef(ref: widget.ref).location;
     unawaited(ShareProposalDialog.show(context, url));
+  }
+
+  void _showLatestLocalProposalWarningSnackbar() {
+    VoicesSnackBar.hideCurrent(context);
+
+    VoicesSnackBar(
+      type: VoicesSnackBarType.warning,
+      behavior: SnackBarBehavior.floating,
+      title: context.l10n.cantEditThisProposal,
+      message: context.l10n.deleteLocalVersionIfWantToPublishThisVersion,
+      duration: const Duration(seconds: 6),
+    ).show(context);
   }
 
   void _showMenu() {

--- a/catalyst_voices/apps/voices/lib/widgets/cards/proposal/workspace_proposal_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/proposal/workspace_proposal_card.dart
@@ -99,6 +99,7 @@ class _Body extends StatelessWidget {
           proposalPublish: proposal.publish,
           title: proposal.title,
           version: proposal.versions.versionNumber(proposal.selfRef.version!),
+          hasNewerLocalIteration: proposal.hasNewerLocalIteration,
         ),
       ],
     );

--- a/catalyst_voices/apps/voices/lib/widgets/cards/proposal_iteration_history_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/proposal_iteration_history_card.dart
@@ -154,14 +154,6 @@ class _IterationVersionList extends StatelessWidget {
 class _ProposalIterationHistoryState extends State<ProposalIterationHistory> {
   bool _isExpanded = false;
 
-  bool get _hasNewerLocalIteration {
-    if (widget.proposal.versions.isEmpty) return false;
-    final latestVersion = widget.proposal.versions.first;
-    return latestVersion.isLatestVersion(
-      widget.proposal.selfRef.version ?? '',
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
@@ -186,7 +178,7 @@ class _ProposalIterationHistoryState extends State<ProposalIterationHistory> {
                   else
                     VoicesAssets.icons.chevronRight.buildIcon(size: 18),
                   const SizedBox(width: 4),
-                  if (_hasNewerLocalIteration)
+                  if (widget.proposal.hasNewerLocalIteration)
                     _Title(
                       publish: widget.proposal.versions.first.publish,
                       title: widget.proposal.versions.first.title,
@@ -210,7 +202,7 @@ class _ProposalIterationHistoryState extends State<ProposalIterationHistory> {
                     ),
                   const Spacer(),
                   Offstage(
-                    offstage: !_hasNewerLocalIteration,
+                    offstage: !widget.proposal.hasNewerLocalIteration,
                     child: _Actions(
                       ref: widget.proposal.versions.first.selfRef,
                     ),

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -2636,5 +2636,13 @@
   "invalidSeedPhraseWord": "Invalid",
   "@invalidSeedPhraseWord": {
     "description": "Error shown when user inputs SeedPhrase word but invalid does not match any"
+  },
+  "deleteLocalVersionIfWantToPublishThisVersion": "If you want to publish this iteration as final, please delete the local draft.",
+  "@deleteLocalVersionIfWantToPublishThisVersion": {
+    "description": "Message shown when user tries to publish a draft proposal as final proposal but there is a newer local draft proposal."
+  },
+  "cantEditThisProposal": "Can't edit this proposal",
+  "@cantEditThisProposal": {
+    "description": "Message shown when user tries to edit a proposal that should not be editable."
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal.dart
@@ -96,6 +96,14 @@ final class Proposal extends Equatable {
     required this.categoryId,
   });
 
+  bool get hasNewerLocalIteration {
+    if (versions.isEmpty) return false;
+    final latestVersion = versions.first;
+    return latestVersion.isLatestVersion(
+      selfRef.version ?? '',
+    );
+  }
+
   @override
   List<Object?> get props => [
         selfRef,


### PR DESCRIPTION
# Description

This PR. makes that when user have new local iteration he cant edit the published one until the local one is deleted.

## Related Issue(s)

#2290

## Description of Changes

- adding new method to show warning snackbar

## Breaking Changes

N/A

## Screenshots

In the video snackbar is blue but its yellow. Video was recorded before this change

https://github.com/user-attachments/assets/322b54d5-433f-49cb-8f94-bb59d439090a


## Related Pull Requests

N/A

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
