### PR TITLE
chore(cat-voices): restore avoid_redundant_argument_values lint rule

### DIFF
--- a/catalyst_voices/apps/voices/integration_test/suites/onboarding_restore_test.dart
+++ b/catalyst_voices/apps/voices/integration_test/suites/onboarding_restore_test.dart
@@ -257,8 +257,7 @@ void main() async {
 
         await UnlockPasswordInputPanel($)
             .enterPassword('Test1234', 'WrongPassword');
-        await UnlockPasswordInputPanel($)
-            .verifyPasswordConfirmErrorIcon(isShown: true);
+        await UnlockPasswordInputPanel($).verifyPasswordConfirmErrorIcon();
       });
 
       patrolWidgetTest('restore - can recover different keychain',

--- a/catalyst_voices/apps/voices/integration_test/suites/onboarding_test.dart
+++ b/catalyst_voices/apps/voices/integration_test/suites/onboarding_test.dart
@@ -296,8 +296,7 @@ void main() async {
         await PasswordInputPanel($).enterPassword('Test1234', 'Test123');
         await PasswordInputPanel($)
             .verifyValidationIndicator(PasswordValidationStatus.normal);
-        await PasswordInputPanel($)
-            .verifyPasswordConfirmErrorIcon(isShown: true);
+        await PasswordInputPanel($).verifyPasswordConfirmErrorIcon();
         await PasswordInputPanel($).verifyNextButtonIsDisabled();
       });
 

--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -61,12 +61,8 @@ final class _AppContent extends StatelessWidget {
       localeListResolutionCallback: basicLocaleListResolution,
       routerConfig: routerConfig,
       themeMode: themeMode,
-      theme: ThemeBuilder.buildTheme(
-        brand: Brand.catalyst,
-        brightness: Brightness.light,
-      ),
+      theme: ThemeBuilder.buildTheme(),
       darkTheme: ThemeBuilder.buildTheme(
-        brand: Brand.catalyst,
         brightness: Brightness.dark,
       ),
       debugShowCheckedModeBanner: false,

--- a/catalyst_voices/apps/voices/lib/app/view/app_mobile_access_restriction.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_mobile_access_restriction.dart
@@ -147,7 +147,6 @@ class _Background extends StatelessWidget {
         ],
         gradient: const RadialGradient(
           center: Alignment(0.2822, -0.3306),
-          radius: 0.5,
           colors: [Color(0x99F9E7FD), Color(0x99F6CEFF)],
           stops: [1.0, 0.0],
         ),
@@ -175,7 +174,6 @@ class _Background extends StatelessWidget {
         ],
         gradient: const RadialGradient(
           center: Alignment(0.2814, -0.3306),
-          radius: 0.5,
           colors: [
             Color.fromRGBO(205, 213, 254, 0.7),
             Color(0x99C6C5FF),

--- a/catalyst_voices/apps/voices/lib/pages/account/delete_keychain_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/delete_keychain_dialog.dart
@@ -39,7 +39,6 @@ class _DeleteKeychainDialogState extends State<DeleteKeychainDialog> {
       child: SizedBox(
         width: double.infinity,
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
           children: [
             const SizedBox(height: 36),
@@ -84,7 +83,6 @@ class _DeleteKeychainDialogState extends State<DeleteKeychainDialog> {
                     decoration: VoicesTextFieldDecoration(
                       errorText: _errorText,
                       errorMaxLines: 2,
-                      filled: true,
                       fillColor: Theme.of(context)
                           .colors
                           .elevationsOnSurfaceNeutralLv1White,

--- a/catalyst_voices/apps/voices/lib/pages/account/widgets/account_username_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/account/widgets/account_username_tile.dart
@@ -32,7 +32,6 @@ class _AccountUsernameTileState extends State<AccountUsernameTile> {
       onChanged: _onEditModeChange,
       isEditMode: _isEditMode,
       isSaveEnabled: _username.isValid,
-      isEditEnabled: true,
       child: VoicesUsernameTextField(
         key: const Key('AccountDisplayNameTextField'),
         controller: _controller,

--- a/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/admin_tools/campaign_admin_tools_dialog.dart
@@ -11,114 +11,6 @@ import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-/// A draggable [CampaignAdminToolsDialog],
-/// should be used as a child of a [Stack].
-///
-/// Initially shown at bottom-left corner with [initialOffset] offset.
-class DraggableCampaignAdminToolsDialog extends StatefulWidget {
-  /// The key for the [CampaignAdminToolsDialog] to make sure it's state
-  /// is kept when a user keeps dragging it.
-  ///
-  /// The state might include currently open tab from [TabBar],
-  /// scroll position, etc.
-  final GlobalKey dialogKey;
-
-  /// See [CampaignAdminToolsDialog.selectedSpace].
-  final Space selectedSpace;
-
-  /// See [CampaignAdminToolsDialog.onSpaceSelected].
-  final ValueChanged<Space> onSpaceSelected;
-
-  /// The initial offset from bottom-left for the dialog.
-  final Offset initialOffset;
-
-  const DraggableCampaignAdminToolsDialog({
-    super.key,
-    required this.dialogKey,
-    required this.selectedSpace,
-    required this.onSpaceSelected,
-    this.initialOffset = const Offset(32, 32),
-  });
-
-  @override
-  State<DraggableCampaignAdminToolsDialog> createState() =>
-      _DraggableCampaignAdminToolsDialogState();
-}
-
-class _DraggableCampaignAdminToolsDialogState
-    extends State<DraggableCampaignAdminToolsDialog> {
-  Offset _position = Offset.infinite;
-  late Size _screenSize;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-
-    _screenSize = MediaQuery.sizeOf(context);
-
-    if (_position.isInfinite) {
-      // initialize it for the first time
-      _position = Offset(
-        widget.initialOffset.dx,
-        _screenSize.height -
-            CampaignAdminToolsDialog._height -
-            widget.initialOffset.dy,
-      );
-    } else {
-      // clamp it so that it fits into the screen
-      // in case user shrinks the app window
-
-      _position = _clampIntoScreenBounds(_position);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final Widget child = CampaignAdminToolsDialog(
-      key: widget.dialogKey,
-      selectedSpace: widget.selectedSpace,
-      onSpaceSelected: widget.onSpaceSelected,
-    );
-
-    return Positioned(
-      left: _position.dx,
-      top: _position.dy,
-      child: Draggable(
-        onDragUpdate: _onDragUpdate,
-        childWhenDragging: const Offstage(),
-        feedback: child,
-        child: child,
-      ),
-    );
-  }
-
-  void _onDragUpdate(DragUpdateDetails details) {
-    final newPosition = _position + details.delta;
-    final clampedPosition = _clampIntoScreenBounds(newPosition);
-
-    if (_position != clampedPosition) {
-      setState(() {
-        _position = clampedPosition;
-      });
-    }
-  }
-
-  /// Makes sure the dialog would fit into a screen window
-  /// even if the window gets shrunk, etc.
-  Offset _clampIntoScreenBounds(Offset offset) {
-    return Offset(
-      offset.dx.clamp(
-        0,
-        _screenSize.width - CampaignAdminToolsDialog._width,
-      ),
-      offset.dy.clamp(
-        0,
-        _screenSize.height - CampaignAdminToolsDialog._height,
-      ),
-    );
-  }
-}
-
 /// The campaign admin tools dialog which supports
 /// mocking different campaign and user states.
 ///
@@ -163,7 +55,6 @@ class CampaignAdminToolsDialog extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: Theme.of(context).colors.onSurfaceNeutral012,
-          width: 1,
         ),
       ),
       child: Material(
@@ -183,74 +74,38 @@ class CampaignAdminToolsDialog extends StatelessWidget {
   }
 }
 
-class _Header extends StatelessWidget {
-  const _Header();
+/// A draggable [CampaignAdminToolsDialog],
+/// should be used as a child of a [Stack].
+///
+/// Initially shown at bottom-left corner with [initialOffset] offset.
+class DraggableCampaignAdminToolsDialog extends StatefulWidget {
+  /// The key for the [CampaignAdminToolsDialog] to make sure it's state
+  /// is kept when a user keeps dragging it.
+  ///
+  /// The state might include currently open tab from [TabBar],
+  /// scroll position, etc.
+  final GlobalKey dialogKey;
+
+  /// See [CampaignAdminToolsDialog.selectedSpace].
+  final Space selectedSpace;
+
+  /// See [CampaignAdminToolsDialog.onSpaceSelected].
+  final ValueChanged<Space> onSpaceSelected;
+
+  /// The initial offset from bottom-left for the dialog.
+  final Offset initialOffset;
+
+  const DraggableCampaignAdminToolsDialog({
+    super.key,
+    required this.dialogKey,
+    required this.selectedSpace,
+    required this.onSpaceSelected,
+    this.initialOffset = const Offset(32, 32),
+  });
 
   @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(24, 12, 12, 12),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              context.l10n.campaignPreviewTitle,
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-          ),
-          XButton(
-            onTap: () => context.read<AdminToolsCubit>().disable(),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _Tabs extends StatelessWidget {
-  const _Tabs();
-
-  @override
-  Widget build(BuildContext context) {
-    return const DefaultTabController(
-      length: 2,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _TabBar(),
-          Expanded(
-            child: TabBarStackView(
-              children: [
-                CampaignAdminToolsEventsTab(),
-                CampaignAdminToolsViewsTab(),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _TabBar extends StatelessWidget {
-  const _TabBar();
-
-  @override
-  Widget build(BuildContext context) {
-    return TabBar(
-      tabAlignment: TabAlignment.fill,
-      indicatorSize: TabBarIndicatorSize.tab,
-      tabs: [
-        Tab(
-          text: context.l10n.campaignPreviewEvents,
-        ),
-        Tab(
-          text: context.l10n.campaignPreviewViews,
-        ),
-      ],
-    );
-  }
+  State<DraggableCampaignAdminToolsDialog> createState() =>
+      _DraggableCampaignAdminToolsDialogState();
 }
 
 class _BlocFooter extends StatelessWidget {
@@ -278,6 +133,80 @@ class _BlocFooter extends StatelessWidget {
         );
       },
     );
+  }
+}
+
+class _DraggableCampaignAdminToolsDialogState
+    extends State<DraggableCampaignAdminToolsDialog> {
+  Offset _position = Offset.infinite;
+  late Size _screenSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final Widget child = CampaignAdminToolsDialog(
+      key: widget.dialogKey,
+      selectedSpace: widget.selectedSpace,
+      onSpaceSelected: widget.onSpaceSelected,
+    );
+
+    return Positioned(
+      left: _position.dx,
+      top: _position.dy,
+      child: Draggable(
+        onDragUpdate: _onDragUpdate,
+        childWhenDragging: const Offstage(),
+        feedback: child,
+        child: child,
+      ),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _screenSize = MediaQuery.sizeOf(context);
+
+    if (_position.isInfinite) {
+      // initialize it for the first time
+      _position = Offset(
+        widget.initialOffset.dx,
+        _screenSize.height -
+            CampaignAdminToolsDialog._height -
+            widget.initialOffset.dy,
+      );
+    } else {
+      // clamp it so that it fits into the screen
+      // in case user shrinks the app window
+
+      _position = _clampIntoScreenBounds(_position);
+    }
+  }
+
+  /// Makes sure the dialog would fit into a screen window
+  /// even if the window gets shrunk, etc.
+  Offset _clampIntoScreenBounds(Offset offset) {
+    return Offset(
+      offset.dx.clamp(
+        0,
+        _screenSize.width - CampaignAdminToolsDialog._width,
+      ),
+      offset.dy.clamp(
+        0,
+        _screenSize.height - CampaignAdminToolsDialog._height,
+      ),
+    );
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    final newPosition = _position + details.delta;
+    final clampedPosition = _clampIntoScreenBounds(newPosition);
+
+    if (_position != clampedPosition) {
+      setState(() {
+        _position = clampedPosition;
+      });
+    }
   }
 }
 
@@ -319,6 +248,30 @@ class _Footer extends StatelessWidget {
   }
 }
 
+class _Header extends StatelessWidget {
+  const _Header();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 12, 12, 12),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              context.l10n.campaignPreviewTitle,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          XButton(
+            onTap: () => context.read<AdminToolsCubit>().disable(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _SpaceItem extends StatelessWidget {
   final Space space;
   final bool isActive;
@@ -339,9 +292,53 @@ class _SpaceItem extends StatelessWidget {
       foregroundColor: isActive
           ? space.foregroundColor(context)
           : Theme.of(context).colors.iconsForeground,
-      padding: const EdgeInsets.all(8),
-      radius: 20,
       onTap: onTap,
+    );
+  }
+}
+
+class _TabBar extends StatelessWidget {
+  const _TabBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return TabBar(
+      tabAlignment: TabAlignment.fill,
+      indicatorSize: TabBarIndicatorSize.tab,
+      tabs: [
+        Tab(
+          text: context.l10n.campaignPreviewEvents,
+        ),
+        Tab(
+          text: context.l10n.campaignPreviewViews,
+        ),
+      ],
+    );
+  }
+}
+
+class _Tabs extends StatelessWidget {
+  const _Tabs();
+
+  @override
+  Widget build(BuildContext context) {
+    return const DefaultTabController(
+      length: 2,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _TabBar(),
+          Expanded(
+            child: TabBarStackView(
+              children: [
+                CampaignAdminToolsEventsTab(),
+                CampaignAdminToolsViewsTab(),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/campaign/details/campaign_details_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/details/campaign_details_dialog.dart
@@ -14,6 +14,9 @@ class CampaignDetailsDialog extends StatefulWidget {
     required this.id,
   });
 
+  @override
+  State<CampaignDetailsDialog> createState() => _CampaignDetailsDialogState();
+
   static Future<void> show(
     BuildContext context, {
     required String id,
@@ -22,22 +25,22 @@ class CampaignDetailsDialog extends StatefulWidget {
       context: context,
       routeSettings: RouteSettings(name: '/campaign/$id'),
       builder: (context) => CampaignDetailsDialog._(id: id),
-      barrierDismissible: true,
     );
   }
-
-  @override
-  State<CampaignDetailsDialog> createState() => _CampaignDetailsDialogState();
 }
 
 class _CampaignDetailsDialogState extends State<CampaignDetailsDialog> {
   late final CampaignDetailsBloc _bloc;
 
   @override
-  void initState() {
-    super.initState();
-    _bloc = Dependencies.instance.get();
-    _bloc.add(LoadCampaignEvent(id: widget.id));
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: _bloc,
+      child: const VoicesDetailsDialog(
+        header: CampaignHeader(),
+        body: CampaignSectionsListView(),
+      ),
+    );
   }
 
   @override
@@ -56,13 +59,9 @@ class _CampaignDetailsDialogState extends State<CampaignDetailsDialog> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: _bloc,
-      child: const VoicesDetailsDialog(
-        header: CampaignHeader(),
-        body: CampaignSectionsListView(),
-      ),
-    );
+  void initState() {
+    super.initState();
+    _bloc = Dependencies.instance.get();
+    _bloc.add(LoadCampaignEvent(id: widget.id));
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/category/change_category_button.dart
+++ b/catalyst_voices/apps/voices/lib/pages/category/change_category_button.dart
@@ -38,13 +38,10 @@ class _ChangeCategoryButtonState extends State<ChangeCategoryButton> {
       builder: (context, state) {
         return CategoryDropdown(
           popupMenuButtonKey: _popupMenuButtonKey,
-          clipBehavior: Clip.hardEdge,
           onSelected: _changeCategory,
           onCanceled: () => _handleClose,
           onOpened: () => _handleOpen,
-          offset: const Offset(0, 40),
           items: state,
-          constraints: const BoxConstraints(maxWidth: 320),
           highlightColor: context.colors.onSurfacePrimary08,
           child: VoicesOutlinedButton(
             onTap: () {

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/how_it_works.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/how_it_works.dart
@@ -4,30 +4,6 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 
-enum HowItWorksItem {
-  collaborate,
-  vote,
-  follow;
-
-  SvgGenImage get icon => switch (this) {
-        HowItWorksItem.collaborate => VoicesAssets.icons.userGroup,
-        HowItWorksItem.vote => VoicesAssets.icons.vote,
-        HowItWorksItem.follow => VoicesAssets.icons.speakerphone,
-      };
-
-  String title(VoicesLocalizations l10n) => switch (this) {
-        HowItWorksItem.collaborate => l10n.howItWorksCollaborate,
-        HowItWorksItem.vote => l10n.howItWorksVote,
-        HowItWorksItem.follow => l10n.howItWorksFollow,
-      };
-
-  String description(VoicesLocalizations l10n) => switch (this) {
-        HowItWorksItem.collaborate => l10n.howItWorksCollaborateDescription,
-        HowItWorksItem.vote => l10n.howItWorksVoteDescription,
-        HowItWorksItem.follow => l10n.howItWorksFollowDescription,
-      };
-}
-
 class HowItWorks extends StatelessWidget {
   const HowItWorks({super.key});
 
@@ -51,7 +27,6 @@ class HowItWorks extends StatelessWidget {
             ),
             const SizedBox(height: 32),
             Wrap(
-              direction: Axis.horizontal,
               runSpacing: 20,
               alignment: WrapAlignment.center,
               children:
@@ -62,6 +37,30 @@ class HowItWorks extends StatelessWidget {
       ),
     );
   }
+}
+
+enum HowItWorksItem {
+  collaborate,
+  vote,
+  follow;
+
+  SvgGenImage get icon => switch (this) {
+        HowItWorksItem.collaborate => VoicesAssets.icons.userGroup,
+        HowItWorksItem.vote => VoicesAssets.icons.vote,
+        HowItWorksItem.follow => VoicesAssets.icons.speakerphone,
+      };
+
+  String description(VoicesLocalizations l10n) => switch (this) {
+        HowItWorksItem.collaborate => l10n.howItWorksCollaborateDescription,
+        HowItWorksItem.vote => l10n.howItWorksVoteDescription,
+        HowItWorksItem.follow => l10n.howItWorksFollowDescription,
+      };
+
+  String title(VoicesLocalizations l10n) => switch (this) {
+        HowItWorksItem.collaborate => l10n.howItWorksCollaborate,
+        HowItWorksItem.vote => l10n.howItWorksVote,
+        HowItWorksItem.follow => l10n.howItWorksFollow,
+      };
 }
 
 class _Item extends StatelessWidget {

--- a/catalyst_voices/apps/voices/lib/pages/overall_spaces/brands_navigation.dart
+++ b/catalyst_voices/apps/voices/lib/pages/overall_spaces/brands_navigation.dart
@@ -21,7 +21,6 @@ class BrandsNavigation extends StatelessWidget {
       ),
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Column(
-        mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ...Brand.values.map(

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_segments_navigation.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_segments_navigation.dart
@@ -77,7 +77,6 @@ class _SegmentMenuTile extends StatelessWidget {
 
         SegmentsControllerScope.of(context).selectSectionStep(section.id);
       },
-      selectedItemId: null,
       isExpanded: isExpanded,
       items: segment.sections.map(
         (section) {

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_loading.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_loading.dart
@@ -34,7 +34,7 @@ class _ProposalBuilderLoading extends StatelessWidget {
         SizedBox(height: 12),
         _SectionHeaderPlaceholder(isOpen: true),
         SizedBox(height: 12),
-        _SectionPlaceholder(blocks: 1),
+        _SectionPlaceholder(),
         SizedBox(height: 12),
         _SectionPlaceholder(blocks: 3),
         SizedBox(height: 24),

--- a/catalyst_voices/apps/voices/lib/pages/registration/no_wallet_found_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/no_wallet_found_dialog.dart
@@ -50,7 +50,6 @@ class SupportedWallet extends StatelessWidget with LaunchUrlMixin {
         vertical: 12,
       ),
       child: Row(
-        mainAxisSize: MainAxisSize.max,
         children: [
           CatalystImage.asset(image.path),
           const SizedBox(width: 16),

--- a/catalyst_voices/apps/voices/lib/pages/registration/pictures/seed_phrase_picture.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/pictures/seed_phrase_picture.dart
@@ -2,9 +2,9 @@ import 'package:catalyst_voices/pages/registration/pictures/task_picture.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:flutter/material.dart';
 
-const _wordsPerColumnCount = 6;
-const _firstHighlightIndex = [0];
 const _allHighlightIndex = [0, 1, 2, 3, 4, 5];
+const _firstHighlightIndex = [0];
+const _wordsPerColumnCount = 6;
 
 class SeedPhrasePicture extends StatelessWidget {
   final bool indicateSelection;
@@ -47,14 +47,39 @@ class SeedPhrasePicture extends StatelessWidget {
   }
 }
 
+class _Word extends StatelessWidget {
+  final bool isSelected;
+  final TaskPictureType type;
+
+  const _Word({
+    this.isSelected = false,
+    required this.type,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = type.foregroundColor(theme, isHighlight: isSelected);
+
+    return AnimatedContainer(
+      height: 6.72,
+      duration: const Duration(milliseconds: 200),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(1.12),
+      ),
+    );
+  }
+}
+
 class _Words extends StatelessWidget {
+  final bool indicateSelection;
+
+  final TaskPictureType type;
   const _Words({
     required this.indicateSelection,
     required this.type,
   });
-
-  final bool indicateSelection;
-  final TaskPictureType type;
 
   @override
   Widget build(BuildContext context) {
@@ -72,7 +97,6 @@ class _Words extends StatelessWidget {
               TaskPictureType.error =>
                 _allHighlightIndex,
             },
-            count: _wordsPerColumnCount,
             type: type,
           ),
         ),
@@ -86,7 +110,6 @@ class _Words extends StatelessWidget {
               TaskPictureType.error =>
                 _allHighlightIndex,
             },
-            count: _wordsPerColumnCount,
             type: type,
           ),
         ),
@@ -110,7 +133,6 @@ class _WordsColumn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
-      mainAxisSize: MainAxisSize.max,
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: List.generate(
         count,
@@ -120,31 +142,6 @@ class _WordsColumn extends StatelessWidget {
             type: type,
           );
         },
-      ),
-    );
-  }
-}
-
-class _Word extends StatelessWidget {
-  final bool isSelected;
-  final TaskPictureType type;
-
-  const _Word({
-    this.isSelected = false,
-    required this.type,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final color = type.foregroundColor(theme, isHighlight: isSelected);
-
-    return AnimatedContainer(
-      height: 6.72,
-      duration: const Duration(milliseconds: 200),
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(1.12),
       ),
     );
   }

--- a/catalyst_voices/apps/voices/lib/pages/registration/pictures/seed_phrase_picture.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/pictures/seed_phrase_picture.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 
 const _allHighlightIndex = [0, 1, 2, 3, 4, 5];
 const _firstHighlightIndex = [0];
-const _wordsPerColumnCount = 6;
 
 class SeedPhrasePicture extends StatelessWidget {
   final bool indicateSelection;
@@ -119,14 +118,14 @@ class _Words extends StatelessWidget {
 }
 
 class _WordsColumn extends StatelessWidget {
+  static const int _count = 6;
+
   final List<int> highlightIndexes;
-  final int count;
   final TaskPictureType type;
 
   const _WordsColumn({
     super.key,
     this.highlightIndexes = const [],
-    this.count = 6,
     required this.type,
   });
 
@@ -135,7 +134,7 @@ class _WordsColumn extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: List.generate(
-        count,
+        _count,
         (index) {
           return _Word(
             isSelected: highlightIndexes.contains(index),

--- a/catalyst_voices/apps/voices/lib/pages/registration/widgets/registration_confirm_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/widgets/registration_confirm_dialog.dart
@@ -72,11 +72,9 @@ class RegistrationConfirmDialog extends StatelessWidget {
       actions: [
         VoicesQuestionActionItem.positive(
           positiveText,
-          type: VoicesQuestionActionType.filled,
         ),
         VoicesQuestionActionItem.negative(
           negativeText,
-          type: VoicesQuestionActionType.text,
         ),
       ],
     );

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_avatar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_avatar.dart
@@ -17,7 +17,6 @@ class SessionAccountAvatar extends StatelessWidget {
       builder: (context, state) {
         return ProfileAvatar(
           key: const Key('ProfileAvatar'),
-          size: 40,
           username: state,
           onTap: onTap,
         );

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_popup_menu.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/account_popup/session_account_popup_menu.dart
@@ -267,7 +267,6 @@ class _SessionAccountPopupMenuState extends State<SessionAccountPopupMenu>
     // didChangeDependencies() method.
     return PopupMenuButton<_MenuItemEvent>(
       key: _popupMenuButtonKey,
-      initialValue: null,
       onSelected: _handleEvent,
       itemBuilder: (context) => const [_PopupMenuItem()],
       tooltip: context.l10n.accountMenuPopupTooltip,

--- a/catalyst_voices/apps/voices/lib/pages/workspace/header/workspace_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/header/workspace_header.dart
@@ -123,7 +123,6 @@ class _WorkspaceHeaderState extends State<WorkspaceHeader> {
           ),
           const SizedBox(height: 8),
           Row(
-            mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(

--- a/catalyst_voices/apps/voices/lib/widgets/cards/campaign_stage_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/campaign_stage_card.dart
@@ -111,7 +111,6 @@ class _CampaignDateInformation extends StatelessWidget {
       children: [
         const SizedBox(height: 30),
         Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             VoicesAssets.icons.calendar.buildIcon(),
             const SizedBox(width: 8),

--- a/catalyst_voices/apps/voices/lib/widgets/cards/comment_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/comment_card.dart
@@ -21,7 +21,6 @@ class CommentCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: Theme.of(context).colorScheme.outline.withValues(alpha: .38),
-          width: 1,
         ),
       ),
       child: Padding(

--- a/catalyst_voices/apps/voices/lib/widgets/cards/funds_detail_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/funds_detail_card.dart
@@ -169,7 +169,6 @@ class _RangeAsk extends StatelessWidget {
         border: Border(
           left: BorderSide(
             color: context.colors.outlineBorder,
-            width: 1,
           ),
         ),
       ),
@@ -210,7 +209,6 @@ class _RangeValue extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.start,
       children: [
         Skeleton.keep(
           child: Text(

--- a/catalyst_voices/apps/voices/lib/widgets/cards/proposal/pending_proposal_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/proposal/pending_proposal_card.dart
@@ -157,7 +157,6 @@ class _PendingProposalCardState extends State<PendingProposalCard> {
         child: InkWell(
           statesController: _statesController,
           onTap: widget.onTap,
-          canRequestFocus: true,
           highlightColor: Colors.transparent,
           borderRadius: BorderRadius.circular(12),
           child: ProposalBorder(
@@ -235,7 +234,6 @@ class _PropertyValue extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.start,
       children: [
         Text(
           key: const Key('Title'),

--- a/catalyst_voices/apps/voices/lib/widgets/cards/proposal/workspace_proposal_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/proposal/workspace_proposal_card.dart
@@ -163,7 +163,6 @@ class _CampaignData extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisAlignment: MainAxisAlignment.start,
       children: [
         Text(
           leadValue,

--- a/catalyst_voices/apps/voices/lib/widgets/cards/role_chooser_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/role_chooser_card.dart
@@ -58,7 +58,6 @@ class RoleChooserCard extends StatelessWidget {
           : BoxDecoration(
               border: Border.all(
                 color: Theme.of(context).colors.outlineBorderVariant,
-                width: 1,
               ),
               borderRadius: BorderRadius.circular(8),
             ),

--- a/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_builder.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_builder.dart
@@ -173,7 +173,6 @@ class _SessionAccountAvatar extends StatelessWidget {
     );
     return ProfileAvatar(
       username: username,
-      size: 40,
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_card.dart
@@ -27,7 +27,6 @@ class ProposalCommentCard extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         ProfileAvatar(
-          size: 40,
           username: authorId.username,
         ),
         const SizedBox(width: 16),
@@ -80,7 +79,6 @@ class _Header extends StatelessWidget {
 
     return Row(
       spacing: 8,
-      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Expanded(
           child: Wrap(

--- a/catalyst_voices/apps/voices/lib/widgets/containers/sidebar/space_side_panel.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/containers/sidebar/space_side_panel.dart
@@ -139,7 +139,6 @@ class _SpaceSidePanelState extends State<SpaceSidePanel>
               child: DefaultTabController(
                 length: widget.tabs.length,
                 child: Column(
-                  mainAxisSize: MainAxisSize.max,
                   children: [
                     _Header(
                       onCollapseTap: () {

--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/value/simple_text_entry_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/value/simple_text_entry_widget.dart
@@ -64,7 +64,6 @@ class _SimpleTextEntryWidgetState extends State<SimpleTextEntryWidget> {
           ),
           enabled: widget.isEditMode,
           resizableVertically: false,
-          resizableHorizontally: false,
           maxLengthEnforcement: MaxLengthEnforcement.none,
           maxLines: _resizable ? null : 1,
           maxLength: _maxLength,

--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/value/single_grouped_tag_selector_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/value/single_grouped_tag_selector_widget.dart
@@ -166,7 +166,6 @@ class _TagChipGroup extends StatelessWidget {
           key: ObjectKey(tag),
           name: tag,
           isSelected: isSelected,
-          isEnabled: true,
           onTap: () => isSelected ? onChanged(null) : onChanged(tag),
         );
       }).toList(),

--- a/catalyst_voices/apps/voices/lib/widgets/dropdown/voices_dropdown.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/dropdown/voices_dropdown.dart
@@ -34,7 +34,6 @@ class FilterByDropdown<T> extends StatelessWidget {
       initialSelection: value,
       enableSearch: false,
       requestFocusOnTap: false,
-      enableFilter: false,
       inputDecorationTheme: const InputDecorationTheme(
         isDense: true,
         contentPadding: EdgeInsets.zero,

--- a/catalyst_voices/apps/voices/lib/widgets/headers/segment_header.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/headers/segment_header.dart
@@ -61,8 +61,6 @@ class SegmentHeader extends StatelessWidget {
               ),
               padding: padding,
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
                   if (leading != null) leading!,
                   Expanded(child: Text(name)),

--- a/catalyst_voices/apps/voices/lib/widgets/indicators/voices_indicator.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/indicators/voices_indicator.dart
@@ -2,20 +2,6 @@ import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 
-enum VoicesIndicatorType {
-  normal,
-  error,
-  success;
-
-  Color _iconColor(BuildContext context) {
-    return switch (this) {
-      VoicesIndicatorType.normal => Theme.of(context).colors.iconsForeground,
-      VoicesIndicatorType.error => Theme.of(context).colors.iconsError,
-      VoicesIndicatorType.success => Theme.of(context).colors.iconsSuccess,
-    };
-  }
-}
-
 class VoicesIndicator extends StatelessWidget {
   final VoicesIndicatorType type;
   final SvgGenImage icon;
@@ -39,7 +25,6 @@ class VoicesIndicator extends StatelessWidget {
       decoration: BoxDecoration(
         border: Border.all(
           color: theme.colors.outlineBorderVariant,
-          width: 1,
         ),
         borderRadius: BorderRadius.circular(8),
       ),
@@ -69,5 +54,19 @@ class VoicesIndicator extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+enum VoicesIndicatorType {
+  normal,
+  error,
+  success;
+
+  Color _iconColor(BuildContext context) {
+    return switch (this) {
+      VoicesIndicatorType.normal => Theme.of(context).colors.iconsForeground,
+      VoicesIndicatorType.error => Theme.of(context).colors.iconsError,
+      VoicesIndicatorType.success => Theme.of(context).colors.iconsSuccess,
+    };
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/menu/voices_node_menu_placeholder.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/menu/voices_node_menu_placeholder.dart
@@ -20,7 +20,7 @@ class VoicesNodeMenuPlaceholder extends StatelessWidget {
       root: SimpleTreeViewRootRow(
         leading: [
           VoicesNodeMenuIcon(isOpen: isExpanded),
-          const _Placeholder(width: 16, height: 16),
+          const _Placeholder(width: 16),
         ],
         child: const _Placeholder(),
       ),

--- a/catalyst_voices/apps/voices/lib/widgets/menu/voices_node_menu_placeholder.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/menu/voices_node_menu_placeholder.dart
@@ -43,12 +43,10 @@ class VoicesNodeMenuPlaceholder extends StatelessWidget {
 
 class _Placeholder extends StatelessWidget {
   final double width;
-  final double height;
   final Color? color;
 
   const _Placeholder({
     this.width = 110,
-    this.height = 16,
     this.color,
   });
 
@@ -56,7 +54,7 @@ class _Placeholder extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: width,
-      height: height,
+      height: 16,
       decoration: BoxDecoration(
         color: color ?? Theme.of(context).colorScheme.primary,
         borderRadius: BorderRadius.circular(4),

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/forget_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/forget_proposal_dialog.dart
@@ -67,7 +67,7 @@ class _ActionButtons extends StatelessWidget {
           const Spacer(),
           VoicesTextButton(
             onTap: () {
-              Navigator.of(context).pop(null);
+              Navigator.of(context).pop();
             },
             child: Text(
               context.l10n.cancelButtonText,

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/proposal_builder_delete_confirmation_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/proposal_builder_delete_confirmation_dialog.dart
@@ -19,11 +19,9 @@ class ProposalBuilderDeleteConfirmationDialog extends StatelessWidget {
       actions: [
         VoicesQuestionActionItem.positive(
           context.l10n.proposalEditorDeleteDialogDeleteButton,
-          type: VoicesQuestionActionType.filled,
         ),
         VoicesQuestionActionItem.negative(
           context.l10n.cancelButtonText,
-          type: VoicesQuestionActionType.text,
         ),
       ],
     );

--- a/catalyst_voices/apps/voices/lib/widgets/modals/voices_info_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/voices_info_dialog.dart
@@ -60,7 +60,6 @@ class VoicesDesktopInfoDialog extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 83),
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             const SizedBox(height: 36),
             IconTheme(

--- a/catalyst_voices/apps/voices/lib/widgets/pagination/layouts/paginated_grid_view.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/pagination/layouts/paginated_grid_view.dart
@@ -56,9 +56,6 @@ class PaginatedGridView<ItemType> extends StatelessWidget {
                 key: const Key('PaginatedGridView'),
                 spacing: 16,
                 runSpacing: 16,
-                alignment: WrapAlignment.start,
-                crossAxisAlignment: WrapCrossAlignment.start,
-                runAlignment: WrapAlignment.start,
                 children: pagingState.itemList
                     .map((item) => _itemBuilder(context, item))
                     .toList(),

--- a/catalyst_voices/apps/voices/lib/widgets/painter/bubble_painter.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/painter/bubble_painter.dart
@@ -96,7 +96,6 @@ class BubblePainter extends CustomPainter {
       ..shader = RadialGradient(
         colors: bubble.gradientColors,
         stops: bubble.gradientStops,
-        center: Alignment.center,
         radius: 0.8,
       ).createShader(rect)
       ..blendMode = BlendMode.softLight;

--- a/catalyst_voices/apps/voices/lib/widgets/search/search_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/search/search_text_field.dart
@@ -53,7 +53,6 @@ class _SearchTextFieldState extends State<SearchTextField> {
           prefixIcon: VoicesAssets.icons.search.buildIcon(
             color: Theme.of(context).colors.iconsForeground,
           ),
-          filled: true,
           fillColor: Theme.of(context).colorScheme.surface,
           suffixIcon: ValueListenableBuilder<TextEditingValue>(
             valueListenable: _controller,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/seed_phrase_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/seed_phrase_field.dart
@@ -175,8 +175,6 @@ class _SeedPhraseFieldState extends State<SeedPhraseField> {
                           key: ValueKey('Word${element.nr}CellKey'),
                           nr: element.nr,
                           data: element.data,
-                          // disabled always for now.
-                          onDeleteTap: null,
                         );
                       },
                     ),

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/seed_phrase_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/seed_phrase_field.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:catalyst_voices/widgets/buttons/voices_buttons.dart';
 import 'package:catalyst_voices/widgets/scrollbar/voices_scrollbar.dart';
 import 'package:catalyst_voices/widgets/text_field/voices_autocomplete.dart';
 import 'package:catalyst_voices/widgets/text_field/voices_text_field.dart';
@@ -260,13 +259,11 @@ class _SeedPhraseFieldState extends State<SeedPhraseField> {
 class _WordCell extends StatelessWidget {
   final int nr;
   final String data;
-  final VoidCallback? onDeleteTap;
 
   const _WordCell({
     super.key,
     required this.nr,
     required this.data,
-    this.onDeleteTap,
   });
 
   @override
@@ -289,10 +286,7 @@ class _WordCell extends StatelessWidget {
             Text('${nr.toString().padLeft(2, '0')}.'),
             const SizedBox(width: 6),
             Text(data),
-            if (onDeleteTap != null)
-              XButton(onTap: onDeleteTap)
-            else
-              const SizedBox(width: 16),
+            const SizedBox(width: 16),
           ],
         ),
       ),

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/token_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/token_field.dart
@@ -52,7 +52,6 @@ class TokenField extends StatelessWidget {
         errorText: errorText,
         prefixText: currency.symbol,
         hintText: range != null ? '${range.min}' : null,
-        filled: true,
         helper: range != null && showHelper
             ? _Helper(
                 currency: currency,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_autocomplete.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_autocomplete.dart
@@ -54,7 +54,6 @@ class VoicesAutocomplete<T extends Object> extends StatelessWidget {
         return VoicesTextField(
           controller: textEditingController,
           focusNode: focusNode,
-          maxLines: 1,
           onFieldSubmitted: (value) {
             onFieldSubmitted();
           },

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_date_time_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_date_time_field.dart
@@ -243,11 +243,6 @@ class _VoicesDateTimeFieldState extends State<VoicesDateTimeField> {
                 },
                 behavior: HitTestBehavior.translucent,
                 excludeFromSemantics: true,
-                onPanUpdate: null,
-                onPanDown: null,
-                onPanCancel: null,
-                onPanEnd: null,
-                onPanStart: null,
                 child: Container(
                   color: Colors.transparent,
                 ),

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_date_time_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_date_time_text_field.dart
@@ -55,7 +55,6 @@ class VoicesDateTimeTextField extends StatelessWidget {
         suffixIcon: ExcludeFocus(child: suffixIcon),
         showStatusSuffixIcon: false,
         fillColor: theme.colors.elevationsOnSurfaceNeutralLv1Grey,
-        filled: true,
         enabledBorder: OutlineInputBorder(
           borderSide: borderSide,
           borderRadius: borderRadius,

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_https_text_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_https_text_field.dart
@@ -82,12 +82,10 @@ class _VoicesHttpsTextFieldState extends State<VoicesHttpsTextField>
             ),
           ),
           fillColor: Theme.of(context).colors.onSurfaceNeutralOpaqueLv1,
-          filled: true,
         ),
         style: _getTextStyle(context),
         enabled: widget.enabled,
         readOnly: !widget.enabled,
-        autovalidateMode: AutovalidateMode.onUserInteraction,
         mouseCursor: widget.enabled ? null : SystemMouseCursors.click,
       ),
     );

--- a/catalyst_voices/apps/voices/lib/widgets/text_field/voices_num_field.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text_field/voices_num_field.dart
@@ -113,7 +113,6 @@ class _VoicesNumFieldState<T extends num> extends State<VoicesNumField<T>> {
       controller: _textEditingController,
       statesController: widget.statesController,
       focusNode: widget.focusNode,
-      maxLines: 1,
       maxLength: widget.maxLength,
       decoration: widget.decoration,
       keyboardType: widget.keyboardType,

--- a/catalyst_voices/apps/voices/lib/widgets/tiles/base_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/tiles/base_tile.dart
@@ -36,7 +36,6 @@ class _BaseTileState extends State<BaseTile> {
     final borderRadius = WidgetStateProperty.fromMap(
       <WidgetStatesConstraint, BorderRadius>{
         selectedOrError: const BorderRadius.horizontal(
-          left: Radius.zero,
           right: _borderRadius,
         ),
         WidgetState.any: const BorderRadius.all(_borderRadius),

--- a/catalyst_voices/apps/voices/lib/widgets/tiles/menu_segments_item_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/tiles/menu_segments_item_tile.dart
@@ -43,8 +43,6 @@ class MenuSegmentsItemTile<T extends Object> extends StatelessWidget {
                     onChanged(value.single);
                   }
                 : null,
-            multiSelectionEnabled: false,
-            emptySelectionAllowed: false,
             showSelectedIcon: false,
           ),
         ],

--- a/catalyst_voices/apps/voices/lib/widgets/tiles/voices_nav_tile.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/tiles/voices_nav_tile.dart
@@ -60,7 +60,6 @@ class VoicesNavTile extends StatelessWidget {
               child: Padding(
                 padding: const EdgeInsets.only(left: 16),
                 child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     if (leading != null) leading!,
                     Expanded(

--- a/catalyst_voices/apps/voices/lib/widgets/tooltips/voices_markdown_tooltip.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/tooltips/voices_markdown_tooltip.dart
@@ -86,7 +86,6 @@ class VoicesMarkdownTooltip extends StatelessWidget {
           BoxShadow(
             offset: Offset(0, 1),
             blurRadius: 2,
-            spreadRadius: 0,
             color: Color(0x4D000000),
           ),
         ],

--- a/catalyst_voices/apps/voices/test/common/formatters/date_formatter_test.dart
+++ b/catalyst_voices/apps/voices/test/common/formatters/date_formatter_test.dart
@@ -201,8 +201,7 @@ void main() {
 
     test('should format date without year when includeYear is false', () {
       final date = DateTime(2023, 10, 25, 14, 30); // 25th October 2023, 14:30
-      final result =
-          DateFormatter.formatDateTimeParts(date, includeYear: false);
+      final result = DateFormatter.formatDateTimeParts(date);
 
       expect(result.date, '25 October');
       expect(result.time, '14:30');

--- a/catalyst_voices/apps/voices/test/widgets/cards/campaign_stage_card_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/cards/campaign_stage_card_test.dart
@@ -13,32 +13,32 @@ void main() {
   final draftCampaignTest = CampaignInfo(
     id: 'campaign_draft',
     stage: CampaignStage.draft,
-    startDate: DateTime(2024, 11, 19, 13, 00, 00),
-    endDate: DateTime(2024, 11, 20, 13, 00, 00),
+    startDate: DateTime(2024, 11, 19, 13),
+    endDate: DateTime(2024, 11, 20, 13),
     description: 'Draft Campaign Test',
   );
 
   final scheduledCampaignTest = CampaignInfo(
     id: 'campaign_scheduled',
     stage: CampaignStage.scheduled,
-    startDate: DateTime(2024, 11, 19, 13, 00, 00),
-    endDate: DateTime(2024, 11, 20, 13, 00, 00),
+    startDate: DateTime(2024, 11, 19, 13),
+    endDate: DateTime(2024, 11, 20, 13),
     description: 'Scheduled Campaign Test',
   );
 
   final liveCampaignTest = CampaignInfo(
     id: 'campaign_live',
     stage: CampaignStage.live,
-    startDate: DateTime(2024, 11, 19, 13, 00, 00),
-    endDate: DateTime(2024, 11, 20, 13, 00, 00),
+    startDate: DateTime(2024, 11, 19, 13),
+    endDate: DateTime(2024, 11, 20, 13),
     description: 'Live Campaign Test',
   );
 
   final completedCampaignText = CampaignInfo(
     id: 'campaign_completed',
     stage: CampaignStage.completed,
-    startDate: DateTime(2024, 11, 19, 13, 00, 00),
-    endDate: DateTime(2024, 11, 20, 13, 00, 00),
+    startDate: DateTime(2024, 11, 19, 13),
+    endDate: DateTime(2024, 11, 20, 13),
     description: 'Completed Campaign Test',
   );
 

--- a/catalyst_voices/apps/voices/test/widgets/cards/small_proposal_card_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/cards/small_proposal_card_test.dart
@@ -100,7 +100,7 @@ void main() {
 
     testWidgets('hides new iteration details when showLatestLocal is false',
         (tester) async {
-      await pumpCard(tester, showLatestLocal: false);
+      await pumpCard(tester);
       await tester.pumpAndSettle();
 
       expect(

--- a/catalyst_voices/apps/voices/test/widgets/common/infrastructure/voices_result_builder_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/common/infrastructure/voices_result_builder_test.dart
@@ -16,7 +16,6 @@ void main() {
       // Arrange: Provide a loading builder
       await tester.pumpApp(
         ResultBuilder<String, String>(
-          result: null,
           successBuilder: (context, data) => Text('Success: $data'),
           failureBuilder: (context, data) => Text('Failure: $data'),
           loadingBuilder: (context) => const CircularProgressIndicator(),
@@ -74,8 +73,6 @@ void main() {
 
       await tester.pumpApp(
         ResultBuilder<String, String>(
-          result: null,
-          minLoadingDuration: minLoadingDuration,
           successBuilder: (context, data) => Text('Success: $data'),
           failureBuilder: (context, data) => Text('Failure: $data'),
           loadingBuilder: (context) => const CircularProgressIndicator(),
@@ -94,7 +91,6 @@ void main() {
       await tester.pumpApp(
         ResultBuilder<String, String>(
           result: Success('Test Success'),
-          minLoadingDuration: minLoadingDuration,
           successBuilder: (context, data) => Text('Success: $data'),
           failureBuilder: (context, data) => Text('Failure: $data'),
           loadingBuilder: (context) => const CircularProgressIndicator(),
@@ -118,7 +114,6 @@ void main() {
           builder: (context, snapshot) {
             return ResultBuilder<String, String>(
               result: snapshot.data,
-              minLoadingDuration: minLoadingDuration,
               successBuilder: (context, data) => Text('Success: $data'),
               failureBuilder: (context, data) => Text('Failure: $data'),
               loadingBuilder: (context) => const CircularProgressIndicator(),
@@ -145,7 +140,7 @@ void main() {
 
       // Now simulate passing the minLoadingDuration,
       // 100ms remaining at this point
-      await tester.pumpAndSettle(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
 
       // Verify that after the full duration, success is displayed
       expect(find.text('Success: Test Success'), findsOneWidget);
@@ -161,7 +156,6 @@ void main() {
         StatefulBuilder(
           builder: (context, setState) {
             return ResultBuilder<String, String>(
-              result: null,
               successBuilder: (context, data) =>
                   Text('Success: $data', key: successWidgetKey),
               failureBuilder: (context, data) =>

--- a/catalyst_voices/apps/voices/test/widgets/common/label_decorator_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/common/label_decorator_test.dart
@@ -13,7 +13,7 @@ void main() {
           fontSize: 24,
           color: Colors.red,
         );
-        const colors = VoicesColorScheme.optional(textPrimary: Colors.black);
+        const colors = VoicesColorScheme.optional();
         final widget = Directionality(
           textDirection: TextDirection.ltr,
           child: Theme(
@@ -57,7 +57,7 @@ void main() {
           fontSize: 12,
           color: Colors.red,
         );
-        const colors = VoicesColorScheme.optional(textPrimary: Colors.black);
+        const colors = VoicesColorScheme.optional();
         final widget = Directionality(
           textDirection: TextDirection.ltr,
           child: Theme(

--- a/catalyst_voices/apps/voices/test/widgets/rich_text/voices_rich_text_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/rich_text/voices_rich_text_test.dart
@@ -14,7 +14,6 @@ void main() {
           document: Document(),
           selection: const TextSelection.collapsed(offset: 0),
         ),
-        enabled: true,
         focusNode: FocusNode(),
         scrollController: ScrollController(),
         onChanged: (_) {},

--- a/catalyst_voices/apps/voices/test/widgets/search/search_text_field_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/search/search_text_field_test.dart
@@ -213,7 +213,6 @@ void main() {
         Material(
           child: SearchTextField(
             hintText: 'Search...',
-            showClearButton: false,
             onSearch: ({
               required String searchValue,
               required bool isSubmitted,

--- a/catalyst_voices/apps/voices/test/widgets/text_field/voices_text_field_test.dart
+++ b/catalyst_voices/apps/voices/test/widgets/text_field/voices_text_field_test.dart
@@ -261,7 +261,7 @@ class _MaterialApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeBuilder.buildTheme(brand: Brand.catalyst),
+      theme: ThemeBuilder.buildTheme(),
       home: Scaffold(body: child),
     );
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/account/account_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/account/account_cubit.dart
@@ -138,8 +138,6 @@ final class AccountCubit extends Cubit<AccountState>
         .toList();
 
     return AccountState(
-      // Note. account status is not supported for f14.
-      status: const None(),
       catalystId: catalystId,
       username: Username.pure(catalystId?.username ?? ''),
       email: Email.pure(from?.email ?? ''),

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/discovery/discovery_cubit.dart
@@ -91,7 +91,6 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
           campaign: DiscoveryCurrentCampaignState(
             currentCampaign: currentCampaign,
             campaignTimeline: campaignTimeline,
-            error: null,
             isLoading: false,
           ),
         ),
@@ -188,7 +187,6 @@ class DiscoveryCubit extends Cubit<DiscoveryState> with BlocErrorEmitterMixin {
       state.copyWith(
         proposals: state.proposals.copyWith(
           isLoading: false,
-          error: null,
           proposals: proposalList,
         ),
       ),

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/document/document_to_segment_mixin.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/document/document_to_segment_mixin.dart
@@ -23,8 +23,6 @@ mixin DocumentToSegmentMixin {
           id: section.schema.nodeId,
           property: section,
           schema: section.schema,
-          isEnabled: true,
-          isEditable: true,
           hasError:
               showValidationErrors && !section.isValidExcludingSubsections,
         );

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/proposal_builder_bloc.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/proposal_builder_bloc.dart
@@ -572,8 +572,6 @@ final class ProposalBuilderBloc
               id: section.schema.nodeId,
               property: section,
               schema: section.schema,
-              isEnabled: true,
-              isEditable: true,
               hasError:
                   showValidationErrors && !section.isValidExcludingSubsections,
             ),

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/proposal_builder_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/proposal_builder_state.dart
@@ -27,11 +27,9 @@ final class ProposalBuilderMetadata extends Equatable {
   }) {
     final firstRef = DraftRef.generateFirstRef();
     return ProposalBuilderMetadata(
-      publish: ProposalPublish.localDraft,
       documentRef: firstRef,
       templateRef: templateRef,
       categoryId: categoryId,
-      versions: const [],
     );
   }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/unlock_password_manager.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/unlock_password_manager.dart
@@ -1,32 +1,22 @@
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
-import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 
 abstract interface class UnlockPasswordManager {
-  void setPassword(String value);
-
   void setConfirmPassword(String value);
+
+  void setPassword(String value);
 }
 
 mixin UnlockPasswordMixin implements UnlockPasswordManager {
-  UnlockPassword get password => _state.password;
-
   UnlockPasswordState _state = const UnlockPasswordState();
+
+  UnlockPassword get password => _state.password;
 
   void onUnlockPasswordStateChanged(UnlockPasswordState data);
 
   void recoverPassword(String value) {
     setPassword(value);
     setConfirmPassword(value);
-  }
-
-  @override
-  void setPassword(String value) {
-    final password = UnlockPassword.dirty(value);
-
-    if (_state.password != password) {
-      _updateState(password: password);
-    }
   }
 
   @override
@@ -38,14 +28,21 @@ mixin UnlockPasswordMixin implements UnlockPasswordManager {
     }
   }
 
+  @override
+  void setPassword(String value) {
+    final password = UnlockPassword.dirty(value);
+
+    if (_state.password != password) {
+      _updateState(password: password);
+    }
+  }
+
   void _updateState({
     UnlockPassword? password,
     UnlockPassword? confirmPassword,
   }) {
     password ??= _state.password;
     confirmPassword ??= _state.confirmPassword;
-
-    const minimumLength = PasswordStrength.minimumLength;
 
     final passwordStrength = password.strength();
     final isPasswordValid = password.isValid;
@@ -58,7 +55,6 @@ mixin UnlockPasswordMixin implements UnlockPasswordManager {
       confirmPassword: confirmPassword,
       passwordStrength: passwordStrength,
       showPasswordStrength: password.value.isNotEmpty,
-      minPasswordLength: minimumLength,
       showPasswordMisMatch: isPasswordValid && hasConfirmPassword && !matching,
       isNextEnabled: isPasswordValid && matching,
     );

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/wallet_link_cubit.dart
@@ -88,7 +88,6 @@ final class WalletLinkCubit extends Cubit<WalletLinkStateData>
       final walletConnection = WalletConnectionData(
         name: walletInfo.metadata.name,
         icon: walletInfo.metadata.icon,
-        isConnected: true,
       );
       final walletSummary = WalletSummaryData(
         walletName: walletInfo.metadata.name,

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/session/session_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/session/session_cubit.dart
@@ -172,16 +172,13 @@ final class SessionCubit extends Cubit<SessionState>
           overallSpaces: Space.values,
           spacesShortcuts: AccessControl.allSpacesShortcutsActivators,
           canCreateAccount: true,
-          settings: const SessionSettings.fallback(),
         );
       case SessionStatus.guest:
         return const SessionState.guest(
           canCreateAccount: true,
-          settings: SessionSettings.fallback(),
         );
       case SessionStatus.visitor:
         return const SessionState.visitor(
-          settings: SessionSettings.fallback(),
           isRegistrationInProgress: false,
           canCreateAccount: true,
         );

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/test/session/session_cubit_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/test/session/session_cubit_test.dart
@@ -227,8 +227,6 @@ void main() {
       adminToolsCubit.emit(
         const AdminToolsState(
           enabled: true,
-          campaignStage: CampaignStage.scheduled,
-          sessionStatus: SessionStatus.actor,
         ),
       );
 

--- a/catalyst_voices/packages/internal/catalyst_voices_brands/lib/src/themes/widgets/voices_input_decoration_theme.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_brands/lib/src/themes/widgets/voices_input_decoration_theme.dart
@@ -32,7 +32,6 @@ class VoicesInputDecorationTheme extends InputDecorationTheme {
       return OutlineInputBorder(
         borderSide: BorderSide(
           color: colors.outlineBorder,
-          width: 1,
         ),
         borderRadius: BorderRadius.circular(4),
       );
@@ -61,7 +60,6 @@ class VoicesInputDecorationTheme extends InputDecorationTheme {
     return OutlineInputBorder(
       borderSide: BorderSide(
         color: colors.outlineBorderVariant,
-        width: 1,
       ),
       borderRadius: BorderRadius.circular(4),
     );

--- a/catalyst_voices/packages/internal/catalyst_voices_brands/test/src/catalyst_voices_brands_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_brands/test/src/catalyst_voices_brands_test.dart
@@ -40,7 +40,6 @@ void main() {
               ),
               theme: ThemeBuilder.buildTheme(
                 brand: state.brand,
-                brightness: Brightness.light,
               ),
               darkTheme: ThemeBuilder.buildTheme(
                 brand: state.brand,

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/blockchain/blockchain_slot_config.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/blockchain/blockchain_slot_config.dart
@@ -35,7 +35,7 @@ final class BlockchainSlotNumberConfig extends Equatable {
   /// The [NetworkId.testnet] configuration.
   factory BlockchainSlotNumberConfig.testnet() {
     return BlockchainSlotNumberConfig(
-      systemStartTimestamp: DateTime.utc(2022, 6, 21, 0, 0, 0),
+      systemStartTimestamp: DateTime.utc(2022, 6, 21),
       systemStartSlot: const SlotBigNum(86400),
       slotLength: const Duration(seconds: 1),
     );

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/campaign/campaign_timeline.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/campaign/campaign_timeline.dart
@@ -50,7 +50,7 @@ extension CampaignTimelineX on CampaignTimeline {
           '''Participants submit initial proposals for ideas to solve challenges. A set amount of ada is allocated to the new funding round.''',
       timeline: DateRange(
         from: DateTime.utc(2025, 4, 30, 13, 20),
-        to: DateTime.utc(2025, 5, 13, 17, 00),
+        to: DateTime.utc(2025, 5, 13, 17),
       ),
       stage: CampaignTimelineStage.proposalSubmission,
     ),
@@ -59,8 +59,8 @@ extension CampaignTimelineX on CampaignTimeline {
       description:
           '''Community members share ideas and insights to refine the proposals. This stage consists of two distinct parts: reviews by LV0 & LV1s reviewers, as well as moderation by LV2s moderators.''',
       timeline: DateRange(
-        from: DateTime.utc(2025, 5, 7, 17, 00),
-        to: DateTime.utc(2025, 5, 13, 17, 00),
+        from: DateTime.utc(2025, 5, 7, 17),
+        to: DateTime.utc(2025, 5, 13, 17),
       ),
       stage: CampaignTimelineStage.communityReview,
     ),
@@ -69,8 +69,8 @@ extension CampaignTimelineX on CampaignTimeline {
       description:
           '''Community members vote using the Project Catalyst voting app. Votes are weighted based on voter's token holding.''',
       timeline: DateRange(
-        from: DateTime.utc(2025, 5, 13, 17, 00),
-        to: DateTime.utc(2025, 5, 14, 17, 00),
+        from: DateTime.utc(2025, 5, 13, 17),
+        to: DateTime.utc(2025, 5, 14, 17),
       ),
       stage: CampaignTimelineStage.communityVoting,
     ),
@@ -79,8 +79,8 @@ extension CampaignTimelineX on CampaignTimeline {
       description:
           '''Votes are tallied and the results revealed. Voters and community reviewers receive their rewards.''',
       timeline: DateRange(
-        from: DateTime.utc(2025, 5, 14, 17, 00),
-        to: DateTime.utc(2025, 5, 15, 17, 00),
+        from: DateTime.utc(2025, 5, 14, 17),
+        to: DateTime.utc(2025, 5, 15, 17),
       ),
       stage: CampaignTimelineStage.votingResults,
     ),

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
@@ -55,7 +55,6 @@ final class Account extends Equatable {
   }) {
     return Account(
       catalystId: catalystId,
-      email: null,
       keychain: keychain,
       roles: const {
         AccountRole.voter,

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/api/api_services.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/api/api_services.dart
@@ -32,7 +32,6 @@ final class ApiServices {
 
     return ApiServices.internal(
       gateway: CatGateway.create(
-        authenticator: null,
         baseUrl: Uri.parse(config.gatewayUrl),
         converter: CborOrJsonDelegateConverter(
           cborConverter: CborSerializableConverter(),
@@ -50,7 +49,6 @@ final class ApiServices {
         ],
       ),
       reviews: CatReviews.create(
-        authenticator: null,
         baseUrl: Uri.parse(config.reviewsUrl),
         interceptors: [
           RbacAuthInterceptor(authTokenProvider),

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/catalyst_database.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/catalyst_database.dart
@@ -86,11 +86,12 @@ class DriftCatalystDatabase extends $DriftCatalystDatabase
             ),
 
             // TODO(damian-molinski): Native not supported yet
+            // ignore: avoid_redundant_argument_values
             native: null,
           ).interceptWith(
             DatabaseLoggingInterceptor(
+              // ignore: avoid_redundant_argument_values
               isEnabled: kDebugMode,
-              onlyErrors: true,
               dbName: config.name,
             ),
           ),

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/dao/proposals_dao.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/dao/proposals_dao.dart
@@ -558,7 +558,7 @@ class DriftProposalsDao extends DatabaseAccessor<DriftCatalystDatabase>
 
   Future<DocumentEntity?> _maybeGetDocument(DocumentRef? ref) {
     if (ref == null) {
-      return Future.value(null);
+      return Future.value();
     }
 
     final id = UuidHiLo.from(ref.id);

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
@@ -406,8 +406,10 @@ final class ProposalRepositoryImpl implements ProposalRepository {
       publish: publish,
       commentsCount: data.commentsCount,
       // TODO(damian-molinski): remove it or use different model.
+      // ignore: avoid_redundant_argument_values
       categoryName: '',
       // TODO(damian-molinski): only Strings or use different model.
+      // ignore: avoid_redundant_argument_values
       versions: const [],
     );
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/process_openapi.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/process_openapi.dart
@@ -77,7 +77,7 @@ class OpenApiProcessor {
     Map<String, dynamic> data, {
     required String source,
   }) {
-    final visitor = _FilterAllOfVisitor(source: source, verbose: false);
+    final visitor = _FilterAllOfVisitor(source: source);
     final result = visitor.visit(data);
     return result as Map<String, dynamic>;
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/process_openapi.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/process_openapi.dart
@@ -89,6 +89,7 @@ class _FilterAllOfVisitor {
 
   _FilterAllOfVisitor({
     required this.source,
+    // ignore: unused_element_parameter
     this.verbose = false,
   });
 

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/api/interceptors/rbac_auth_interceptor_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/api/interceptors/rbac_auth_interceptor_test.dart
@@ -92,7 +92,7 @@ void main() {
 
       // When
       when(() => authTokenProvider.createRbacToken())
-          .thenAnswer((_) => Future.value(null));
+          .thenAnswer((_) => Future.value());
       when(() => chain.request).thenReturn(request);
       when(() => chain.proceed(any())).thenAnswer((_) => requestResponse);
       when(() => requestResponse.statusCode).thenAnswer((_) => 200);

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/database/dao/drafts_dao_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/database/dao/drafts_dao_test.dart
@@ -213,9 +213,7 @@ void main() {
           );
 
           final updateDraft = draft.copyWith(
-            metadata: draft.metadata.copyWith(
-              authors: null,
-            ),
+            metadata: draft.metadata.copyWith(),
             content: const DocumentDataContent({
               'title': 'Update',
             }),

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/database/dao/proposals_dao_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/database/dao/proposals_dao_test.dart
@@ -129,7 +129,7 @@ void main() {
             ];
             final actions = [
               _buildProposalAction(
-                selfRef: _buildRefAt(DateTime(2025, 04, 1)),
+                selfRef: _buildRefAt(DateTime(2025, 04)),
                 action: ProposalSubmissionActionDto.aFinal,
                 proposalRef: ref,
               ),
@@ -212,7 +212,7 @@ void main() {
             ];
             final actions = [
               _buildProposalAction(
-                selfRef: _buildRefAt(DateTime(2025, 04, 1)),
+                selfRef: _buildRefAt(DateTime(2025, 04)),
                 action: ProposalSubmissionActionDto.draft,
                 proposalRef: proposalOneRef,
               ),
@@ -380,9 +380,7 @@ void main() {
             );
             const expectedCount = ProposalsCount(
               total: 1,
-              drafts: 0,
               finals: 1,
-              favorites: 0,
               my: 1,
             );
 
@@ -438,10 +436,7 @@ void main() {
             final filters = ProposalsCountFilters(category: categoryId);
             const expectedCount = ProposalsCount(
               total: 1,
-              drafts: 0,
               finals: 1,
-              favorites: 0,
-              my: 0,
             );
 
             // When
@@ -479,9 +474,6 @@ void main() {
             const expectedCount = ProposalsCount(
               total: 1,
               drafts: 1,
-              finals: 0,
-              favorites: 0,
-              my: 0,
             );
 
             // When
@@ -517,9 +509,6 @@ void main() {
             const expectedCount = ProposalsCount(
               total: 1,
               drafts: 1,
-              finals: 0,
-              favorites: 0,
-              my: 0,
             );
 
             // When
@@ -554,9 +543,6 @@ void main() {
             const expectedCount = ProposalsCount(
               total: 1,
               drafts: 1,
-              finals: 0,
-              favorites: 0,
-              my: 0,
             );
 
             // When
@@ -777,7 +763,7 @@ void main() {
 
           final proposals = [
             _buildProposal(
-              selfRef: _buildRefAt(DateTime(2025, 4, 1)),
+              selfRef: _buildRefAt(DateTime(2025, 4)),
               template: templateRef,
               categoryId: categoryId,
             ),
@@ -831,7 +817,7 @@ void main() {
             _buildProposalTemplate(selfRef: templateRef),
           ];
 
-          final proposalRef1 = _buildRefAt(DateTime(2025, 4, 1));
+          final proposalRef1 = _buildRefAt(DateTime(2025, 4));
           final proposalRef2 = _buildRefAt(DateTime(2025, 4, 2));
           final proposalRef3 = _buildRefAt(DateTime(2025, 4, 3));
 
@@ -900,7 +886,7 @@ void main() {
             _buildProposalTemplate(selfRef: templateRef),
           ];
 
-          final proposalRef1 = _buildRefAt(DateTime(2025, 4, 1));
+          final proposalRef1 = _buildRefAt(DateTime(2025, 4));
           final proposalRef2 = _buildRefAt(DateTime(2025, 4, 2));
           final proposalRef3 = _buildRefAt(DateTime(2025, 4, 3));
 
@@ -927,7 +913,7 @@ void main() {
               proposalRef: proposalRef1,
             ),
             _buildProposalAction(
-              selfRef: _buildRefAt(DateTime(2025, 4, 1)),
+              selfRef: _buildRefAt(DateTime(2025, 4)),
               action: ProposalSubmissionActionDto.draft,
               proposalRef: proposalRef1,
             ),
@@ -970,7 +956,7 @@ void main() {
             _buildProposalTemplate(selfRef: templateRef),
           ];
 
-          final proposalRef1 = _buildRefAt(DateTime(2025, 4, 1));
+          final proposalRef1 = _buildRefAt(DateTime(2025, 4));
           final proposalRef2 =
               _buildRefAt(DateTime(2025, 4, 2)).copyWith(id: proposalRef1.id);
           final proposalRef3 =
@@ -998,7 +984,7 @@ void main() {
               proposalRef: proposalRef2,
             ),
             _buildProposalAction(
-              selfRef: _buildRefAt(DateTime(2025, 4, 1)),
+              selfRef: _buildRefAt(DateTime(2025, 4)),
               action: ProposalSubmissionActionDto.draft,
               proposalRef: proposalRef1,
             ),
@@ -1173,7 +1159,7 @@ void main() {
 
           final proposals = [
             _buildProposal(
-              selfRef: _buildRefAt(DateTime(2025, 4, 1)),
+              selfRef: _buildRefAt(DateTime(2025, 4)),
               template: templateRef,
             ),
             _buildProposal(
@@ -1225,7 +1211,7 @@ void main() {
             _buildProposalTemplate(selfRef: templateRef),
           ];
 
-          final proposalRef1 = _buildRefAt(DateTime(2025, 4, 1));
+          final proposalRef1 = _buildRefAt(DateTime(2025, 4));
           final proposalRef2 = _buildRefAt(DateTime(2025, 4, 2));
           final proposalRef3 = _buildRefAt(DateTime(2025, 4, 3));
 
@@ -1291,7 +1277,7 @@ void main() {
             _buildProposalTemplate(selfRef: templateRef),
           ];
 
-          final baseTime = DateTime(2025, 4, 1);
+          final baseTime = DateTime(2025, 4);
           final proposalRef1 = _buildRefAt(baseTime);
           final proposalRef2 =
               _buildRefAt(baseTime.add(const Duration(days: 1)))

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/document/document_repository_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/document/document_repository_test.dart
@@ -64,7 +64,6 @@ void main() {
         );
         final proposal = DocumentDataFactory.build(
           selfRef: SignedDocumentRef.first(const Uuid().v7()),
-          type: DocumentType.proposalDocument,
           template: templateRef,
           content: DocumentDataContent(proposalData),
         );
@@ -99,9 +98,7 @@ void main() {
         );
         final proposal = DocumentDataFactory.build(
           selfRef: SignedDocumentRef.first(const Uuid().v7()),
-          type: DocumentType.proposalDocument,
           template: templateRef,
-          content: const DocumentDataContent({}),
         );
 
         when(() => remoteDocuments.get(ref: templateRef)).thenAnswer(
@@ -512,7 +509,6 @@ void main() {
       'should emit changes',
       () async {
         // Given
-        const initialContent = DocumentDataContent({});
         const updatedContent = DocumentDataContent({'title': 'My proposal'});
 
         final templateRef = SignedDocumentRef.generateFirstRef();
@@ -523,14 +519,11 @@ void main() {
 
         final draftRef = DraftRef.generateFirstRef();
         final draftData = DocumentDataFactory.build(
-          type: DocumentType.proposalDocument,
           selfRef: draftRef,
           template: templateRef,
-          content: initialContent,
         );
 
         final updatedData = DocumentDataFactory.build(
-          type: DocumentType.proposalDocument,
           selfRef: draftRef,
           template: templateRef,
           content: updatedContent,
@@ -575,7 +568,6 @@ void main() {
             DocumentDataContent({'title': 'My proposal'});
         final publicDraftRef = DraftRef.generateFirstRef();
         final publicDraftData = DocumentDataFactory.build(
-          type: DocumentType.proposalDocument,
           selfRef: publicDraftRef,
           template: templateRef,
           content: publicDraftContent,

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/auth/auth_token_cache.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/auth/auth_token_cache.dart
@@ -10,7 +10,6 @@ abstract interface class AuthTokenCache {
 final class LocalAuthTokenCache extends LocalTllCache
     implements AuthTokenCache {
   static const _maxTokenAge = Duration(hours: 1);
-  static const _expiryTolerance = Duration(minutes: 1);
 
   LocalAuthTokenCache({
     required super.sharedPreferences,
@@ -20,7 +19,7 @@ final class LocalAuthTokenCache extends LocalTllCache
 
   @override
   Future<String?> getRbac({required CatalystId id}) async {
-    if (await isAboutToExpire(key: id.asKey, tolerance: _expiryTolerance)) {
+    if (await isAboutToExpire(key: id.asKey)) {
       return null;
     }
     return get(key: id.asKey);

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
@@ -338,7 +338,6 @@ final class RegistrationServiceImpl implements RegistrationService {
 
       return Account(
         catalystId: catalystId,
-        email: null,
         keychain: keychain,
         roles: roles,
         address: _testNetAddress,

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/blockchain/blockchain_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/blockchain/blockchain_service_test.dart
@@ -54,7 +54,7 @@ void main() {
     group('calculateSlotNumber on ${NetworkId.testnet}', () {
       test('https://preprod.cardanoscan.io/block/46', () async {
         await testSlotNumber(
-          targetDateTime: DateTime.utc(2022, 6, 21, 0, 0, 0),
+          targetDateTime: DateTime.utc(2022, 6, 21),
           networkId: NetworkId.testnet,
           expected: const SlotBigNum(86400),
         );

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/proposal/proposal_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/proposal/proposal_service_test.dart
@@ -92,9 +92,7 @@ void main() {
       );
 
       when(
-        () => mockProposalRepository.watchLatestProposals(
-          limit: null,
-        ),
+        () => mockProposalRepository.watchLatestProposals(),
       ).thenAnswer((_) => Stream.value([proposalData1, proposalData2]));
 
       when(
@@ -131,9 +129,7 @@ void main() {
       expect(proposals.length, equals(2));
 
       verify(
-        () => mockProposalRepository.watchLatestProposals(
-          limit: null,
-        ),
+        () => mockProposalRepository.watchLatestProposals(),
       ).called(1);
 
       verify(
@@ -220,9 +216,7 @@ void main() {
             Stream.value([proposalData1, proposalData2]).asBroadcastStream();
 
         when(
-          () => mockProposalRepository.watchLatestProposals(
-            limit: null,
-          ),
+          () => mockProposalRepository.watchLatestProposals(),
         ).thenAnswer((_) => proposalsStream);
 
         when(

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -102,7 +102,6 @@ void main() {
       final oldAccount = Account.dummy(
         catalystId: catalystId,
         keychain: oldKeychain,
-        isActive: false,
       );
 
       final newKeychain = await keychainProvider.create(newKeychainId);

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/test/src/range/range_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/test/src/range/range_test.dart
@@ -76,17 +76,17 @@ void main() {
       expect(range1!.min, equals(10));
       expect(range1.max, equals(20));
 
-      final range2 = NumRange.optionalRangeOf<num>(min: null, max: 20);
+      final range2 = NumRange.optionalRangeOf<num>(max: 20);
       expect(range2, isNotNull);
       expect(range2!.min, isNull);
       expect(range2.max, equals(20));
 
-      final range3 = NumRange.optionalRangeOf<num>(min: 10, max: null);
+      final range3 = NumRange.optionalRangeOf<num>(min: 10);
       expect(range3, isNotNull);
       expect(range3!.min, equals(10));
       expect(range3.max, isNull);
 
-      final range4 = NumRange.optionalRangeOf<num>(min: null, max: null);
+      final range4 = NumRange.optionalRangeOf<num>();
       expect(range4, isNull);
     });
   });

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/test/src/utils/date_time_ext_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/test/src/utils/date_time_ext_test.dart
@@ -11,15 +11,15 @@ void main() {
     });
 
     test('plusDays', () {
-      final dstEnd = DateTime(2022, 10, 30, 0, 0);
-      final nextDay = DateTime(2022, 10, 31, 0, 0);
+      final dstEnd = DateTime(2022, 10, 30);
+      final nextDay = DateTime(2022, 10, 31);
 
       expect(dstEnd.plusDays(1), equals(nextDay));
     });
 
     test('minusDays', () {
-      final dstEnd = DateTime(2022, 10, 31, 0, 0);
-      final previousDay = DateTime(2022, 10, 30, 0, 0);
+      final dstEnd = DateTime(2022, 10, 31);
+      final previousDay = DateTime(2022, 10, 30);
 
       expect(dstEnd.minusDays(1), equals(previousDay));
     });

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/test/authentication/email_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/test/authentication/email_test.dart
@@ -18,11 +18,8 @@ void main() {
       });
 
       test('empty value is accepted as valid', () {
-        // Given
-        const value = '';
-
         // When
-        const email = Email.pure(value);
+        const email = Email.pure();
 
         // Then
         final error = email.error;

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/test/authentication/username_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/test/authentication/username_test.dart
@@ -18,11 +18,8 @@ void main() {
       });
 
       test('empty returns error', () {
-        // Given
-        const value = '';
-
         // When
-        const username = Username.pure(value);
+        const username = Username.pure();
 
         // Then
         final error = username.error;

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/test/campaign/campaign_stage_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/test/campaign/campaign_stage_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 
 void main() {
   group(CampaignStage, () {
-    final date = DateTime(2024, 12, 3, 12, 0);
+    final date = DateTime(2024, 12, 3, 12);
     final campaign = Campaign(
       id: 'id',
       name: 'name',

--- a/catalyst_voices/packages/libs/catalyst_analysis/lib/analysis_options.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/lib/analysis_options.yaml
@@ -101,7 +101,6 @@ linter:
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
     - package_names
     - package_prefixed_library_names
     - parameter_assignments

--- a/catalyst_voices/packages/libs/catalyst_analysis/lib/analysis_options.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/lib/analysis_options.yaml
@@ -32,9 +32,7 @@ linter:
     - avoid_positional_boolean_parameters
     - avoid_print
     - avoid_private_typedef_functions
-    # TODO(dtscalac) below lint rule crashes in dart 3.5.0+,
-    # disabled until https://github.com/dart-lang/sdk/issues/56561 is addressed
-    - avoid_redundant_argument_values: false
+    - avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/test/rbac/x509_certificate_test.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/test/rbac/x509_certificate_test.dart
@@ -29,7 +29,7 @@ void main() {
       serialNumber: 1,
       subjectPublicKey: publicKey,
       issuer: issuer,
-      validityNotBefore: DateTime.utc(2025, 3, 1, 12, 0, 0),
+      validityNotBefore: DateTime.utc(2025, 3, 1, 12),
       validityNotAfter: X509TBSCertificate.foreverValid,
       subject: issuer,
       extensions: const X509CertificateExtensions(

--- a/catalyst_voices/utilities/uikit_example/lib/examples/voices_rich_text_example.dart
+++ b/catalyst_voices/utilities/uikit_example/lib/examples/voices_rich_text_example.dart
@@ -3,6 +3,17 @@ import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 
+const _textSample = [
+  {'insert': 'Sample Rich Text Editor'},
+  {
+    'attributes': {'header': 1},
+    'insert': '\n',
+  },
+  {'insert': '\n'},
+  {'insert': 'We will be able to create content now!'},
+  {'insert': '\n'},
+];
+
 class VoicesRichTextExample extends StatefulWidget {
   static const String route = '/rich-text-example';
 
@@ -16,11 +27,19 @@ class _VoicesRichTextExampleState extends State<VoicesRichTextExample> {
   late final VoicesRichTextController _controller;
 
   @override
-  void initState() {
-    super.initState();
-    _controller = VoicesRichTextController(
-      document: Document.fromJson(_textSample),
-      selection: const TextSelection.collapsed(offset: 0),
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colors.onSurfaceNeutralOpaqueLv0,
+      appBar: AppBar(title: const Text('Voices Rich Text')),
+      body: SingleChildScrollView(
+        child: VoicesRichText(
+          controller: _controller,
+          charsLimit: 800,
+          focusNode: FocusNode(),
+          scrollController: ScrollController(),
+          onChanged: (_) {},
+        ),
+      ),
     );
   }
 
@@ -31,31 +50,11 @@ class _VoicesRichTextExampleState extends State<VoicesRichTextExample> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Theme.of(context).colors.onSurfaceNeutralOpaqueLv0,
-      appBar: AppBar(title: const Text('Voices Rich Text')),
-      body: SingleChildScrollView(
-        child: VoicesRichText(
-          controller: _controller,
-          charsLimit: 800,
-          enabled: true,
-          focusNode: FocusNode(),
-          scrollController: ScrollController(),
-          onChanged: (_) {},
-        ),
-      ),
+  void initState() {
+    super.initState();
+    _controller = VoicesRichTextController(
+      document: Document.fromJson(_textSample),
+      selection: const TextSelection.collapsed(offset: 0),
     );
   }
 }
-
-const _textSample = [
-  {'insert': 'Sample Rich Text Editor'},
-  {
-    'attributes': {'header': 1},
-    'insert': '\n',
-  },
-  {'insert': '\n'},
-  {'insert': 'We will be able to create content now!'},
-  {'insert': '\n'},
-];

--- a/catalyst_voices/utilities/uikit_example/lib/main.dart
+++ b/catalyst_voices/utilities/uikit_example/lib/main.dart
@@ -16,56 +16,6 @@ class UIKitExampleApp extends StatefulWidget {
   State<UIKitExampleApp> createState() => _UIKitExampleAppState();
 }
 
-class _UIKitExampleAppState extends State<UIKitExampleApp> {
-  ThemeMode _themeMode = ThemeMode.system;
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'UI kit examples',
-      supportedLocales: VoicesLocalizations.supportedLocales,
-      localizationsDelegates: const [
-        ...VoicesLocalizations.localizationsDelegates,
-        LocaleNamesLocalizationsDelegate(),
-      ],
-      localeListResolutionCallback: basicLocaleListResolution,
-      theme: ThemeBuilder.buildTheme(brand: Brand.catalyst),
-      darkTheme: ThemeBuilder.buildTheme(
-        brand: Brand.catalyst,
-        brightness: Brightness.dark,
-      ),
-      themeMode: _themeMode,
-      onGenerateRoute: _onGenerateRoute,
-    );
-  }
-
-  Route<dynamic> _onGenerateRoute(RouteSettings settings) {
-    final page = ExamplesListPage.examples
-            .where((e) => e.route == settings.name)
-            .map((e) => e.page)
-            .firstOrNull ??
-        const ExamplesListPage();
-
-    return MaterialPageRoute(
-      settings: settings,
-      builder: (_) {
-        return _ThemeModeSwitcherWrapper(
-          brightness:
-              _themeMode == ThemeMode.dark ? Brightness.dark : Brightness.light,
-          onChanged: _onThemeModeChanged,
-          child: page,
-        );
-      },
-    );
-  }
-
-  void _onThemeModeChanged(ThemeMode themeMode) {
-    setState(() {
-      _themeMode = themeMode;
-    });
-  }
-}
-
 class _ThemeModeSwitcherWrapper extends StatelessWidget {
   final Brightness brightness;
   final ValueChanged<ThemeMode> onChanged;
@@ -101,5 +51,54 @@ class _ThemeModeSwitcherWrapper extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+class _UIKitExampleAppState extends State<UIKitExampleApp> {
+  ThemeMode _themeMode = ThemeMode.system;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'UI kit examples',
+      supportedLocales: VoicesLocalizations.supportedLocales,
+      localizationsDelegates: const [
+        ...VoicesLocalizations.localizationsDelegates,
+        LocaleNamesLocalizationsDelegate(),
+      ],
+      localeListResolutionCallback: basicLocaleListResolution,
+      theme: ThemeBuilder.buildTheme(),
+      darkTheme: ThemeBuilder.buildTheme(
+        brightness: Brightness.dark,
+      ),
+      themeMode: _themeMode,
+      onGenerateRoute: _onGenerateRoute,
+    );
+  }
+
+  Route<dynamic> _onGenerateRoute(RouteSettings settings) {
+    final page = ExamplesListPage.examples
+            .where((e) => e.route == settings.name)
+            .map((e) => e.page)
+            .firstOrNull ??
+        const ExamplesListPage();
+
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) {
+        return _ThemeModeSwitcherWrapper(
+          brightness:
+              _themeMode == ThemeMode.dark ? Brightness.dark : Brightness.light,
+          onChanged: _onThemeModeChanged,
+          child: page,
+        );
+      },
+    );
+  }
+
+  void _onThemeModeChanged(ThemeMode themeMode) {
+    setState(() {
+      _themeMode = themeMode;
+    });
   }
 }


### PR DESCRIPTION
# Description

- Enable again the `avoid_redundant_argument_values` since it works stable now.
- Align the code with the lint rule.
- `package_api_docs` lint rule was removed in dart 3.7.0

## Related Issue(s)

https://github.com/dart-lang/sdk/issues/56561

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
