### PR TITLE
chore(cat-voices): revert win32 workaround

### DIFF
--- a/catalyst_voices/apps/voices/pubspec.yaml
+++ b/catalyst_voices/apps/voices/pubspec.yaml
@@ -84,10 +84,6 @@ dependencies:
   url_strategy: ^0.3.0
   uuid_plus: ^0.1.0
   video_player: ^2.9.2
-  # TODO(dtscalac): win32 dependency is just a transitive dependency and shouldn't be imported
-  # but here we import it explicitly to make sure the latest version is used which addresses
-  # the problem from here: https://github.com/jonataslaw/get_cli/issues/263
-  win32: ^5.5.4
 
 dev_dependencies:
   analyzer: 7.3.0

--- a/catalyst_voices/melos.yaml
+++ b/catalyst_voices/melos.yaml
@@ -163,10 +163,6 @@ command:
       shared_preferences_platform_interface: ^2.4.1
       skeletonizer: ^1.4.3
       synchronized: ^3.3.0+3
-      # TODO(dtscalac): win32 dependency is just a transitive dependency and shouldn't be imported
-      # but here we import it explicitly to make sure the latest version is used which addresses
-      # the problem from here: https://github.com/jonataslaw/get_cli/issues/263
-      win32: ^5.5.4
       web: ^1.1.0
       webdriver: ^3.0.3
     dev_dependencies:


### PR DESCRIPTION
# Description

Reverts the [workaround for win32](https://github.com/jonataslaw/get_cli/issues/263) which is no longer needed.

## Related Issue(s)

https://github.com/jonataslaw/get_cli/issues/263

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
