### PR TITLE
fix(cat-voices): Proposals route as nav fallback for proposal details

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_navigation_controls.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_navigation_controls.dart
@@ -1,9 +1,11 @@
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_version.dart';
+import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class ProposalNavigationControls extends StatelessWidget {
   final VoidCallback onToggleTap;
@@ -40,6 +42,14 @@ class _BackButton extends StatelessWidget {
     return NavigationBack(
       label: context.l10n.backToList,
       isCompact: isCompact,
+      onTap: () {
+        final router = GoRouter.of(context);
+        if (router.canPop()) {
+          router.pop();
+        } else {
+          const ProposalsRoute().go(context);
+        }
+      },
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/common/navigation_back.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/common/navigation_back.dart
@@ -9,18 +9,20 @@ import 'package:go_router/go_router.dart';
 class NavigationBack extends StatelessWidget {
   final String? label;
   final bool isCompact;
+  final VoidCallback? onTap;
 
   const NavigationBack({
     super.key,
     this.label,
     this.isCompact = false,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
     return VoicesTextButton(
       key: const Key('NavigationBackBtn'),
-      onTap: () => _popRoute(context),
+      onTap: onTap ?? () => _popRoute(context),
       leading: isCompact ? null : VoicesAssets.icons.arrowLeft.buildIcon(),
       style: TextButton.styleFrom(
         foregroundColor: context.colors.textOnPrimaryLevel1,


### PR DESCRIPTION
# Description

Fixes bug when opening proposal directly and routing stack is empty

## Related Issue(s)

Fixes #2478 
