### PR TITLE
fix(cat-gateway): Include follower reaching tip condition in ready endpoint

### DIFF
--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -295,6 +295,7 @@ fn sync_subchain(
 
                     // Update flag if this is the first time reaching TIP.
                     if chain_update.tip && !follower_has_first_reached_tip() {
+                        info!("Follower has reached TIP for the first time");
                         set_follower_first_reached_tip();
                     }
 

--- a/catalyst-gateway/bin/src/service/utilities/health/start.rs
+++ b/catalyst-gateway/bin/src/service/utilities/health/start.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{
     Ordering::{Acquire, Release},
 };
 
+use tracing::debug;
+
 /// Flag to determine if the service has started
 static STARTED: AtomicBool = AtomicBool::new(false);
 
@@ -30,7 +32,11 @@ pub(crate) fn set_to_started() {
 
 /// Returns whether the service has started or not.
 pub(crate) fn condition_for_started() -> bool {
-    event_db_is_live() && index_db_is_live() && follower_has_first_reached_tip()
+    let event_db = event_db_is_live();
+    let index_db = index_db_is_live();
+    let follower = follower_has_first_reached_tip();
+    debug!("Checking if service has started. Event DB: {event_db}, Index DB: {index_db}, Follower: {follower}");
+    event_db && index_db && follower
 }
 
 /// Returns whether the Event DB is live or not.


### PR DESCRIPTION
# Description

Adds check to chain follower having reached tip before responding.

## Related Issue(s)

Closes #2662 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
