### PR TITLE
fix(cat-voices): do not emit new state when closed

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
@@ -217,7 +217,7 @@ class _VoterCard extends StatelessWidget {
       ),
       additionalInfo: BlocSelector<DiscoveryCubit, DiscoveryState, DateTime?>(
         selector: (state) {
-          return state.currentCampaign.votingStartsAt;
+          return state.campaign.votingStartsAt;
         },
         builder: (context, date) {
           return date == null

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/campaign_categories_state_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/campaign_categories_state_selector.dart
@@ -47,7 +47,7 @@ class _CampaignCategoriesData extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocSelector<DiscoveryCubit, DiscoveryState, _ListItems>(
       selector: (state) {
-        return state.campaignCategories.categories;
+        return state.categories.categories;
       },
       builder: (context, state) {
         return Offstage(
@@ -67,10 +67,8 @@ class _CampaignCategoriesError extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocSelector<DiscoveryCubit, DiscoveryState, VisibilityState>(
-      selector: (state) => (
-        show: state.campaignCategories.showError,
-        error: state.campaignCategories.error
-      ),
+      selector: (state) =>
+          (show: state.categories.showError, error: state.categories.error),
       builder: (context, state) {
         final errorMessage = state.error?.message(context);
         return Offstage(
@@ -100,7 +98,7 @@ class _CampaignCategoriesLoading extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocSelector<DiscoveryCubit, DiscoveryState, bool>(
       selector: (state) {
-        return state.campaignCategories.isLoading;
+        return state.categories.isLoading;
       },
       builder: (context, isLoading) {
         final dummyCategories = List.filled(

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/current_campaign_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/current_campaign_selector.dart
@@ -76,7 +76,7 @@ class CurrentCampaignLoading extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocSelector<DiscoveryCubit, DiscoveryState, bool>(
       selector: (state) {
-        return state.currentCampaign.isLoading;
+        return state.campaign.isLoading;
       },
       builder: (context, state) {
         return Offstage(
@@ -100,7 +100,7 @@ class CurrentCampaignData extends StatelessWidget {
         CurrentCampaignInfoViewModel>(
       key: const Key('CurrentCampaignData'),
       selector: (state) {
-        return state.currentCampaign.currentCampaign;
+        return state.campaign.currentCampaign;
       },
       builder: (context, state) {
         return Offstage(
@@ -122,8 +122,8 @@ class CurrentCampaignError extends StatelessWidget {
     return BlocSelector<DiscoveryCubit, DiscoveryState, VisibilityState>(
       selector: (state) {
         return (
-          show: state.currentCampaign.showError,
-          error: state.currentCampaign.error,
+          show: state.campaign.showError,
+          error: state.campaign.error,
         );
       },
       builder: (context, state) {

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/most_recent_proposals_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/most_recent_proposals_selector.dart
@@ -31,7 +31,7 @@ class _MostRecentProposalsData extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocSelector<DiscoveryCubit, DiscoveryState, _ListItems>(
-      selector: (state) => state.mostRecentProposals.proposals,
+      selector: (state) => state.proposals.proposals,
       builder: (context, state) {
         if (state.length < _minProposalsToShowRecent) {
           return const ViewAllProposals();
@@ -50,8 +50,8 @@ class _MostRecentProposalsError extends StatelessWidget {
     return BlocSelector<DiscoveryCubit, DiscoveryState, VisibilityState>(
       selector: (state) {
         return (
-          show: state.mostRecentProposals.showError,
-          error: state.mostRecentProposals.error,
+          show: state.proposals.showError,
+          error: state.proposals.error,
         );
       },
       builder: (context, state) {
@@ -83,7 +83,7 @@ class _MostRecentProposalsLoading extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocSelector<DiscoveryCubit, DiscoveryState, bool>(
       selector: (state) {
-        return state.mostRecentProposals.isLoading;
+        return state.proposals.isLoading;
       },
       builder: (context, state) {
         return const Offstage();

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery.dart
@@ -1,1 +1,2 @@
 export 'discovery_cubit.dart';
+export 'discovery_state.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
@@ -5,18 +5,17 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
-import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 
-part 'discovery_state.dart';
-
+const _maxRecentProposalsCount = 7;
 final _logger = Logger('DiscoveryCubit');
 
 class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
-  // ignore: unused_field
   final CampaignService _campaignService;
   final ProposalService _proposalService;
-  StreamSubscription<List<Proposal>>? _proposalsSubscription;
-  StreamSubscription<List<String>>? _favoritesProposalsIdsSubscription;
+
+  StreamSubscription<List<Proposal>>? _proposalsSub;
+  StreamSubscription<List<String>>? _favoritesProposalsIdsSub;
 
   DiscoveryCubit(
     this._campaignService,
@@ -34,10 +33,12 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
 
   @override
   Future<void> close() {
-    _proposalsSubscription?.cancel();
-    _proposalsSubscription = null;
-    _favoritesProposalsIdsSubscription?.cancel();
-    _favoritesProposalsIdsSubscription = null;
+    _proposalsSub?.cancel();
+    _proposalsSub = null;
+
+    _favoritesProposalsIdsSub?.cancel();
+    _favoritesProposalsIdsSub = null;
+
     return super.close();
   }
 
@@ -52,7 +53,7 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
   Future<void> getCampaignCategories() async {
     emit(
       state.copyWith(
-        campaignCategories: const DiscoveryCampaignCategoriesState(),
+        categories: const DiscoveryCampaignCategoriesState(),
       ),
     );
 
@@ -60,57 +61,61 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
     final categoriesModel =
         categories.map(CampaignCategoryDetailsViewModel.fromModel).toList();
 
-    emit(
-      state.copyWith(
-        campaignCategories: DiscoveryCampaignCategoriesState(
-          isLoading: false,
-          categories: categoriesModel,
+    // TODO(damian-molinski): create VoicesBloc / VoicesCubit where this
+    // always will be checked.
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          categories: DiscoveryCampaignCategoriesState(
+            isLoading: false,
+            categories: categoriesModel,
+          ),
         ),
-      ),
-    );
+      );
+    }
   }
 
   Future<void> getCurrentCampaign() async {
     emit(
       state.copyWith(
-        currentCampaign: const DiscoveryCurrentCampaignState(),
+        campaign: const DiscoveryCurrentCampaignState(),
       ),
     );
     final campaign = await _campaignService.getCurrentCampaign();
     final campaignTimeline = await _campaignService.getCampaignTimeline();
     final currentCampaign = CurrentCampaignInfoViewModel.fromModel(campaign);
 
-    emit(
-      state.copyWith(
-        currentCampaign: DiscoveryCurrentCampaignState(
-          currentCampaign: currentCampaign,
-          campaignTimeline: campaignTimeline,
-          error: null,
-          isLoading: false,
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          campaign: DiscoveryCurrentCampaignState(
+            currentCampaign: currentCampaign,
+            campaignTimeline: campaignTimeline,
+            error: null,
+            isLoading: false,
+          ),
         ),
-      ),
-    );
+      );
+    }
   }
 
   Future<void> getMostRecentProposals() async {
     emit(
       state.copyWith(
-        mostRecentProposals: const DiscoveryMostRecentProposalsState(),
+        proposals: const DiscoveryMostRecentProposalsState(),
       ),
     );
 
-    await _proposalsSubscription?.cancel();
-    _proposalsSubscription = null;
-    _setupProposalsSubscription();
+    unawaited(_proposalsSub?.cancel());
+    _proposalsSub = _buildProposalsSub();
 
-    await _favoritesProposalsIdsSubscription?.cancel();
-    _favoritesProposalsIdsSubscription = null;
-    _setupFavoritesProposalsIdsSubscription();
+    unawaited(_favoritesProposalsIdsSub?.cancel());
+    _favoritesProposalsIdsSub = _buildFavoritesProposalsIdsSub();
 
-    final mostRecentState = state.mostRecentProposals;
+    final mostRecentState = state.proposals;
     emit(
       state.copyWith(
-        mostRecentProposals: mostRecentState.copyWith(isLoading: false),
+        proposals: mostRecentState.copyWith(isLoading: false),
       ),
     );
   }
@@ -124,26 +129,42 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
     }
   }
 
+  StreamSubscription<List<String>> _buildFavoritesProposalsIdsSub() {
+    _logger.info('Building favorites proposals ids subscription');
+
+    return _proposalService
+        .watchFavoritesProposalsIds()
+        .distinct(listEquals)
+        .listen(
+          _emitFavoritesIds,
+          onError: _emitMostRecentError,
+        );
+  }
+
+  StreamSubscription<List<Proposal>> _buildProposalsSub() {
+    _logger.fine('Building proposals subscription');
+
+    return _proposalService
+        .watchLatestProposals(limit: _maxRecentProposalsCount)
+        .distinct(listEquals)
+        .listen(
+          _handleProposals,
+          onError: _emitMostRecentError,
+        );
+  }
+
   void _emitFavoritesIds(List<String> ids) {
-    final proposals = state.mostRecentProposals.proposals;
-
-    final newProposals = [...proposals]
-        .map((e) => e.copyWith(isFavorite: ids.contains(e.ref.id)))
-        .toList();
-
     emit(
-      state.copyWith(
-        mostRecentProposals: state.mostRecentProposals.copyWith(
-          proposals: newProposals,
-        ),
-      ),
+      state.copyWith(proposals: state.proposals.updateFavorites(ids)),
     );
   }
 
-  void _emitMostRecentError(Object error) {
+  void _emitMostRecentError(Object error, StackTrace stackTrace) {
+    _logger.severe('Loading recent proposals emitted', error, stackTrace);
+
     emit(
       state.copyWith(
-        mostRecentProposals: state.mostRecentProposals.copyWith(
+        proposals: state.proposals.copyWith(
           isLoading: false,
           error: LocalizedException.create(error),
           proposals: const [],
@@ -161,9 +182,10 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
           ),
         )
         .toList();
+
     emit(
       state.copyWith(
-        mostRecentProposals: state.mostRecentProposals.copyWith(
+        proposals: state.proposals.copyWith(
           isLoading: false,
           error: null,
           proposals: proposalList,
@@ -172,31 +194,9 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
     );
   }
 
-  void _setupFavoritesProposalsIdsSubscription() {
-    _logger.info('Setting up favorites proposals ids subscription');
-    _favoritesProposalsIdsSubscription =
-        _proposalService.watchFavoritesProposalsIds().listen(
-      _emitFavoritesIds,
-      onError: (Object error) {
-        _emitMostRecentError(error);
-      },
-    );
-  }
+  Future<void> _handleProposals(List<Proposal> proposals) async {
+    _logger.info('Got proposals: ${proposals.length}');
 
-  void _setupProposalsSubscription() {
-    _logger.fine('Setting up proposals subscription');
-    _proposalsSubscription =
-        _proposalService.watchLatestProposals(limit: 7).listen(
-      (proposals) async {
-        _logger.info('Got proposals: ${proposals.length}');
-        _emitMostRecentProposals(proposals);
-        final currentFavorites =
-            await _proposalService.watchFavoritesProposalsIds().first;
-        _emitFavoritesIds(currentFavorites);
-      },
-      onError: (Object error) {
-        _emitMostRecentError(error);
-      },
-    );
+    _emitMostRecentProposals(proposals);
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_state.dart
@@ -1,4 +1,6 @@
-part of 'discovery_cubit.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:equatable/equatable.dart';
 
 final class DiscoveryCampaignCategoriesState extends Equatable {
   final bool isLoading;
@@ -92,35 +94,43 @@ final class DiscoveryMostRecentProposalsState extends Equatable {
       proposals: proposals ?? this.proposals,
     );
   }
+
+  DiscoveryMostRecentProposalsState updateFavorites(List<String> ids) {
+    final updatedProposals = [...proposals]
+        .map((e) => e.copyWith(isFavorite: ids.contains(e.ref.id)))
+        .toList();
+
+    return copyWith(proposals: updatedProposals);
+  }
 }
 
 final class DiscoveryState extends Equatable {
-  final DiscoveryCurrentCampaignState currentCampaign;
-  final DiscoveryCampaignCategoriesState campaignCategories;
-  final DiscoveryMostRecentProposalsState mostRecentProposals;
+  final DiscoveryCurrentCampaignState campaign;
+  final DiscoveryCampaignCategoriesState categories;
+  final DiscoveryMostRecentProposalsState proposals;
 
   const DiscoveryState({
-    this.currentCampaign = const DiscoveryCurrentCampaignState(),
-    this.campaignCategories = const DiscoveryCampaignCategoriesState(),
-    this.mostRecentProposals = const DiscoveryMostRecentProposalsState(),
+    this.campaign = const DiscoveryCurrentCampaignState(),
+    this.categories = const DiscoveryCampaignCategoriesState(),
+    this.proposals = const DiscoveryMostRecentProposalsState(),
   });
 
   @override
   List<Object?> get props => [
-        currentCampaign,
-        campaignCategories,
-        mostRecentProposals,
+        campaign,
+        categories,
+        proposals,
       ];
 
   DiscoveryState copyWith({
-    DiscoveryCurrentCampaignState? currentCampaign,
-    DiscoveryCampaignCategoriesState? campaignCategories,
-    DiscoveryMostRecentProposalsState? mostRecentProposals,
+    DiscoveryCurrentCampaignState? campaign,
+    DiscoveryCampaignCategoriesState? categories,
+    DiscoveryMostRecentProposalsState? proposals,
   }) {
     return DiscoveryState(
-      currentCampaign: currentCampaign ?? this.currentCampaign,
-      campaignCategories: campaignCategories ?? this.campaignCategories,
-      mostRecentProposals: mostRecentProposals ?? this.mostRecentProposals,
+      campaign: campaign ?? this.campaign,
+      categories: categories ?? this.categories,
+      proposals: proposals ?? this.proposals,
     );
   }
 }


### PR DESCRIPTION
# Description

Making sure new state is not emitted after bloc is closed

## Description of Changes

Only relevant changes are adding `if (!isClosed)` in `DiscoveryCubit`. In future i'll extract this behaviour into abstract class
