### PR TITLE
Fix for issue with fee calculation and cbor overhead for complex utxo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,10 @@ $RECYCLE.BIN/
 !/.vscode/settings.recommended.json
 !/.vscode/tasks.recommended.json
 
+
+### DevContainers ###
+.devcontainer/
+
 # Flutter/Dart/Pub
 .dart_tool/
 .packages
@@ -128,3 +132,6 @@ browser_extensions/
 #Test report and coverage
 *.junit-report.xml
 *.coverage.info
+
+# FVM Version Cache
+.fvm/

--- a/catalyst_voices/.gitignore
+++ b/catalyst_voices/.gitignore
@@ -126,6 +126,9 @@ coverage/
 !.vscode/extensions.json
 !.vscode/*.code-snippets
 
+### DevContainers ###
+!.devcontainer/
+
 # Local History for Visual Studio Code
 .history/
 

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
@@ -360,16 +360,7 @@ final class RegistrationServiceImpl implements RegistrationService {
       );
     }
 
-    final witnessSet = await enabledWallet.signTx(transaction: unsignedTx);
-
-    final signedTx = Transaction(
-      body: unsignedTx.body,
-      isValid: true,
-      witnessSet: witnessSet,
-      auxiliaryData: unsignedTx.auxiliaryData,
-    );
-
-    final txHash = await enabledWallet.submitTx(transaction: signedTx);
+    final txHash = await enabledWallet.submitTx(transaction: unsignedTx);
 
     _logger.info('Registration transaction submitted [$txHash]');
 

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_transaction_builder.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_transaction_builder.dart
@@ -184,9 +184,12 @@ final class RegistrationTransactionBuilder {
         vkeys: {},
         vkeysCount: 2,
       ),
+      changeAddress: changeAddress,
     );
 
-    final txBody = txBuilder.withChangeAddressIfNeeded(changeAddress).buildBody();
+    // coin selection to minimize UTXOs
+    final optimizedBuilder = txBuilder.applySelection();
+    final txBody = optimizedBuilder.buildBody();
 
     return Transaction(
       body: txBody,

--- a/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/builders/strategies/greedy_selection_strategy.dart
+++ b/catalyst_voices/packages/libs/catalyst_cardano_serialization/lib/src/builders/strategies/greedy_selection_strategy.dart
@@ -2,57 +2,73 @@ import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.da
 import 'package:catalyst_cardano_serialization/src/builders/types.dart';
 import 'package:cbor/cbor.dart';
 
-/// A greedy selection strategy that selects UTxOs by length and value.
-final class GreedySelectionStrategy implements CoinSelectionStrategy {
+/// A greedy selection strategy that prioritizes UTXOs with fewer multi-assets
+/// to minimize transaction complexity and fees.
+class GreedySelectionStrategy implements CoinSelectionStrategy {
   /// Default const constructor for [GreedySelectionStrategy]
   const GreedySelectionStrategy();
 
   @override
-  void apply(AssetsGroup assetsGroup) {
-    for (final asset in assetsGroup) {
-      asset.value.sort((a, b) => tokenCompare(asset.key, a, b));
+  void apply(AssetsGroup assetGroups) {
+    for (final entry in assetGroups) {
+      final asset = entry.key;
+      final utxos = entry.value;
+
+      // Sort UTXOs by complexity
+      utxos.sort((a, b) => _compareUtxosForEfficiency(a, b, asset));
+    }
+  }
+}
+
+/// Select best UTXOs
+/// 1. UTXOs with fewer multi-assets
+/// 2. Smaller size
+/// 3. Asset amount for the specific asset required
+int _compareUtxosForEfficiency(
+  TransactionUnspentOutput thisUtxo,
+  TransactionUnspentOutput otherUtxo,
+  AssetId asset,
+) {
+  final thisBalance = thisUtxo.output.amount;
+  final otherBalance = otherUtxo.output.amount;
+
+  // Prioritise UTXOs with fewer multi-assets to reduce change complexity
+  final thisAssetCount =
+      thisBalance.multiAsset?.bundle.values.fold<int>(0, (sum, assets) => sum + assets.length) ?? 0;
+  final otherAssetCount =
+      otherBalance.multiAsset?.bundle.values.fold<int>(0, (sum, assets) => sum + assets.length) ??
+          0;
+
+  // Prefer UTXOs with fewer assets
+  if (thisAssetCount != otherAssetCount) {
+    return thisAssetCount.compareTo(otherAssetCount);
+  }
+
+  // For ADA use larger amounts to minimize input count
+  if (asset == CoinSelector.adaAssetId) {
+    final thisAda = thisBalance.coin;
+    final otherAda = otherBalance.coin;
+
+    if (thisAda != otherAda) {
+      return otherAda.compareTo(thisAda);
     }
   }
 
-  /// Compares this [TransactionUnspentOutput] with another
-  /// [TransactionUnspentOutput].
-  ///
-  /// This method compares the UTxOs based on:
-  /// 1. The length of the UTxO's balance.
-  /// 2. The value of the UTxO.
-  ///
-  /// Parameters:
-  /// - [asset]: The asset key to compare against.
-  /// - [thisUtxo]: The first [TransactionUnspentOutput] to compare.
-  /// - [otherUtxo]: The second [TransactionUnspentOutput] to compare.
-  ///
-  /// Returns:
-  /// A negative integer, zero, or a positive integer as this UTxO is less than,
-  /// equal to, or greater than the specified UTxO.
-  int tokenCompare(
-    AssetId asset,
-    TransactionUnspentOutput thisUtxo,
-    TransactionUnspentOutput otherUtxo,
-  ) {
-    final thisBalance = thisUtxo.output.amount;
-    final otherBalance = otherUtxo.output.amount;
+  final thisBalanceLength = cbor.encode(thisBalance.toCbor()).length;
+  final otherBalanceLength = cbor.encode(otherBalance.toCbor()).length;
 
-    final thisBalanceLength = cbor.encode(thisBalance.toCbor()).length;
-    final otherBalanceLength = cbor.encode(otherBalance.toCbor()).length;
-
-    if (thisBalanceLength != otherBalanceLength) {
-      return thisBalanceLength.compareTo(otherBalanceLength);
-    }
-
-    final (pid, assetName) = asset;
-
-    final thisAssetBalance = (asset == CoinSelector.adaAssetId)
-        ? thisBalance.coin
-        : thisBalance.multiAsset?.bundle[pid]?[assetName] ?? const Coin(0);
-    final otherAssetBalance = (asset == CoinSelector.adaAssetId)
-        ? otherBalance.coin
-        : otherBalance.multiAsset?.bundle[pid]?[assetName] ?? const Coin(0);
-
-    return thisAssetBalance.compareTo(otherAssetBalance);
+  if (thisBalanceLength != otherBalanceLength) {
+    return thisBalanceLength.compareTo(otherBalanceLength);
   }
+
+  final (pid, assetName) = asset;
+
+  final thisAssetBalance = (asset == CoinSelector.adaAssetId)
+      ? thisBalance.coin
+      : thisBalance.multiAsset?.bundle[pid]?[assetName] ?? const Coin(0);
+  final otherAssetBalance = (asset == CoinSelector.adaAssetId)
+      ? otherBalance.coin
+      : otherBalance.multiAsset?.bundle[pid]?[assetName] ?? const Coin(0);
+
+  return thisAssetBalance.compareTo(otherAssetBalance);
 }


### PR DESCRIPTION
I have tried address two fundamental issues here, the first is the decoding of the cbor transactions witness and encoding again, while the size should remain constant there is a possibility that additional data could be introduced, the data should only be encoded and never decoded, keep a copy if needed. this is addressed in the submit transaction which I merged to a single function for simplicity, can't see a reason for it being 2 ..


the second is the fee calculation:
the code is currently building a “draft” transaction with zero fee, stubbed in the correct number of fake signatures, serialised to get body+stubs size, then computed:

   `
   baseFee = a * draftSize + b
   `
   
then adds change output by doing:

   `
   changeFee = a * sizeOf(changeOutput)
   `
   
combines the fees*

   `
   totalFee = baseFee + changeFee
   `

   But it never ran the full `a * txSize + b` over the larger transaction.


For complex transactions which may have numerous outputs / inputs adding additional data also introduces extra bytes for the  CBOR map/array the difference might be tiny but compounds over a couple of areas to be sufficient enough to make the transaction fail. 

What we were seeing: 

transactions with no change were no problem they succeeded, when change was introduced the calulation was slightly too smal and did not rerun the calculation to include the cbor overhead of the extra outputs. 

Where there was change but just a single utxo output these also seemed to work but anywhere there was multiple UTXOs and change it would fail.

There are a couple of options the one I drafted introduces a slight buffer depending on the number of inputs, the greater the inputs the more buffer required. 

We need to decide which is best, a more precise fee calculation with the potential of some failed transactions or introducing a slight buffer when there are more inputs we may be unable to be precise with the calculation


Example response from wallet...
```
Full JS error JSON: {"code":2,"info":"BAD_REQUEST ({\"error\":\"Bad Request\",\"message\":\"{\\\"contents\\\":{\\\"contents\\\":{\\\"contents\\\":{\\\"era\\\":\\\"ShelleyBasedEraConway\\\",\\\"error\\\":[\\\"ConwayUtxowFailure (UtxoFailure (FeeTooSmallUTxO (Mismatch {mismatchSupplied = Coin 194805, mismatchExpected = Coin 194937})))\\\"],\\\"kind\\\":\\\"ShelleyTxValidationError\\\"},\\\"tag\\\":\\\"TxValidationErrorInCardanoMode\\\"},\\\"tag\\\":\\\"TxCmdTxSubmitValidationError\\\"},\\\"tag\\\":\\\"TxSubmitFail\\\"}\",\"status_code\":400}) due to\n BlockfrostError: Blockfrost error with status '400': {\"error\":\"Bad Request\",\"message\":\"{\\\"contents\\\":{\\\"contents\\\":{\\\"contents\\\":{\\\"era\\\":\\\"ShelleyBasedEraConway\\\",\\\"error\\\":[\\\"ConwayUtxowFailure (UtxoFailure (FeeTooSmallUTxO (Mismatch {mismatchSupplied = Coin 194805, mismatchExpected = Coin 194937})))\\\"],\\\"kind\\\":\\\"ShelleyTxValidationError\\\"},\\\"tag\\\":\\\"TxValidationErrorInCardanoMode\\\"},\\\"tag\\\":\\\"TxCmdTxSubmitValidationError\\\"},\\\"tag\\\":\\\"TxSubmitFail\\\"}\",\"status_code\":400}","name":"TxSendError","message":"","stack":"TxSendError\n    at Object.submitTx (chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/sw/171.chunk.js:7:70423)\n    at async chrome-extension://gafhhkghbfjjkeiendhlofajokpaflmk/sw/171.chunk.js:7:124552"}
```