### PR TITLE
feat(cat-gateway): OpenAPI spec backwards compatibility check

### DIFF
--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -2,6 +2,7 @@ VERSION 0.8
 
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.4.2 AS rust-ci
 IMPORT ../ AS repo-ci
+IMPORT github.com/input-output-hk/catalyst-voices/catalyst-gateway:main AS cat-gateway-main
 
 #cspell: words rustfmt toolsets USERARCH stdcfgs
 
@@ -79,6 +80,14 @@ build:
 
     SAVE ARTIFACT target/doc doc
     SAVE ARTIFACT target/release/cat-gateway cat-gateway
+
+test-openapi-diff:
+    FROM openapitools/openapi-diff:2.1.1
+
+    COPY cat-gateway-main+build/doc/cat-gateway-api.json cat-gateway-api.old.json
+    COPY +build/doc/cat-gateway-api.json cat-gateway-api.new.json
+    RUN java -jar openapi-diff.jar ./cat-gateway-api.old.json ./cat-gateway-api.new.json --fail-on-incompatible
+
 
 # all-hosts-build : Test which runs check with all supported host tooling.  Needs qemu or rosetta to run.
 # Only used to validate tooling is working across host toolsets.


### PR DESCRIPTION
# Description

Added a new `test-openapi-diff` earthly target, to run an OpenAPI  backwards compatibility check against the changed spec from the upstream branch with the `main` branch spec.

## Related Issue(s)

Closes #2614 