### PR TITLE
chore(cat-voices): hide pagination controls when less then one page available

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/pagination/layouts/paginated_grid_view.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/pagination/layouts/paginated_grid_view.dart
@@ -83,7 +83,8 @@ class PaginatedGridView<ItemType> extends StatelessWidget {
           children: [
             child,
             Offstage(
-              offstage: pagingState.itemList.isEmpty,
+              offstage: pagingState.itemList.isEmpty ||
+                  (pagingState.isFirstPage && pagingState.isLastPage),
               child: _Controls(
                 fromNumber: pagingState.fromValue,
                 toNumber: pagingState.toValue,


### PR DESCRIPTION
# Description

Hide pagination controls when less then 1 page available

## Related Issue(s)

Fixes #2415 
