### PR TITLE
refactor(catalyst-libs/signed-doc): add parameter field

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -15,12 +15,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-cardano-chain-follower = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250512-00" }
-rbac-registration = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250512-00" }
-catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250512-00" }
-cardano-blockchain-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250512-00" }
-catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250512-00" }
-c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250512-00" }
+cardano-chain-follower = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "refactor/rust/signed_doc" }
+rbac-registration = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "refactor/rust/signed_doc" }
+catalyst-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "refactor/rust/signed_doc" }
+cardano-blockchain-types = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "refactor/rust/signed_doc" }
+catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "refactor/rust/signed_doc" }
+c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", branch = "refactor/rust/signed_doc" }
 
 pallas = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }
 pallas-traverse = { version = "0.30.1", git = "https://github.com/input-output-hk/catalyst-pallas.git", rev = "9b5183c8b90b90fe2cc319d986e933e9518957b3" }

--- a/catalyst-gateway/bin/src/service/api/documents/post_document_index_query/response.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/post_document_index_query/response.rs
@@ -158,15 +158,9 @@ pub(crate) struct IndexedDocumentVersion {
     /// Document Template Reference that matches the filter
     #[oai(skip_serializing_if_is_none)]
     pub template: Option<FilteredDocumentReference>,
-    /// Document Brand Reference that matches the filter
+    /// Document Parameters Reference that matches the filter
     #[oai(skip_serializing_if_is_none)]
-    pub brand: Option<FilteredDocumentReference>,
-    /// Document Campaign Reference that matches the filter
-    #[oai(skip_serializing_if_is_none)]
-    pub campaign: Option<FilteredDocumentReference>,
-    /// Document Category Reference that matches the filter
-    #[oai(skip_serializing_if_is_none)]
-    pub category: Option<FilteredDocumentReference>,
+    pub parameters: Option<FilteredDocumentReference>,
 }
 
 impl Example for IndexedDocumentVersion {
@@ -177,9 +171,7 @@ impl Example for IndexedDocumentVersion {
             doc_ref: Some(DocumentReference::example().into()),
             reply: None,
             template: None,
-            brand: None,
-            campaign: None,
-            category: None,
+            parameters: None,
         }
     }
 }
@@ -256,17 +248,13 @@ impl TryFrom<SignedDocBody> for IndexedDocumentVersionDocumented {
         let mut doc_ref = None;
         let mut reply = None;
         let mut template = None;
-        let mut brand = None;
-        let mut campaign = None;
-        let mut category = None;
+        let mut parameters = None;
         if let Some(json_meta) = doc.metadata() {
             let meta: catalyst_signed_doc::ExtraFields = serde_json::from_value(json_meta.clone())?;
             doc_ref = meta.doc_ref().map(Into::into);
             reply = meta.reply().map(Into::into);
             template = meta.template().map(Into::into);
-            brand = meta.brand_id().map(Into::into);
-            campaign = meta.campaign_id().map(Into::into);
-            category = meta.campaign_id().map(Into::into);
+            parameters = meta.parameters().map(Into::into);
         }
 
         Ok(IndexedDocumentVersionDocumented(IndexedDocumentVersion {
@@ -275,9 +263,7 @@ impl TryFrom<SignedDocBody> for IndexedDocumentVersionDocumented {
             doc_ref,
             reply,
             template,
-            brand,
-            campaign,
-            category,
+            parameters,
         }))
     }
 }

--- a/catalyst-gateway/bin/src/service/api/documents/templates/data.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/data.rs
@@ -32,7 +32,7 @@ impl From<CategoryDocData> for SignedDocData {
         Self {
             id: value.0,
             ver: value.0,
-            doc_type: catalyst_signed_doc::doc_types::CATEGORY_DOCUMENT_UUID_TYPE,
+            doc_type: catalyst_signed_doc::doc_types::PARAMETERS_DOCUMENT_UUID_TYPE,
             content: EMPTY_JSON_OBJECT_BYTES,
             category_id: None,
         }


### PR DESCRIPTION
# Description

This commit replaces the ad-hoc attributes (category_id, election_id, campaign_id, brand_id) for a single parameters field, that is expected to hold document-specific validation rules.

## Related Issue(s)

https://github.com/input-output-hk/catalyst-libs/issues/307

## Description of Changes

Ad-hoc rules are anti-pattern and they must be document-specific instead of enforced by static definitions.

## Breaking Changes

- Removal of signed docs attr rules category_id, election_id, campaign_id, brand_id
- Add a centralized parameters signed docs attr rules

## Screenshots

N/A

## Related Pull Requests

https://github.com/input-output-hk/catalyst-libs/pull/317

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
