### PR TITLE
fix(cat-voices): enable unit web tests for catalyst_voices_assets

### DIFF
--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -259,10 +259,9 @@ scripts:
   # TODO(kukkok3):
   # catalyst_voices: this package should contain only widget tests
   # catalyst_voices_repositories: enable when https://github.com/input-output-hk/catalyst-voices/issues/1980 is fixed
-  # catalyst_voices_assets: enable when https://github.com/input-output-hk/catalyst-voices/issues/1979 is fixed
   test-web:
     run: |
-      melos exec -c 1 --dir-exists="test" --ignore="catalyst_voices,catalyst_voices_repositories,catalyst_voices_assets" -- flutter test --platform chrome
+      melos exec -c 1 --dir-exists="test" --ignore="catalyst_voices,catalyst_voices_repositories" -- flutter test --platform chrome
     description: Run `flutter test --platform chrome` for all packages.
 
   test-report-web:

--- a/catalyst_voices/packages/internal/catalyst_voices_brands/test/src/catalyst_voices_brands_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_brands/test/src/catalyst_voices_brands_test.dart
@@ -8,11 +8,15 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   const catalystKey = Key('C');
 
-  Widget buildApp() => BlocProvider(
+  Widget buildApp({
+    ThemeMode themeMode = ThemeMode.light,
+  }) =>
+      BlocProvider(
         create: (context) => BrandBloc(),
         child: BlocBuilder<BrandBloc, BrandState>(
           builder: (context, state) {
             return MaterialApp(
+              themeMode: themeMode,
               home: Builder(
                 builder: (context) => Scaffold(
                   body: Row(


### PR DESCRIPTION
# Description

Enable web unit tests for `catalyst_voices_assets` package.

This PR does not really resolve root problem as described in issue but since issue was reported we've moved template json tests from depending on assets file to directly from `/docs` in #2298 and we can enable back tests for this package.

## Related Issue(s)

Resolves #1979 

## Description of Changes

- no longer ignoring unit tests for `catalyst_voices_assets`
- make sure brand widget unit tests are using non system theme mode 


