### PR TITLE
feat(cat-gateway): add a new immutable and live metric for chain indexer

### DIFF
--- a/catalyst-gateway/bin/src/cardano/event.rs
+++ b/catalyst-gateway/bin/src/cardano/event.rs
@@ -17,13 +17,17 @@ pub(crate) enum ChainIndexerEvent {
     },
     /// Event triggered when the live tip slot changes.
     LiveTipSlotChanged {
+        /// The immutable tip slot.
+        immutable_slot: Slot,
         /// The new live tip slot.
-        slot: Slot,
+        live_slot: Slot,
     },
     /// Event triggered when the immutable tip slot changes.
     ImmutableTipSlotChanged {
         /// The new immutable tip slot.
-        slot: Slot,
+        immutable_slot: Slot,
+        /// The live tip slot.
+        live_slot: Slot,
     },
     /// Event triggered when the indexed slot progresses.
     IndexedSlotProgressed {

--- a/catalyst-gateway/bin/src/metrics/chain_indexer.rs
+++ b/catalyst-gateway/bin/src/metrics/chain_indexer.rs
@@ -89,4 +89,14 @@ pub(crate) mod reporter {
         )
         .unwrap()
     });
+
+    /// A slot difference between immutable tip slot and the volatile tip slot number.
+    pub(crate) static SLOT_TIP_DIFF: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec!(
+            format!("indexer_slot_tip_diff"),
+            "A slot difference between immutable tip slot and the volatile tip slot number",
+            &METRIC_LABELS
+        )
+        .unwrap()
+    });
 }


### PR DESCRIPTION
# Description

Added a new metric to been captured, a slot difference between immutable tip slot and the volatile tip slot number.

## Related Issue(s)

Closes #2592

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
