### PR TITLE
fix(cat-voices): loading my proposals

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
@@ -30,9 +30,7 @@ final class ProposalsCubit extends Cubit<ProposalsState>
     this._campaignService,
     this._proposalService,
   ) : super(const ProposalsState()) {
-    final activeAccount = _userService.user.activeAccount;
-    final filters = ProposalsFilters(author: activeAccount?.catalystId);
-    _cache = _cache.copyWith(filters: filters);
+    _resetCache();
 
     _activeAccountIdSub = _userService.watchUser
         .map((event) => event.activeAccount?.catalystId)
@@ -119,8 +117,7 @@ final class ProposalsCubit extends Cubit<ProposalsState>
     required SignedDocumentRef? category,
     required ProposalsFilterType type,
   }) {
-    _cache = const ProposalsCubitCache();
-
+    _resetCache();
     unawaited(_loadCampaignCategories());
 
     changeFilters(
@@ -242,6 +239,12 @@ final class ProposalsCubit extends Cubit<ProposalsState>
     }).toList();
 
     emit(state.copyWith(categorySelectorItems: categorySelectorItems));
+  }
+
+  void _resetCache() {
+    final activeAccount = _userService.user.activeAccount;
+    final filters = ProposalsFilters(author: activeAccount?.catalystId);
+    _cache = ProposalsCubitCache(filters: filters);
   }
 
   Future<void> _updateFavoriteProposal(

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
@@ -190,7 +190,7 @@ final class ProposalRepositoryImpl implements ProposalRepository {
   }) async {
     return _proposalsLocalSource
         .getProposals(type: type, categoryRef: categoryRef)
-        .then((value) => value.map((e) => _buildProposalData(e)!).toList());
+        .then((value) => value.map(_buildProposalData).toList());
   }
 
   @override
@@ -200,7 +200,7 @@ final class ProposalRepositoryImpl implements ProposalRepository {
   }) {
     return _proposalsLocalSource
         .getProposalsPage(request: request, filters: filters)
-        .then((value) => value.map((e) => _buildProposalData(e)!));
+        .then((value) => value.map(_buildProposalData));
   }
 
   @override
@@ -384,18 +384,19 @@ final class ProposalRepositoryImpl implements ProposalRepository {
     return proposalAction;
   }
 
-  ProposalData? _buildProposalData(ProposalDocumentData data) {
+  ProposalData _buildProposalData(ProposalDocumentData data) {
     final action = _buildProposalActionData(data.action);
 
     final publish = switch (action) {
       ProposalSubmissionAction.aFinal => ProposalPublish.submittedProposal,
-      ProposalSubmissionAction.hide => null,
+      ProposalSubmissionAction.hide => throw ArgumentError.value(
+          action,
+          'action',
+          'Unsupported ${ProposalSubmissionAction.hide}, Make sure to filter'
+              ' out hidden proposals before this code is reached.',
+        ),
       ProposalSubmissionAction.draft || null => ProposalPublish.publishedDraft,
     };
-
-    if (publish == null) {
-      return null;
-    }
 
     final document = _buildProposalDocument(
       documentData: data.proposal,

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
@@ -389,13 +389,11 @@ final class ProposalRepositoryImpl implements ProposalRepository {
 
     final publish = switch (action) {
       ProposalSubmissionAction.aFinal => ProposalPublish.submittedProposal,
-      ProposalSubmissionAction.hide => throw ArgumentError.value(
-          action,
-          'action',
-          'Unsupported ${ProposalSubmissionAction.hide}, Make sure to filter'
-              ' out hidden proposals before this code is reached.',
-        ),
       ProposalSubmissionAction.draft || null => ProposalPublish.publishedDraft,
+      ProposalSubmissionAction.hide => throw ArgumentError(
+          'Unsupported ${ProposalSubmissionAction.hide}, Make sure to filter'
+          ' out hidden proposals before this code is reached.',
+        ),
     };
 
     final document = _buildProposalDocument(


### PR DESCRIPTION
# Description

- Makes sure that hidden proposals are excluded in `My Proposals` tab.
- Makes sure that `ProposalCubit.cache` has correctly assigned `author`.

## Related Issue(s)

Refers #2469

![Screenshot 2025-05-05 at 19 51 36](https://github.com/user-attachments/assets/4d9c2193-2ee2-483f-8e9a-09f1a985bad5)

## Screenshots

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
