### PR TITLE
fix(cat-voices): proposals limit in navigation rail

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/discovery_overview_proposal_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/space/user_proposal_selectors/discovery_overview_proposal_selector.dart
@@ -31,14 +31,8 @@ class _DataProposalSelector extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // TODO(dtscalac): clarify what to show here, currently it shows
-              // published + submitted together, however the limit for proposals
-              // is only for submitted ones
               _Header(
-                title: context.l10n.noPublishedProposalsOnMaxCount(
-                  state.data.length,
-                  ProposalDocument.maxSubmittedProposalsPerUser,
-                ),
+                title: context.l10n.publishedProposals,
               ),
               Offstage(
                 offstage: !state.show,

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
@@ -41,7 +41,7 @@ final class WorkspaceState extends Equatable {
 
   bool get showError => error != null && !isLoading;
   bool get showProposals => error == null;
-  
+
   DateTime? get submissionCloseDate => timelineItems
       .firstWhereOrNull(
         (e) => e.stage == CampaignTimelineStage.proposalSubmission,

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
@@ -36,12 +36,12 @@ final class WorkspaceState extends Equatable {
 
   List<Proposal> get published => userProposals
       .where((e) => (e.publish.isPublished || e.publish.isDraft))
-      .sortedBy((e) => e.publish)
+      .sorted(_compareProposals)
       .toList();
 
   bool get showError => error != null && !isLoading;
-  bool get showProposals => error == null;
 
+  bool get showProposals => error == null;
   DateTime? get submissionCloseDate => timelineItems
       .firstWhereOrNull(
         (e) => e.stage == CampaignTimelineStage.proposalSubmission,
@@ -63,5 +63,15 @@ final class WorkspaceState extends Equatable {
       userProposals: userProposals ?? this.userProposals,
       timelineItems: timelineItems ?? this.timelineItems,
     );
+  }
+
+  static int _compareProposals(Proposal a, Proposal b) {
+    if (a.publish != b.publish) {
+      // sort by status first
+      return a.publish.compareTo(b.publish);
+    }
+
+    // most recent first, older later
+    return b.updateDate.compareTo(a.updateDate);
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
@@ -40,8 +40,8 @@ final class WorkspaceState extends Equatable {
     ..sort();
 
   bool get showError => error != null && !isLoading;
-
   bool get showProposals => error == null;
+  
   DateTime? get submissionCloseDate => timelineItems
       .firstWhereOrNull(
         (e) => e.stage == CampaignTimelineStage.proposalSubmission,

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
@@ -36,8 +36,8 @@ final class WorkspaceState extends Equatable {
 
   List<Proposal> get published => userProposals
       .where((e) => (e.publish.isPublished || e.publish.isDraft))
-      .sorted(_compareProposals)
-      .toList();
+      .toList()
+    ..sort();
 
   bool get showError => error != null && !isLoading;
 
@@ -63,15 +63,5 @@ final class WorkspaceState extends Equatable {
       userProposals: userProposals ?? this.userProposals,
       timelineItems: timelineItems ?? this.timelineItems,
     );
-  }
-
-  static int _compareProposals(Proposal a, Proposal b) {
-    if (a.publish != b.publish) {
-      // sort by status first
-      return a.publish.compareTo(b.publish);
-    }
-
-    // most recent first, older later
-    return b.updateDate.compareTo(a.updateDate);
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/workspace/workspace_state.dart
@@ -35,9 +35,8 @@ final class WorkspaceState extends Equatable {
       ];
 
   List<Proposal> get published => userProposals
-      .where(
-        (e) => (e.publish.isPublished || e.publish.isDraft),
-      )
+      .where((e) => (e.publish.isPublished || e.publish.isDraft))
+      .sortedBy((e) => e.publish)
       .toList();
 
   bool get showError => error != null && !isLoading;

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -1875,17 +1875,9 @@
       }
     }
   },
-  "noPublishedProposalsOnMaxCount": "Published Proposals ({current}/{max})",
-  "@noPublishedProposalsOnMaxCount": {
-    "description": "Title for section to show number of published proposals out of max proposals",
-    "placeholders": {
-      "current": {
-        "type": "int"
-      },
-      "max": {
-        "type": "int"
-      }
-    }
+  "publishedProposals": "Published Proposals",
+  "@publishedProposals": {
+    "description": "A label for proposals that have been published (public)."
   },
   "nrOfIteration": "Iteration {nr}",
   "@nrOfIteration": {

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal.dart
@@ -3,7 +3,7 @@ import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:equatable/equatable.dart';
 
-final class Proposal extends Equatable {
+final class Proposal extends Equatable implements Comparable<Proposal> {
   final DocumentRef selfRef;
   final String title;
   final String description;
@@ -122,6 +122,17 @@ final class Proposal extends Equatable {
       ];
 
   int get versionCount => versions.isEmpty ? 1 : versions.length;
+
+  @override
+  int compareTo(Proposal other) {
+    if (publish != other.publish) {
+      // sort by status first
+      return publish.compareTo(other.publish);
+    }
+
+    // most recent first, older later
+    return other.updateDate.compareTo(updateDate);
+  }
 
   Proposal copyWith({
     DocumentRef? selfRef,

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal_enums.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal_enums.dart
@@ -1,4 +1,4 @@
-enum ProposalPublish {
+enum ProposalPublish implements Comparable<ProposalPublish> {
   /// A proposal has not yet been published,
   /// it's stored only in the local storage.
   localDraft,
@@ -17,6 +17,12 @@ enum ProposalPublish {
   bool get isLocal => this == localDraft;
 
   bool get isPublished => this == submittedProposal;
+
+  /// Sorts in reverse order to how the [ProposalStatus] enums are declared.
+  @override
+  int compareTo(ProposalPublish other) {
+    return other.index.compareTo(index);
+  }
 }
 
 // Note. This enum may be deleted later. Its here for backwards compatibility.

--- a/catalyst_voices/packages/internal/catalyst_voices_models/test/proposal/proposal_enums_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/test/proposal/proposal_enums_test.dart
@@ -1,0 +1,40 @@
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ProposalPublish, () {
+    test('sort from latest status to earliest', () {
+      final actual = [
+        ProposalPublish.submittedProposal,
+        ProposalPublish.localDraft,
+        ProposalPublish.publishedDraft,
+      ]..sort();
+
+      expect(
+        actual,
+        equals([
+          ProposalPublish.submittedProposal,
+          ProposalPublish.publishedDraft,
+          ProposalPublish.localDraft,
+        ]),
+      );
+    });
+
+    test('sort from earliest status to latest', () {
+      final actual = [
+        ProposalPublish.localDraft,
+        ProposalPublish.publishedDraft,
+        ProposalPublish.submittedProposal,
+      ]..sort();
+
+      expect(
+        actual,
+        equals([
+          ProposalPublish.submittedProposal,
+          ProposalPublish.publishedDraft,
+          ProposalPublish.localDraft,
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Description

- Let's remove the (x/x)
- Show final proposals first
  - Sort finals by newest in the top.
 - Than show draft proposals
   - Sort Drafts by newest in the top.

## Screenshots

![Screenshot 2025-05-12 at 13 27 35](https://github.com/user-attachments/assets/76a2dfe8-0236-40c5-8e5d-f86a1b7c7fc7)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
