### PR TITLE
fix(cat-voices): missing opportunities drawer in account page

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/account/account_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/account_page.dart
@@ -13,6 +13,7 @@ import 'package:catalyst_voices/pages/account/widgets/account_status_banner.dart
 import 'package:catalyst_voices/pages/account/widgets/account_username_tile.dart';
 import 'package:catalyst_voices/pages/spaces/appbar/session_action_header.dart';
 import 'package:catalyst_voices/pages/spaces/appbar/session_state_header.dart';
+import 'package:catalyst_voices/pages/spaces/drawer/opportunities_drawer.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
@@ -39,6 +40,7 @@ class _AccountPageState extends State<AccountPage>
           SessionStateHeader(),
         ],
       ),
+      endDrawer: const OpportunitiesDrawer(),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [


### PR DESCRIPTION
# Description

As the account page is outside of the go router shell its need its own end drawer with opportunities.

## Related Issue(s)

#2428

## Description of Changes

- adding new end drawer

## Breaking Changes

N/A

## Screenshots

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/179bdd7a-bbd4-4c1a-b3dd-7b6e6f962001" />


## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
