### PR TITLE
fix(docs): 

### DIFF
--- a/docs/src/appendix/important/license.md
+++ b/docs/src/appendix/important/license.md
@@ -9,11 +9,11 @@ icon: material/license
 ??? note "Apache 2 License"
 
     ```text
-    {{ include_file('includes/repo/LICENSE-APACHE', 0, -1, 8) }}
+    {{ include_file('includes/repo/LICENSE-APACHE') }}
     ```
 
 ??? note "MIT License"
 
     ```text
-    {{ include_file('includes/repo/LICENSE-MIT', 0, -1, 8) }}
+    {{ include_file('includes/repo/LICENSE-MIT') }}
     ```


### PR DESCRIPTION
# Description

Fixing docs CI failing
```
           ./docs+docs | WARNING -  [macros] - ERROR # _Macro Rendering Error_
           ./docs+docs | _File_: `appendix/important/license.md`
           ./docs+docs | _TypeError_: define_env.<locals>.include_file() takes 1 positional argument but 4 were given
```

```
Aborted with 1 warnings in strict mode!
```