### PR TITLE
fix(cat-gateway): Detect Service Outage with Health Endpoints

### DIFF
--- a/catalyst-gateway/bin/src/db/event/signed_docs/tests/mod.rs
+++ b/catalyst-gateway/bin/src/db/event/signed_docs/tests/mod.rs
@@ -7,7 +7,7 @@ use futures::TryStreamExt;
 use super::*;
 use crate::db::event::{
     common::{eq_or_ranged_uuid::EqOrRangedUuid, query_limits::QueryLimits},
-    establish_connection,
+    establish_connection_pool,
 };
 
 mod filter_by_field;
@@ -15,7 +15,7 @@ mod filter_by_field;
 #[ignore = "An integration test which requires a running EventDB instance, disabled from `testunit` CI run"]
 #[tokio::test]
 async fn queries_test() {
-    establish_connection();
+    establish_connection_pool().await;
 
     let doc_type = uuid::Uuid::new_v4();
     let docs = test_docs(doc_type);

--- a/catalyst-gateway/bin/src/db/index/session.rs
+++ b/catalyst-gateway/bin/src/db/index/session.rs
@@ -63,6 +63,12 @@ pub(crate) enum CassandraSessionError {
         /// The underlying error that caused the session creation to fail.
         source: anyhow::Error,
     },
+    /// Error when connecting to database.
+    #[error("Database connection failed: {source}")]
+    ConnectionUnavailable {
+        /// The underlying error that caused the connection failure.
+        source: anyhow::Error,
+    },
     /// Error when schema migration fails.
     #[error("Schema migration failed: {source}")]
     SchemaMigrationFailed {

--- a/catalyst-gateway/bin/src/service/utilities/catch_panic.rs
+++ b/catalyst-gateway/bin/src/service/utilities/catch_panic.rs
@@ -6,6 +6,7 @@ use panic_message::panic_message;
 use poem::{http::StatusCode, middleware::PanicHandler, IntoResponse};
 use poem_openapi::payload::Json;
 use serde_json::json;
+use tracing::debug;
 
 use crate::{
     service::{
@@ -58,8 +59,14 @@ impl PanicHandler for ServicePanicHandler {
         // Increment the counter used for liveness checks.
         inc_live_counter();
 
+        let current_count = get_live_counter();
+        debug!(
+            live_counter = current_count,
+            "Handling service panic response"
+        );
+
         // If current count is above the threshold, then flag the system as NOT live.
-        if get_live_counter() > Settings::service_live_counter_threshold() {
+        if current_count > Settings::service_live_counter_threshold() {
             set_not_live();
         }
 


### PR DESCRIPTION
# Description

Defines DB connection errors, and updates middleware and endpoints to handle them by setting the relevant DB (_Event DB_ or _Index DB_) liveness flags.


Closes #2349 .


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
