### PR TITLE
fix(cat-voices): center dialogs

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/modals/voices_desktop_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/voices_desktop_dialog.dart
@@ -157,7 +157,7 @@ class _VoicesDesktopDialog extends StatelessWidget {
             )
           : Theme.of(context).dialogTheme.shape,
       backgroundColor: backgroundColor,
-      alignment: Alignment.topCenter,
+      alignment: Alignment.center,
       insetPadding: const EdgeInsets.symmetric(horizontal: 40, vertical: 90),
       child: ConstrainedBox(
         constraints: constraints,


### PR DESCRIPTION
# Description

Positions all dialogs in center relative to screen. (Not parent).

This means all "big" dialogs moves from `topCenter` just to `center`. 

## Related Issue(s)

Fixes #2405 

### Screenshot

<img width="1728" alt="Screenshot 2025-05-05 at 11 30 37" src="https://github.com/user-attachments/assets/e7b6c989-95a3-4996-896f-a83d3fd4e2df" />


