### PR TITLE
Implement a cache for RBAC registrations

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -15,12 +15,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-cardano-chain-follower = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250506-00" }
-rbac-registration = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250506-00" }
-catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250506-00" }
-cardano-blockchain-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250506-00" }
-catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250506-00" }
-c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250506-00" }
+cardano-chain-follower = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "stake-addresses-set" }
+rbac-registration = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "stake-addresses-set" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "stake-addresses-set" }
+cardano-blockchain-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "stake-addresses-set" }
+catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "stake-addresses-set" }
+c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "stake-addresses-set" }
 
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 pallas-traverse = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/insert_catalyst_id_for_stake_address.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/insert_catalyst_id_for_stake_address.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use cardano_blockchain_types::{Slot, StakeAddress};
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use scylla::{SerializeRow, Session};
 use tracing::error;
 
@@ -41,7 +41,7 @@ impl Debug for Params {
 
 impl Params {
     /// Create a new record for this transaction.
-    pub(crate) fn new(stake_address: StakeAddress, slot_no: Slot, catalyst_id: IdUri) -> Self {
+    pub(crate) fn new(stake_address: StakeAddress, slot_no: Slot, catalyst_id: CatalystId) -> Self {
         Params {
             stake_address: stake_address.into(),
             catalyst_id: catalyst_id.into(),

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/insert_catalyst_id_for_txn_id.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/insert_catalyst_id_for_txn_id.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use cardano_blockchain_types::TransactionId;
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use scylla::{SerializeRow, Session};
 use tracing::error;
 
@@ -38,7 +38,7 @@ impl Debug for Params {
 
 impl Params {
     /// Creates a new record for this transaction.
-    pub(crate) fn new(catalyst_id: IdUri, txn_id: TransactionId) -> Self {
+    pub(crate) fn new(catalyst_id: CatalystId, txn_id: TransactionId) -> Self {
         Params {
             txn_id: txn_id.into(),
             catalyst_id: catalyst_id.into(),

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/insert_rbac509.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/insert_rbac509.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use cardano_blockchain_types::{Slot, TransactionId, TxnIndex};
-use catalyst_types::{id_uri::IdUri, uuid::UuidV4};
+use catalyst_types::{catalyst_id::CatalystId, uuid::UuidV4};
 use scylla::{frame::value::MaybeUnset, SerializeRow, Session};
 use tracing::error;
 
@@ -55,7 +55,7 @@ impl Debug for Params {
 impl Params {
     /// Create a new record for this transaction.
     pub(crate) fn new(
-        catalyst_id: IdUri, txn_id: TransactionId, slot_no: Slot, txn_index: TxnIndex,
+        catalyst_id: CatalystId, txn_id: TransactionId, slot_no: Slot, txn_index: TxnIndex,
         purpose: UuidV4, prv_txn_id: Option<TransactionId>,
     ) -> Self {
         let prv_txn_id = prv_txn_id.map_or(MaybeUnset::Unset, |v| MaybeUnset::Set(v.into()));

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/insert_rbac509_invalid.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/insert_rbac509_invalid.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use cardano_blockchain_types::{Slot, TransactionId, TxnIndex};
-use catalyst_types::{id_uri::IdUri, problem_report::ProblemReport, uuid::UuidV4};
+use catalyst_types::{catalyst_id::CatalystId, problem_report::ProblemReport, uuid::UuidV4};
 use scylla::{frame::value::MaybeUnset, SerializeRow, Session};
 use tracing::error;
 
@@ -40,7 +40,7 @@ pub(crate) struct Params {
 impl Params {
     /// Create a new record for this transaction.
     pub(crate) fn new(
-        catalyst_id: IdUri, txn_id: TransactionId, slot_no: Slot, txn_index: TxnIndex,
+        catalyst_id: CatalystId, txn_id: TransactionId, slot_no: Slot, txn_index: TxnIndex,
         purpose: Option<UuidV4>, prv_txn_id: Option<TransactionId>, report: &ProblemReport,
     ) -> Self {
         let purpose = purpose.map_or(MaybeUnset::Unset, |v| MaybeUnset::Set(v.into()));

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -11,7 +11,7 @@ use anyhow::{bail, Context};
 use cardano_blockchain_types::{
     Cip0134Uri, MultiEraBlock, Slot, StakeAddress, TransactionId, TxnIndex,
 };
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use pallas::ledger::addresses::Address;
 use rbac_registration::cardano::cip509::{Cip509, Cip509RbacMetadata};
 use scylla::Session;
@@ -214,7 +214,7 @@ impl Rbac509InsertQuery {
 async fn catalyst_id(
     session: &Arc<CassandraSession>, cip509: &Cip509, txn_id: TransactionId, slot: Slot,
     index: TxnIndex, is_immutable: bool,
-) -> anyhow::Result<IdUri> {
+) -> anyhow::Result<CatalystId> {
     use crate::db::index::queries::rbac::get_catalyst_id_from_transaction_id::cache_for_transaction_id;
 
     let id = match cip509.previous_transaction() {
@@ -235,7 +235,7 @@ async fn catalyst_id(
 /// Queries a Catalyst ID from the database by the given transaction ID.
 async fn query_catalyst_id(
     session: &Arc<CassandraSession>, txn_id: TransactionId, is_immutable: bool,
-) -> anyhow::Result<IdUri> {
+) -> anyhow::Result<CatalystId> {
     use crate::db::index::queries::rbac::get_catalyst_id_from_transaction_id::Query;
 
     if let Some(q) = Query::get_latest(session, txn_id.into())

--- a/catalyst-gateway/bin/src/db/index/queries/rbac/get_catalyst_id_from_transaction_id.rs
+++ b/catalyst-gateway/bin/src/db/index/queries/rbac/get_catalyst_id_from_transaction_id.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, LazyLock};
 
 use anyhow::{Context, Result};
 use cardano_blockchain_types::{Slot, TransactionId, TxnIndex};
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use futures::StreamExt;
 use moka::{policy::EvictionPolicy, sync::Cache};
 use scylla::{
@@ -102,7 +102,7 @@ impl Query {
 
 /// Update the cache when a rbac registration is indexed.
 pub(crate) fn cache_for_transaction_id(
-    _transaction_id: TransactionId, _catalyst_id: IdUri, _slot_no: Slot, _txn_idx: TxnIndex,
+    _transaction_id: TransactionId, _catalyst_id: CatalystId, _slot_no: Slot, _txn_idx: TxnIndex,
 ) {
     // TODO: Caching is disabled because we want to measure the performance without it and
     // be sure that the logic is sound. Also caches needs to be tunable.

--- a/catalyst-gateway/bin/src/db/index/queries/rbac/get_rbac_registrations.rs
+++ b/catalyst-gateway/bin/src/db/index/queries/rbac/get_rbac_registrations.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use cardano_blockchain_types::{Network, Point, Slot, TxnIndex};
 use cardano_chain_follower::ChainFollower;
-use catalyst_signed_doc::IdUri;
+use catalyst_signed_doc::CatalystId;
 use futures::{TryFutureExt, TryStreamExt};
 use rbac_registration::{cardano::cip509::Cip509, registration::cardano::RegistrationChain};
 use scylla::{
@@ -74,7 +74,7 @@ impl Query {
 /// Returns a sorted list of all registrations for the given Catalyst ID from the
 /// database.
 pub(crate) async fn indexed_registrations(
-    session: &CassandraSession, catalyst_id: &IdUri,
+    session: &CassandraSession, catalyst_id: &CatalystId,
 ) -> anyhow::Result<Vec<Query>> {
     let mut result: Vec<_> = Query::execute(session, QueryParams {
         catalyst_id: catalyst_id.clone().into(),

--- a/catalyst-gateway/bin/src/db/index/tests/scylla_queries.rs
+++ b/catalyst-gateway/bin/src/db/index/tests/scylla_queries.rs
@@ -4,7 +4,7 @@
 // cSpell:ignoreRegExp cardano/Fftx
 
 use cardano_blockchain_types::TransactionId;
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use futures::StreamExt;
 
 use super::*;
@@ -113,7 +113,7 @@ async fn get_rbac_registrations_by_catalyst_id() {
         panic!("{SESSION_ERR_MSG}");
     };
 
-    let id: IdUri = "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
+    let id: CatalystId = "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
         .parse()
         .unwrap();
     let mut row_stream = Query::execute(&session, QueryParams {
@@ -136,7 +136,7 @@ async fn get_rbac_invalid_registrations_by_catalyst_id() {
         panic!("{SESSION_ERR_MSG}");
     };
 
-    let id: IdUri = "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
+    let id: CatalystId = "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
         .parse()
         .unwrap();
     let mut row_stream = Query::execute(&session, QueryParams {

--- a/catalyst-gateway/bin/src/db/types/catalyst_id.rs
+++ b/catalyst-gateway/bin/src/db/types/catalyst_id.rs
@@ -1,6 +1,6 @@
 //! A `IdUri` wrapper that can be stored to and load from a database.
 
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use scylla::_macro_internal::{
     CellWriter, ColumnType, DeserializationError, DeserializeValue, FrameSlice, SerializationError,
     SerializeValue, TypeCheckError, WrittenCellProof,
@@ -9,15 +9,15 @@ use scylla::_macro_internal::{
 /// A `IdUri` wrapper that can be stored to and load from a database.
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, PartialEq, Hash)]
-pub struct DbCatalystId(IdUri);
+pub struct DbCatalystId(CatalystId);
 
-impl From<IdUri> for DbCatalystId {
-    fn from(value: IdUri) -> Self {
+impl From<CatalystId> for DbCatalystId {
+    fn from(value: CatalystId) -> Self {
         Self(value)
     }
 }
 
-impl From<DbCatalystId> for IdUri {
+impl From<DbCatalystId> for CatalystId {
     fn from(value: DbCatalystId) -> Self {
         value.0
     }
@@ -40,7 +40,7 @@ impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for DbCatalystId {
         typ: &'metadata ColumnType<'metadata>, v: Option<FrameSlice<'frame>>,
     ) -> Result<Self, DeserializationError> {
         let id = String::deserialize(typ, v)?;
-        let id: IdUri = id.parse().map_err(DeserializationError::new)?;
+        let id: CatalystId = id.parse().map_err(DeserializationError::new)?;
         Ok(Self(id))
     }
 }

--- a/catalyst-gateway/bin/src/main.rs
+++ b/catalyst-gateway/bin/src/main.rs
@@ -8,6 +8,7 @@ mod db;
 mod jinja;
 mod logger;
 mod metrics;
+mod rbac_cache;
 mod service;
 mod settings;
 mod utils;

--- a/catalyst-gateway/bin/src/rbac_cache/mod.rs
+++ b/catalyst-gateway/bin/src/rbac_cache/mod.rs
@@ -1,0 +1,272 @@
+//! A cache for RBAC registrations.
+
+// TODO: Remove the attribute.
+#![allow(dead_code)]
+
+use std::sync::LazyLock;
+
+use cardano_blockchain_types::{StakeAddress, TransactionId};
+use catalyst_types::{
+    catalyst_id::{role_index::RoleId, CatalystId},
+    problem_report::ProblemReport,
+    uuid::UuidV4,
+};
+use moka::{policy::EvictionPolicy, sync::Cache};
+use rbac_registration::{cardano::cip509::Cip509, registration::cardano::RegistrationChain};
+use tracing::{debug, error};
+
+/// A cache of valid RBAC registration chains.
+static CHAINS: LazyLock<Cache<CatalystId, RegistrationChain>> = LazyLock::new(|| {
+    Cache::builder()
+        .eviction_policy(EvictionPolicy::lru())
+        .build()
+});
+
+/// A cache of active stake addresses.
+///
+/// An address considered active if it is used by any of valid RBAC chains.
+static ACTIVE_ADDRESSES: LazyLock<Cache<StakeAddress, CatalystId>> = LazyLock::new(|| {
+    Cache::builder()
+        .eviction_policy(EvictionPolicy::lru())
+        .build()
+});
+
+/// A cache that allows to find a Catalyst ID of the previous registration using its
+/// transaction identifier (hash).
+static TRANSACTIONS: LazyLock<Cache<TransactionId, CatalystId>> = LazyLock::new(|| {
+    Cache::builder()
+        .eviction_policy(EvictionPolicy::lru())
+        .build()
+});
+
+/// A cache for RBAC registrations.
+pub struct RbacCache {}
+
+/// A value returned from the `RbacCache::add` on happy path.
+///
+/// It is used to insert a registration data to the `rbac_registration` table.
+pub struct RbacCacheAddSuccess {
+    /// A Catalyst ID.
+    pub catalyst_id: CatalystId,
+    /// A registration purpose.
+    pub purpose: UuidV4,
+}
+
+/// And error returned from the `RbacCache::add` method.
+///
+/// It is used to insert a registration data to the `rbac_invalid_registration` table.
+pub struct RbacCacheAddError {
+    /// A Catalyst ID.
+    pub catalyst_id: Option<CatalystId>,
+    /// A registration purpose.
+    pub purpose: Option<UuidV4>,
+    /// A problem report.
+    pub report: ProblemReport,
+}
+
+impl RbacCache {
+    /// Adds the given registration to one of the existing chains or starts a new one.
+    ///
+    /// In case of failure a problem report from the given registration is updated and
+    /// returned.
+    #[allow(clippy::result_large_err)]
+    pub fn add(registration: Cip509) -> Result<RbacCacheAddSuccess, RbacCacheAddError> {
+        match registration.previous_transaction() {
+            Some(previous_txn) => update_chain(registration, previous_txn),
+            None => start_new_chain(registration),
+        }
+    }
+
+    /// Returns a registration chain by the given Catalyst ID.
+    pub fn get(id: &CatalystId) -> Option<RegistrationChain> {
+        CHAINS.get(id)
+    }
+
+    /// Returns a registration chain by the stake address.
+    pub fn get_by_address(address: &StakeAddress) -> Option<RegistrationChain> {
+        let id = ACTIVE_ADDRESSES.get(address)?;
+        CHAINS.get(&id)
+    }
+}
+
+/// Applies the given registration to one of the existing chains.
+#[allow(clippy::result_large_err)]
+fn update_chain(
+    registration: Cip509, previous_txn: TransactionId,
+) -> Result<RbacCacheAddSuccess, RbacCacheAddError> {
+    let catalyst_id = registration.catalyst_id().cloned();
+    let purpose = registration.purpose();
+    let report = registration.report().to_owned();
+
+    // Find a chain this registration belongs to.
+    let catalyst_id = TRANSACTIONS.get(&previous_txn).ok_or_else(|| {
+        debug!("Unable to find previous transaction {previous_txn} in the RBAC cache");
+        // We are unable to determine a Catalyst ID, so there is no sense to update the
+        // problem report.
+        RbacCacheAddError {
+            catalyst_id,
+            purpose,
+            report: report.clone(),
+        }
+    })?;
+    let chain = CHAINS.get(&catalyst_id).ok_or_else(|| {
+        // This means the cache is broken. This should never normally happen.
+        error!("Broken Rbac cache: {catalyst_id} is present in TRANSACTIONS cache, but missing in CHAINS");
+        RbacCacheAddError {
+            catalyst_id: Some(catalyst_id.clone()),
+            purpose,
+            report: report.clone(),
+        }
+    })?;
+
+    // Check that addresses from the new registration aren't used in other chains.
+    let previous_addresses = chain.role_0_stake_addresses();
+    let registration_addresses = registration.role_0_stake_addresses();
+    let new_addresses: Vec<_> = registration_addresses
+        .difference(&previous_addresses)
+        .collect();
+    for address in &new_addresses {
+        if ACTIVE_ADDRESSES.get(address).is_some() {
+            report.functional_validation(
+                &format!("{address} stake addresses is already used"),
+                "It isn't allowed to use same stake address in multiple registration chains",
+            );
+        }
+    }
+    if report.is_problematic() {
+        return Err(RbacCacheAddError {
+            catalyst_id: Some(catalyst_id),
+            purpose,
+            report,
+        });
+    }
+
+    // Try to add a new registration to the chain.
+    let new_chain = chain.update(registration).map_err(|_| {
+        // TODO: FIXME: Decide if we want update report inside of
+        // `RegistrationChain::update`. If not update the report here.
+        RbacCacheAddError {
+            catalyst_id: Some(catalyst_id.clone()),
+            purpose,
+            report,
+        }
+    })?;
+
+    // Everything is fine: update caches.
+    for address in new_addresses {
+        ACTIVE_ADDRESSES.insert(address.to_owned(), catalyst_id.clone());
+    }
+    TRANSACTIONS.insert(new_chain.current_tx_id_hash(), catalyst_id.clone());
+    CHAINS.insert(catalyst_id.clone(), new_chain);
+
+    Ok(RbacCacheAddSuccess {
+        catalyst_id,
+        // A valid registration must have a purpose.
+        #[allow(clippy::expect_used)]
+        purpose: purpose.expect("Missing registration purpose"),
+    })
+}
+
+/// Starts a new Rbac registration chain.
+#[allow(clippy::result_large_err)]
+fn start_new_chain(registration: Cip509) -> Result<RbacCacheAddSuccess, RbacCacheAddError> {
+    let catalyst_id = registration.catalyst_id().cloned();
+    let purpose = registration.purpose();
+    let report = registration.report().to_owned();
+
+    let new_chain = RegistrationChain::new(registration).map_err(|_| {
+        // TODO: FIXME: Decide if we want update report inside of
+        // `RegistrationChain::new`. If not update the report here.
+        RbacCacheAddError {
+            catalyst_id,
+            purpose,
+            report: report.clone(),
+        }
+    })?;
+    let catalyst_id = new_chain.catalyst_id().to_owned();
+    if CHAINS.get(&catalyst_id).is_some() {
+        report.functional_validation(
+            &format!("{catalyst_id} is already used"),
+            "It isn't allowed to use same Catalyst ID (certificate subject public key) in multiple registration chains",
+        );
+        return Err(RbacCacheAddError {
+            catalyst_id: Some(catalyst_id),
+            purpose,
+            report,
+        });
+    }
+
+    let new_addresses = new_chain.role_0_stake_addresses();
+    let mut other_chains = Vec::new();
+    for address in &new_addresses {
+        if let Some(id) = ACTIVE_ADDRESSES.get(address) {
+            other_chains.push(id);
+        }
+    }
+
+    match other_chains.as_slice() {
+        [] => {
+            // All addresses are unique - nothing to do.
+        },
+        [previous_chain] => {
+            // Check if it is a proper overriding registration.
+            let previous_chain = CHAINS.get(previous_chain).ok_or_else(|| {
+                // This means the cache is broken. This should never normally happen.
+                error!("Broken Rbac cache: {previous_chain} is present in ACTIVE_ADDRESSES cache, but missing in CHAINS");
+                RbacCacheAddError {
+                    catalyst_id: Some(catalyst_id.clone()),
+                    purpose,
+                    report: report.clone(),
+                }
+            })?;
+            if previous_chain.get_latest_signing_pk_for_role(&RoleId::Role0)
+                == new_chain.get_latest_signing_pk_for_role(&RoleId::Role0)
+            {
+                report.functional_validation(
+                    &format!("A new registration ({catalyst_id}) uses the same public key as the previous one ({})",
+                             previous_chain.catalyst_id()),
+                    "It is only allowed to override the existing chain by using different public key",
+                );
+                return Err(RbacCacheAddError {
+                    catalyst_id: Some(catalyst_id),
+                    purpose,
+                    report,
+                });
+            }
+
+            // Remove the previous chain from caches.
+            CHAINS.invalidate(previous_chain.catalyst_id());
+            // There is no need to update `ACTIVE_ADDRESSES` cache because it will
+            // be overwritten below anyway.
+            // TODO: FIXME: Cleanup `TRANSACTIONS` cache.
+        },
+        [..] => {
+            // At the moment we don't allow for one registration to override multiple
+            // existing chains. We can reconsider this logic when multiple stake addressed
+            // will be properly supported.
+            report.functional_validation(
+                &format!("{catalyst_id} Catalyst ID is already used"),
+                "It isn't allowed to use same stake address in multiple registration chains",
+            );
+            return Err(RbacCacheAddError {
+                catalyst_id: Some(catalyst_id),
+                purpose,
+                report,
+            });
+        },
+    }
+
+    // Everything is fine: update caches.
+    for address in new_addresses {
+        ACTIVE_ADDRESSES.insert(address.clone(), catalyst_id.clone());
+    }
+    TRANSACTIONS.insert(new_chain.current_tx_id_hash(), catalyst_id.clone());
+    CHAINS.insert(catalyst_id.clone(), new_chain);
+
+    Ok(RbacCacheAddSuccess {
+        catalyst_id,
+        // A valid registration must have a purpose.
+        #[allow(clippy::expect_used)]
+        purpose: purpose.expect("Missing registration purpose"),
+    })
+}

--- a/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/chain_info.rs
+++ b/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/chain_info.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Context;
 use cardano_blockchain_types::{Slot, TransactionId};
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use futures::future::try_join;
 use rbac_registration::registration::cardano::RegistrationChain;
 
@@ -32,7 +32,7 @@ impl ChainInfo {
     /// Creates a new `ChainInfo` instance.
     pub(crate) async fn new(
         persistent_session: &CassandraSession, volatile_session: &CassandraSession,
-        catalyst_id: &IdUri,
+        catalyst_id: &CatalystId,
     ) -> anyhow::Result<Option<Self>> {
         let registrations =
             last_registration_chain(persistent_session, volatile_session, catalyst_id).await?;
@@ -70,7 +70,8 @@ impl ChainInfo {
 
 /// Returns a last independent chain of both persistent and volatile registrations.
 async fn last_registration_chain(
-    persistent_session: &CassandraSession, volatile_session: &CassandraSession, catalyst_id: &IdUri,
+    persistent_session: &CassandraSession, volatile_session: &CassandraSession,
+    catalyst_id: &CatalystId,
 ) -> anyhow::Result<Vec<(bool, Query)>> {
     let (persistent_registrations, volatile_registrations) = try_join(
         indexed_registrations(persistent_session, catalyst_id),

--- a/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/mod.rs
@@ -19,7 +19,7 @@ mod unprocessable_content;
 
 use anyhow::{anyhow, Context};
 use cardano_blockchain_types::StakeAddress;
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use futures::{TryFutureExt, TryStreamExt};
 use poem_openapi::payload::Json;
 use tracing::error;
@@ -109,7 +109,7 @@ pub(crate) async fn endpoint(
 /// Returns a Catalyst ID for the given stake address.
 async fn catalyst_id_from_stake(
     session: &CassandraSession, address: StakeAddress,
-) -> anyhow::Result<Option<IdUri>> {
+) -> anyhow::Result<Option<CatalystId>> {
     let mut result: Vec<_> = Query::execute(session, QueryParams {
         stake_address: address.into(),
     })

--- a/catalyst-gateway/bin/src/service/api/documents/put_document/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/put_document/mod.rs
@@ -157,7 +157,7 @@ async fn validate_against_original_doc(doc: &CatalystSignedDocument) -> anyhow::
         .body()
         .authors()
         .iter()
-        .map(|author| catalyst_signed_doc::IdUri::from_str(author))
+        .map(|author| catalyst_signed_doc::CatalystId::from_str(author))
         .collect::<Result<HashSet<_>, _>>()?;
     let authors: HashSet<_> = doc.authors().into_iter().collect();
     Ok(authors == original_authors)

--- a/catalyst-gateway/bin/src/service/api/documents/templates/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/mod.rs
@@ -4,7 +4,9 @@ mod data;
 
 use std::{collections::HashMap, env, sync::LazyLock};
 
-use catalyst_signed_doc::{Builder, CatalystSignedDocument, ContentEncoding, ContentType, IdUri};
+use catalyst_signed_doc::{
+    Builder, CatalystId, CatalystSignedDocument, ContentEncoding, ContentType,
+};
 use data::{CATEGORY_DOCUMENTS, COMMENT_TEMPLATES, PROPOSAL_TEMPLATES};
 use ed25519_dalek::{ed25519::signature::Signer, SigningKey};
 use hex::FromHex;
@@ -107,7 +109,7 @@ fn build_signed_doc(data: &SignedDocData, sk: &SigningKey) -> (Uuid, CatalystSig
         "brand_id":  {"id": BRAND_ID, "ver": BRAND_VERSION},
     });
 
-    let kid = IdUri::new(KID_NETWORK, None, sk.verifying_key());
+    let kid = CatalystId::new(KID_NETWORK, None, sk.verifying_key());
     let doc = Builder::new()
         .with_json_metadata(metadata.clone())
         .expect("Failed to build Metadata from template")

--- a/catalyst-gateway/bin/src/service/common/auth/rbac/scheme.rs
+++ b/catalyst-gateway/bin/src/service/common/auth/rbac/scheme.rs
@@ -1,10 +1,10 @@
 //! Catalyst RBAC Security Scheme
 use std::{env, error::Error, sync::LazyLock, time::Duration};
 
+use catalyst_types::catalyst_id::role_index::RoleId;
 use moka::future::Cache;
 use poem::{error::ResponseError, http::StatusCode, IntoResponse, Request};
 use poem_openapi::{auth::Bearer, SecurityScheme};
-use rbac_registration::cardano::cip509::RoleNumber;
 use tracing::debug;
 
 use super::token::CatalystRBACTokenV1;
@@ -194,7 +194,7 @@ async fn checker_api_catalyst_auth(
 
     // Step 8: Get the latest stable signing certificate registered for Role 0.
     let (latest_pk, _) = reg_chain
-        .get_latest_signing_pk_for_role(&RoleNumber::ROLE_0)
+        .get_latest_signing_pk_for_role(&RoleId::Role0)
         .ok_or_else(|| {
             debug!(
                 "Unable to get last signing key for {} Catalyst ID",

--- a/catalyst-gateway/bin/src/service/common/auth/rbac/token.rs
+++ b/catalyst-gateway/bin/src/service/common/auth/rbac/token.rs
@@ -11,7 +11,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
 use cardano_blockchain_types::Network;
-use catalyst_types::id_uri::IdUri;
+use catalyst_types::catalyst_id::CatalystId;
 use chrono::{TimeDelta, Utc};
 use ed25519_dalek::{ed25519::signature::Signer, Signature, SigningKey, VerifyingKey};
 use futures::future::try_join;
@@ -36,7 +36,7 @@ static REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"/\d+$").unwrap());
 #[derive(Debug, Clone)]
 pub(crate) struct CatalystRBACTokenV1 {
     /// A Catalyst identifier.
-    catalyst_id: IdUri,
+    catalyst_id: CatalystId,
     /// A network value.
     ///
     /// The network value is contained in the Catalyst ID and can be accessed from it, but
@@ -61,7 +61,9 @@ impl CatalystRBACTokenV1 {
     pub(crate) fn new(
         network: &str, subnet: Option<&str>, role0_pk: VerifyingKey, sk: &SigningKey,
     ) -> Result<Self> {
-        let catalyst_id = IdUri::new(network, subnet, role0_pk).with_nonce().as_id();
+        let catalyst_id = CatalystId::new(network, subnet, role0_pk)
+            .with_nonce()
+            .as_id();
         let network = convert_network(&catalyst_id.network())?;
         let raw = as_raw_bytes(&catalyst_id.to_string());
         let signature = sk.sign(&raw);
@@ -103,7 +105,7 @@ impl CatalystRBACTokenV1 {
             .map_err(|_| anyhow!("Invalid token signature length"))?;
         let raw = as_raw_bytes(token);
 
-        let catalyst_id: IdUri = token.parse().context("Invalid Catalyst ID")?;
+        let catalyst_id: CatalystId = token.parse().context("Invalid Catalyst ID")?;
         if catalyst_id.username().is_some_and(|n| !n.is_empty()) {
             return Err(anyhow!("Catalyst ID must not contain username"));
         }
@@ -166,7 +168,7 @@ impl CatalystRBACTokenV1 {
     }
 
     /// Returns a Catalyst ID from the token.
-    pub(crate) fn catalyst_id(&self) -> &IdUri {
+    pub(crate) fn catalyst_id(&self) -> &CatalystId {
         &self.catalyst_id
     }
 

--- a/catalyst-gateway/bin/src/service/common/types/cardano/catalyst_id.rs
+++ b/catalyst-gateway/bin/src/service/common/types/cardano/catalyst_id.rs
@@ -5,7 +5,6 @@
 use std::{borrow::Cow, sync::LazyLock};
 
 use anyhow::Context;
-use catalyst_types::id_uri::IdUri;
 use ed25519_dalek::SigningKey;
 use poem_openapi::{
     registry::{MetaSchema, MetaSchemaRef},
@@ -33,11 +32,11 @@ static SCHEMA: LazyLock<MetaSchema> = LazyLock::new(|| {
 
 /// A Catalyst short identifier.
 #[derive(Debug, Clone, PartialEq, Hash)]
-pub(crate) struct CatalystId(IdUri);
+pub(crate) struct CatalystId(catalyst_types::catalyst_id::CatalystId);
 
 impl Type for CatalystId {
-    type RawElementValueType = IdUri;
-    type RawValueType = IdUri;
+    type RawElementValueType = catalyst_types::catalyst_id::CatalystId;
+    type RawValueType = catalyst_types::catalyst_id::CatalystId;
 
     const IS_REQUIRED: bool = true;
 
@@ -61,13 +60,13 @@ impl Type for CatalystId {
     }
 }
 
-impl From<IdUri> for CatalystId {
-    fn from(value: IdUri) -> Self {
+impl From<catalyst_types::catalyst_id::CatalystId> for CatalystId {
+    fn from(value: catalyst_types::catalyst_id::CatalystId) -> Self {
         Self(value.as_short_id())
     }
 }
 
-impl From<CatalystId> for IdUri {
+impl From<CatalystId> for catalyst_types::catalyst_id::CatalystId {
     fn from(value: CatalystId) -> Self {
         value.0
     }
@@ -80,7 +79,7 @@ impl TryFrom<&str> for CatalystId {
         value
             .parse()
             .context("Invalid Catalyst ID")
-            .map(|id: IdUri| Self(id.as_short_id()))
+            .map(|id: catalyst_types::catalyst_id::CatalystId| Self(id.as_short_id()))
     }
 }
 
@@ -114,7 +113,7 @@ impl Example for CatalystId {
             105, 123, 50, 105, 25, 112, 59, 172, 3, 28, 174, 127, 96,
         ];
         let signing_key = &SigningKey::from_bytes(&secret_key_bytes);
-        IdUri::new("cardano", Some("preprod"), signing_key.into())
+        catalyst_types::catalyst_id::CatalystId::new("cardano", Some("preprod"), signing_key.into())
             .as_id()
             .into()
     }


### PR DESCRIPTION
# Description

- Introduce `RbacCache` that allows fast and convenient RBAC registrations validation.

## Related Issue(s)

https://github.com/input-output-hk/catalyst-voices/issues/2427
https://github.com/input-output-hk/catalyst-voices/issues/2152

## Related Pull Requests

Depends on https://github.com/input-output-hk/catalyst-libs/pull/304/.
