### PR TITLE
fix(cat-voices): lookup account public profile when setup

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_public_status.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_public_status.dart
@@ -14,5 +14,7 @@ enum AccountPublicStatus {
   notSetup,
   unknown;
 
+  bool get isNotSetup => this == AccountPublicStatus.notSetup;
+
   bool get isVerified => this == AccountPublicStatus.verified;
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/user_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/user_service.dart
@@ -4,6 +4,7 @@ import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.da
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_repositories/catalyst_voices_repositories.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+import 'package:collection/collection.dart';
 
 abstract interface class UserService implements ActiveAware {
   const factory UserService(
@@ -268,11 +269,13 @@ final class UserServiceImpl implements UserService {
       return;
     }
 
-    final publicStatus = await _userRepository.getAccountPublicStatus();
-    final updatedAccount = activeAccount.copyWith(publicStatus: publicStatus);
-    final updatedUser = user.updateAccount(updatedAccount);
+    if (!activeAccount.publicStatus.isNotSetup) {
+      final publicStatus = await _userRepository.getAccountPublicStatus();
+      final updatedAccount = activeAccount.copyWith(publicStatus: publicStatus);
+      final updatedUser = user.updateAccount(updatedAccount);
 
-    await _updateUser(updatedUser);
+      await _updateUser(updatedUser);
+    }
   }
 
   @override

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -347,6 +347,105 @@ void main() {
         );
       });
     });
+
+    group('updateActiveAccountDetails', () {
+      setUp(() {
+        userRepository = _MockUserRepository();
+        service = UserService(userRepository, userObserver);
+
+        registerFallbackValue(const User.empty());
+      });
+
+      tearDown(() {
+        reset(userRepository);
+      });
+
+      test('user repository is not called when public status is not setup', () async {
+        // Given
+        final keychainId = const Uuid().v4();
+        const publicStatus = AccountPublicStatus.notSetup;
+
+        final keychain = await keychainProvider.create(keychainId);
+        final account = Account.dummy(
+          catalystId: DummyCatalystIdFactory.create(),
+          keychain: keychain,
+          isActive: true,
+        ).copyWith(publicStatus: publicStatus);
+        final user = User.optional(accounts: [account]);
+
+        // When
+        when(() => userRepository.getUser()).thenAnswer((_) => Future.value(user));
+        when(() => userRepository.saveUser(any())).thenAnswer((_) => Future(() {}));
+
+        await service.useLastAccount();
+        await service.updateActiveAccountDetails();
+
+        // Then
+        verifyNever(() => userRepository.getAccountPublicStatus());
+
+        final serviceUser = await service.getUser();
+        expect(serviceUser, user);
+      });
+
+      test('user repository is called when public status is setup', () async {
+        // Given
+        final keychainId = const Uuid().v4();
+        const publicStatus = AccountPublicStatus.verifying;
+
+        final keychain = await keychainProvider.create(keychainId);
+        final account = Account.dummy(
+          catalystId: DummyCatalystIdFactory.create(),
+          keychain: keychain,
+          isActive: true,
+        ).copyWith(
+          email: const Optional('dev@iohk.com'),
+          publicStatus: publicStatus,
+        );
+        final user = User.optional(accounts: [account]);
+
+        // When
+        when(() => userRepository.getUser()).thenAnswer((_) => Future.value(user));
+        when(() => userRepository.saveUser(any())).thenAnswer((_) => Future(() {}));
+        when(() => userRepository.getAccountPublicStatus())
+            .thenAnswer((_) => Future.value(AccountPublicStatus.verified));
+
+        await service.useLastAccount();
+        await service.updateActiveAccountDetails();
+
+        // Then
+        verify(() => userRepository.getAccountPublicStatus()).called(1);
+      });
+
+      test('user account is updated when status changes', () async {
+        // Given
+        final keychainId = const Uuid().v4();
+        const publicStatus = AccountPublicStatus.verifying;
+        const updatedPublicStatus = AccountPublicStatus.verified;
+
+        final keychain = await keychainProvider.create(keychainId);
+        final account = Account.dummy(
+          catalystId: DummyCatalystIdFactory.create(),
+          keychain: keychain,
+          isActive: true,
+        ).copyWith(
+          email: const Optional('dev@iohk.com'),
+          publicStatus: publicStatus,
+        );
+        final user = User.optional(accounts: [account]);
+
+        // When
+        when(() => userRepository.getUser()).thenAnswer((_) => Future.value(user));
+        when(() => userRepository.saveUser(any())).thenAnswer((_) => Future(() {}));
+        when(() => userRepository.getAccountPublicStatus())
+            .thenAnswer((_) => Future.value(updatedPublicStatus));
+
+        await service.useLastAccount();
+        await service.updateActiveAccountDetails();
+
+        // Then
+        expect(service.user.activeAccount?.publicStatus, updatedPublicStatus);
+      });
+    });
   });
 }
 
@@ -378,3 +477,5 @@ class _FakeUserRepository extends Fake implements UserRepository {
     _user = user;
   }
 }
+
+class _MockUserRepository extends Mock implements UserRepository {}


### PR DESCRIPTION
# Description

Only looking up account public status if public profile is setup

## Related Issue(s)

Fixes #2647 

## Description of Changes

- Checks account `publicStatus` before quering status

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
