### PR TITLE
chore(cat-voices): remove linter 80 char long line

### DIFF
--- a/catalyst_voices/apps/voices/lib/common/formatters/date_formatter.dart
+++ b/catalyst_voices/apps/voices/lib/common/formatters/date_formatter.dart
@@ -17,7 +17,6 @@ abstract class DateFormatter {
         return '${l10n.weekOf} ${DateFormat.MMMd().format(from)}';
       }
 
-      // ignore: lines_longer_than_80_chars
       return '${DateFormat.MMMd().format(from)} - ${DateFormat.MMMd().format(to)}';
     } else if (to == null && from != null) {
       return '${l10n.from} ${DateFormat.MMMd().format(from)}';

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
@@ -48,9 +48,7 @@ class __ReviewerCardState extends State<_ReviewerCard> {
   Widget build(BuildContext context) {
     return _StayInvolvedCard(
       icon: VoicesAssets.icons.clipboardCheck,
-      title:
-          // ignore: lines_longer_than_80_chars
-          '${context.l10n.turnOpinionsIntoActions} ${context.l10n.becomeReviewer}!',
+      title: '${context.l10n.turnOpinionsIntoActions} ${context.l10n.becomeReviewer}!',
       description: context.l10n.stayInvolvedReviewerDescription,
       actions: Row(
         children: [

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/dao/drafts_dao.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/dao/drafts_dao.dart
@@ -216,10 +216,7 @@ class DriftDraftsDao extends DatabaseAccessor<DriftCatalystDatabase>
       final searchId = authorId.toSignificant().toUri().toStringWithoutScheme();
 
       query.where(
-        (doc) => CustomExpression<bool>(
-          // ignore: lines_longer_than_80_chars
-          "json_extract(metadata, '\$.authors') LIKE '%$searchId%'",
-        ),
+        (doc) => CustomExpression<bool>("json_extract(metadata, '\$.authors') LIKE '%$searchId%'"),
       );
     }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/query/jsonb_expressions.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/query/jsonb_expressions.dart
@@ -8,7 +8,6 @@ final class ContainsAuthorId extends CustomExpression<bool> {
   ContainsAuthorId({
     required CatalystId id,
   }) : super(
-          //ignore: lines_longer_than_80_chars
           "json_extract(metadata, '\$.authors') LIKE '%${id.toSignificant().toUri().toStringWithoutScheme()}%'",
         );
 }
@@ -16,10 +15,7 @@ final class ContainsAuthorId extends CustomExpression<bool> {
 final class ContainsContentAuthorName extends CustomExpression<bool> {
   ContainsContentAuthorName({
     required String query,
-  }) : super(
-          //ignore: lines_longer_than_80_chars
-          "json_extract(content, '\$.setup.proposer.applicant') LIKE '%$query%'",
-        );
+  }) : super("json_extract(content, '\$.setup.proposer.applicant') LIKE '%$query%'");
 }
 
 final class ContainsMetadataAuthorName extends CustomExpression<bool> {

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/table/documents_metadata.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/table/documents_metadata.dart
@@ -18,20 +18,19 @@ enum DocumentMetadataFieldKey {
 )
 @DataClassName('DocumentMetadataEntity')
 class DocumentsMetadata extends Table with VerHiLoTableMixin {
-  /// e.g. 'category', 'title', 'description'
-  TextColumn get fieldKey => textEnum<DocumentMetadataFieldKey>()();
-
-  /// The actual value (for category, title, description, etc.)
-  TextColumn get fieldValue => text()();
-
   @override
   List<String> get customConstraints => [
         /// Referring with two columns throws a
         /// "SqliteException(1): foreign key mismatch"
         /// But when doing it explicitly it no longer complains
-        // ignore: lines_longer_than_80_chars
         'FOREIGN KEY("ver_hi", "ver_lo") REFERENCES "${$DocumentsTable.$name}"("ver_hi", "ver_lo") ON DELETE CASCADE ON UPDATE CASCADE',
       ];
+
+  /// e.g. 'category', 'title', 'description'
+  TextColumn get fieldKey => textEnum<DocumentMetadataFieldKey>()();
+
+  /// The actual value (for category, title, description, etc.)
+  TextColumn get fieldValue => text()();
 
   @override
   Set<Column> get primaryKey => {

--- a/catalyst_voices/packages/libs/catalyst_analysis/lib/analysis_options.yaml
+++ b/catalyst_voices/packages/libs/catalyst_analysis/lib/analysis_options.yaml
@@ -8,9 +8,6 @@ analyzer:
     - test/.test_coverage.dart
     - lib/generated_plugin_registrant.dart
 
-  errors:
-    lines_longer_than_80_chars: ignore
-
 formatter:
   page_width: 100
 
@@ -88,7 +85,6 @@ linter:
     - library_names
     - library_prefixes
     - library_private_types_in_public_api
-    - lines_longer_than_80_chars
     - literal_only_boolean_expressions
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list


### PR DESCRIPTION
# Description

As we transition to 100 char long line we don't longer need linter for 80 char long line

## Related Issue(s)

N/A

## Description of Changes

- Remove linter rule
- Remove ignore comments for that rule

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
