### PR TITLE
feat(cat-voices): show snackbar at the same level of share dialog

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/share_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/share_proposal_dialog.dart
@@ -13,11 +13,20 @@ class ShareProposalDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return VoicesShareDialog(
-      key: const Key('ShareProposalDialog'),
-      shareItemType: context.l10n.proposal,
-      shareUrl: shareUrl,
-      shareMessage: context.l10n.proposalShareMessage,
+    return ScaffoldMessenger(
+      child: Builder(
+        builder: (context) {
+          return Scaffold(
+            backgroundColor: Colors.transparent,
+            body: VoicesShareDialog(
+              key: const Key('ShareProposalDialog'),
+              shareItemType: context.l10n.proposal,
+              shareUrl: shareUrl,
+              shareMessage: context.l10n.proposalShareMessage,
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/share_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/share_proposal_dialog.dart
@@ -14,18 +14,14 @@ class ShareProposalDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ScaffoldMessenger(
-      child: Builder(
-        builder: (context) {
-          return Scaffold(
-            backgroundColor: Colors.transparent,
-            body: VoicesShareDialog(
-              key: const Key('ShareProposalDialog'),
-              shareItemType: context.l10n.proposal,
-              shareUrl: shareUrl,
-              shareMessage: context.l10n.proposalShareMessage,
-            ),
-          );
-        },
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: VoicesShareDialog(
+          key: const Key('ShareProposalDialog'),
+          shareItemType: context.l10n.proposal,
+          shareUrl: shareUrl,
+          shareMessage: context.l10n.proposalShareMessage,
+        ),
       ),
     );
   }

--- a/catalyst_voices/apps/voices/lib/widgets/modals/voices_share_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/voices_share_dialog.dart
@@ -216,6 +216,7 @@ class _ShareItem extends StatelessWidget with LaunchUrlMixin {
   void _showSnackbar(BuildContext context) {
     VoicesSnackBar(
       type: VoicesSnackBarType.success,
+      behavior: SnackBarBehavior.floating,
       title: context.l10n.copied,
       message: context.l10n.linkCopiedToClipboard,
       duration: const Duration(seconds: 2),


### PR DESCRIPTION
# Description

This PR makes the snackbar visible at the level of the dialog not under the overlay

## Related Issue(s)

Closes #2619

## Description of Changes

-adding new snackbarmesseger and scaffold to show snackbar at proper level

## Breaking Changes

N/A

## Screenshots

<img width="722" alt="Screenshot 2025-06-02 at 15 46 13" src="https://github.com/user-attachments/assets/c49c8450-9252-4683-9413-19fcb5d28dec" />


## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
