### PR TITLE
fix(cat-voices): cut character in avatar - proposal viewer

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/user/profile_avatar.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/user/profile_avatar.dart
@@ -33,6 +33,7 @@ class ProfileAvatar extends StatelessWidget {
       radius: size / 2,
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
+      padding: const EdgeInsets.all(6),
       icon: Text(
         username?.first?.capitalize() ?? '',
         style: effectiveTextStyle,


### PR DESCRIPTION
# Description

A little change in padding to resolve issue with cutted of bottom of letter in voices avatar in [proposal.viewer]

## Related Issue(s)

Part of #2505

## Description of Changes

- change of padding

## Breaking Changes

N/A

## Screenshots

After: 
<img width="1099" alt="image" src="https://github.com/user-attachments/assets/c2ee16fd-54a4-4903-ad5a-0f7f07fdaa3e" />
                 
Before:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/0e81dd95-60e2-4cff-bb9d-0e9f0ecb7e18" />
           

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
