### PR TITLE
fix(cat-voices): missing multiline for MarkdownText

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/viewer/document_property_builder_viewer.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/viewer/document_property_builder_viewer.dart
@@ -235,17 +235,17 @@ class _DocumentPropertyBuilderViewerState
 class _ListItem extends StatelessWidget {
   final String title;
   final bool isRequired;
-  final Widget value;
   final bool isMultiline;
   final bool isAnswered;
+  final Widget child;
 
   const _ListItem({
     required super.key,
     required this.title,
     required this.isRequired,
-    required this.value,
     this.isMultiline = false,
     this.isAnswered = false,
+    required this.child,
   });
 
   @override
@@ -276,7 +276,7 @@ class _ListItem extends StatelessWidget {
           ),
           maxLines: !isMultiline ? 1 : null,
           overflow: !isMultiline ? TextOverflow.ellipsis : TextOverflow.clip,
-          child: value,
+          child: child,
         ),
       ],
     );
@@ -312,8 +312,9 @@ class _MarkdownListItem extends StatelessWidget {
       key: ValueKey(id),
       title: title,
       isRequired: isRequired,
-      value: child,
       isAnswered: isAnswered,
+      isMultiline: true,
+      child: child,
     );
   }
 }
@@ -353,9 +354,9 @@ class _TextListItem extends StatelessWidget {
       key: ValueKey(id),
       title: title,
       isRequired: isRequired,
-      value: child,
       isMultiline: isMultiline,
       isAnswered: isAnswered,
+      child: child,
     );
   }
 }


### PR DESCRIPTION
# Description

Allows multiline for markdown in ProposalBuilder view mode

## Related Issue(s)

Fixes #2481 

## Description of Changes

Allows markdown text to be multiline when viewing in ProposalBuilder 

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

Before

https://github.com/user-attachments/assets/b5a9e407-2437-4039-b623-f9046df6fb45

After

<img width="1725" alt="Screenshot 2025-05-08 at 14 30 25" src="https://github.com/user-attachments/assets/d5514df5-d99d-403f-996c-5c18fbb71f1a" />
