### PR TITLE
feat(cat-voices): min title length validation and recheck checkboxes 

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal_builder/new_proposal/new_proposal_cubit.dart
@@ -110,7 +110,13 @@ class NewProposalCubit extends Cubit<NewProposalState>
   }
 
   void updateSelectedCategory(SignedDocumentRef? categoryRef) {
-    emit(state.copyWith(categoryRef: Optional(categoryRef)));
+    emit(
+      state.copyWith(
+        categoryRef: Optional(categoryRef),
+        isAgreeToCategoryCriteria: false,
+        isAgreeToNoFurtherCategoryChange: false,
+      ),
+    );
   }
 
   void updateTitle(ProposalTitle title) {

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_title.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_title.dart
@@ -5,7 +5,7 @@ import 'package:formz/formz.dart';
 
 final class ProposalTitle extends FormzInput<String, ProposalTitleValidationException> {
   static const titleMinLength = 3;
-  
+
   const ProposalTitle.dirty([super.value = '']) : super.dirty();
 
   const ProposalTitle.pure([super.value = '']) : super.pure();

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_title.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_title.dart
@@ -5,6 +5,7 @@ import 'package:formz/formz.dart';
 
 final class ProposalTitle extends FormzInput<String, ProposalTitleValidationException> {
   static const titleMinLength = 3;
+  
   const ProposalTitle.dirty([super.value = '']) : super.dirty();
 
   const ProposalTitle.pure([super.value = '']) : super.pure();

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_title.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_title.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:formz/formz.dart';
 
 final class ProposalTitle extends FormzInput<String, ProposalTitleValidationException> {
+  static const titleMinLength = 3;
   const ProposalTitle.dirty([super.value = '']) : super.dirty();
 
   const ProposalTitle.pure([super.value = '']) : super.pure();
@@ -12,6 +13,8 @@ final class ProposalTitle extends FormzInput<String, ProposalTitleValidationExce
   ProposalTitleValidationException? validator(String value) {
     if (value.isEmpty) {
       return const ProposalTitleEmptyValidationException();
+    } else if (value.length < titleMinLength) {
+      return const ProposalTitleMinLengthValidationException(minLength: titleMinLength);
     }
 
     return null;
@@ -24,6 +27,17 @@ final class ProposalTitleEmptyValidationException extends ProposalTitleValidatio
   @override
   String message(BuildContext context) {
     return context.l10n.errorValidationStringEmpty;
+  }
+}
+
+final class ProposalTitleMinLengthValidationException extends ProposalTitleValidationException {
+  final int minLength;
+
+  const ProposalTitleMinLengthValidationException({required this.minLength});
+
+  @override
+  String message(BuildContext context) {
+    return context.l10n.errorValidationStringLengthBelowMin(minLength);
   }
 }
 


### PR DESCRIPTION
# Description

Additinal requirements for new proposal dialog:

If user checks the boxes then selects a different category, the boxes are cleared.
After inputting minimum of 3 characters in the Title, button activates

## Related Issue(s)

Closes #2608

## Description of Changes

- adding min length validation
- Resetting check boxes if the selected category changes.

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
