### PR TITLE
fix(cat-voices): reseting list after filters change

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
@@ -198,7 +198,7 @@ final class ProposalsCubit extends Cubit<ProposalsState>
       return;
     }
 
-    changeFilters(searchQuery: asOptional);
+    changeFilters(searchQuery: asOptional, resetProposals: true);
 
     emit(state.copyWith(hasSearchQuery: !asOptional.isEmpty));
   }
@@ -232,7 +232,7 @@ final class ProposalsCubit extends Cubit<ProposalsState>
   }
 
   void _handleActiveAccountIdChange(CatalystId? id) {
-    changeFilters(author: Optional(id));
+    changeFilters(author: Optional(id), resetProposals: true);
   }
 
   void _handleFavoriteProposalsIds(List<String> ids) {


### PR DESCRIPTION
# Description

Fixes missing reset list argument

## Related Issue(s)

Part of #2437 

## Description of Changes

- Sets reset pagination to true

## Related Pull Requests

Refers to #2643 


