### PR TITLE
(Partially) update the RBAC endpoint

### DIFF
--- a/catalyst-gateway/bin/src/db/index/queries/rbac/get_rbac_registrations.rs
+++ b/catalyst-gateway/bin/src/db/index/queries/rbac/get_rbac_registrations.rs
@@ -43,6 +43,7 @@ pub(crate) struct Query {
     /// A transaction index.
     pub txn_index: DbTxnIndex,
     /// A previous  transaction id.
+    #[allow(dead_code)]
     pub prv_txn_id: Option<DbTransactionId>,
 }
 

--- a/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/chain_info.rs
+++ b/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/chain_info.rs
@@ -1,20 +1,7 @@
 //! A RBAC registration chain information.
 
-// cspell: words rposition
-
-use anyhow::Context;
 use cardano_blockchain_types::{Slot, TransactionId};
-use catalyst_types::catalyst_id::CatalystId;
-use futures::future::try_join;
 use rbac_registration::registration::cardano::RegistrationChain;
-
-use crate::{
-    db::index::{
-        queries::rbac::get_rbac_registrations::{build_reg_chain, indexed_registrations, Query},
-        session::CassandraSession,
-    },
-    settings::Settings,
-};
 
 /// A RBAC registration chain along with additional information.
 pub struct ChainInfo {
@@ -30,76 +17,33 @@ pub struct ChainInfo {
 
 impl ChainInfo {
     /// Creates a new `ChainInfo` instance.
-    pub(crate) async fn new(
-        persistent_session: &CassandraSession, volatile_session: &CassandraSession,
-        catalyst_id: &CatalystId,
-    ) -> anyhow::Result<Option<Self>> {
-        let registrations =
-            last_registration_chain(persistent_session, volatile_session, catalyst_id).await?;
-
-        let network = Settings::cardano_network();
-
+    pub(crate) fn new(
+        persistent_chain: Option<RegistrationChain>, volatile_chain: Option<RegistrationChain>,
+    ) -> Option<Self> {
+        let mut chain = None;
         let mut last_persistent_txn = None;
         let mut last_volatile_txn = None;
+        // TODO: FIXME:
         let mut last_persistent_slot = 0.into();
 
-        let res = build_reg_chain(
-            registrations.into_iter(),
-            network,
-            |is_persistent: bool, slot_no: Slot, chain: &RegistrationChain| {
-                if is_persistent {
-                    last_persistent_txn = Some(chain.current_tx_id_hash());
-                    last_persistent_slot = slot_no;
-                } else {
-                    last_volatile_txn = Some(chain.current_tx_id_hash());
-                }
-            },
-        )
-        .await?
-        .map(|chain| {
-            Self {
-                chain,
-                last_persistent_txn,
-                last_volatile_txn,
-                last_persistent_slot,
-            }
-        });
-        Ok(res)
+        if let Some(c) = persistent_chain {
+            last_persistent_txn = Some(c.current_tx_id_hash());
+            chain = Some(c);
+        };
+        if let Some(c) = volatile_chain {
+            last_volatile_txn = Some(c.current_tx_id_hash());
+            chain = Some(c);
+        };
+
+        let Some(chain) = chain else {
+            return None;
+        };
+
+        Some(Self {
+            chain,
+            last_persistent_txn,
+            last_volatile_txn,
+            last_persistent_slot,
+        })
     }
-}
-
-/// Returns a last independent chain of both persistent and volatile registrations.
-async fn last_registration_chain(
-    persistent_session: &CassandraSession, volatile_session: &CassandraSession,
-    catalyst_id: &CatalystId,
-) -> anyhow::Result<Vec<(bool, Query)>> {
-    let (persistent_registrations, volatile_registrations) = try_join(
-        indexed_registrations(persistent_session, catalyst_id),
-        indexed_registrations(volatile_session, catalyst_id),
-    )
-    .await?;
-
-    // Combine persistent and volatile registrations.
-    let registrations: Vec<_> = persistent_registrations
-        .into_iter()
-        .map(|r| (true, r))
-        .chain(volatile_registrations.into_iter().map(|r| (false, r)))
-        .collect();
-    if registrations.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    // Find the last independent registration chain.
-    let pos = registrations
-        .iter()
-        .rposition(|(_, r)| r.prv_txn_id.is_none())
-        // This should never happen because we don't index registrations with unknown Catalyst
-        // ID, and it can only be extracted from the root registration, so there must be at
-        // least one.
-        .context("Unable to find root registration")?;
-    registrations
-        .get(pos..)
-        .map(<[_]>::to_vec)
-        // This should never happen: the index is valid because of the check above.
-        .context("Invalid root registration index")
 }


### PR DESCRIPTION
# Description

- Update RBAC endpoint to use RBAC cache.
- Extend the returned value to include information about stake addresses ranges.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/2532.