### PR TITLE
feat(cat-voices): get author name of proposal firstly from CatalystId

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -296,9 +296,7 @@ final class ProposalCubit extends Cubit<ProposalState>
       categoryName: category?.categoryName ?? '',
       proposalTitle: document.title ?? '',
       data: ProposalViewMetadata(
-        author: Profile(
-          catalystId: document.metadataCatalystId!,
-        ),
+        author: Profile(catalystId: document.metadataCatalystId!),
         description: document.description,
         status: proposal.publish,
         createdAt: version?.id.tryDateTime ?? DateTime.now(),

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -296,7 +296,7 @@ final class ProposalCubit extends Cubit<ProposalState>
       categoryName: category?.categoryName ?? '',
       proposalTitle: document.title ?? '',
       data: ProposalViewMetadata(
-        author: Profile(catalystId: document.metadataCatalystId!),
+        author: Profile(catalystId: document.authorId!),
         description: document.description,
         status: proposal.publish,
         createdAt: version?.id.tryDateTime ?? DateTime.now(),

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -296,7 +296,9 @@ final class ProposalCubit extends Cubit<ProposalState>
       categoryName: category?.categoryName ?? '',
       proposalTitle: document.title ?? '',
       data: ProposalViewMetadata(
-        author: Profile(catalystId: DummyCatalystIdFactory.create()),
+        author: Profile(
+          catalystId: document.metadataCatalystId!,
+        ),
         description: document.description,
         status: proposal.publish,
         createdAt: version?.id.tryDateTime ?? DateTime.now(),

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/specialized/proposal_document.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/specialized/proposal_document.dart
@@ -60,6 +60,8 @@ final class ProposalDocument extends Equatable {
     required this.document,
   });
 
+  CatalystId? get authorId => metadata.authors.firstOrNull;
+
   String? get authorName => _metadataAuthorName ?? _contentAuthorName;
 
   String? get description {
@@ -93,8 +95,6 @@ final class ProposalDocument extends Equatable {
     if (value == null) return null;
     return Coin.fromWholeAda(value);
   }
-
-  CatalystId? get metadataCatalystId => metadata.authors.firstOrNull;
 
   int? get milestoneCount {
     final property = document.getProperty(milestonesNodeId);

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/specialized/proposal_document.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/specialized/proposal_document.dart
@@ -60,7 +60,7 @@ final class ProposalDocument extends Equatable {
     required this.document,
   });
 
-  String? get authorName => _contentAuthorName ?? _metadataAuthorName;
+  String? get authorName => _metadataAuthorName ?? _contentAuthorName;
 
   String? get description {
     final property = document.getProperty(descriptionNodeId);
@@ -93,6 +93,8 @@ final class ProposalDocument extends Equatable {
     if (value == null) return null;
     return Coin.fromWholeAda(value);
   }
+
+  CatalystId? get metadataCatalystId => metadata.authors.firstOrNull;
 
   int? get milestoneCount {
     final property = document.getProperty(milestonesNodeId);


### PR DESCRIPTION
# Description

This PR sets proper autho name for proposal in proposal cards and proposal viewer in Profile Section.

## Related Issue(s)

N/A

## Description of Changes

- adding getter for CatalystId
- changing other of fallback for getter for authorName (firstly we try to get name from CatalystId)

## Breaking Changes

N/A

## Screenshots

Now:
<img width="792" alt="image" src="https://github.com/user-attachments/assets/5a4fd784-ef7a-49ad-ad0b-3ed303bfb8b8" />

Before
<img width="584" alt="image" src="https://github.com/user-attachments/assets/fd9262c1-d367-4e3a-8f2f-9f2730d532c4" />


## Related Pull Requests

N/A

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
