### PR TITLE
fix(cat-voices): start proposal dialog on wide screen

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_category_selection.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_category_selection.dart
@@ -24,34 +24,36 @@ class CreateNewProposalCategorySelection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 430),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: ListView.separated(
-              itemBuilder: (context, index) => _CategoryCard(
-                name: categories[index].formattedName,
-                description: categories[index].shortDescription,
-                ref: categories[index].id,
-                isSelected: categories[index].id == selectedCategory,
-                onCategorySelected: onCategorySelected,
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 50),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: ListView.separated(
+                itemBuilder: (context, index) => _CategoryCard(
+                  name: categories[index].formattedName,
+                  description: categories[index].shortDescription,
+                  ref: categories[index].id,
+                  isSelected: categories[index].id == selectedCategory,
+                  onCategorySelected: onCategorySelected,
+                ),
+                separatorBuilder: (context, index) => const SizedBox(height: 16),
+                itemCount: categories.length,
               ),
-              separatorBuilder: (context, index) => const SizedBox(height: 16),
-              itemCount: categories.length,
             ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            flex: 2,
-            child: _selectedCategory != null
-                ? SingleChildScrollView(
-                    child: CategoryCompactDetailView(category: _selectedCategory!),
-                  )
-                : const _NoneCategorySelected(),
-          ),
-        ],
+            const SizedBox(width: 16),
+            Expanded(
+              flex: 2,
+              child: _selectedCategory != null
+                  ? SingleChildScrollView(
+                      child: CategoryCompactDetailView(category: _selectedCategory!),
+                    )
+                  : const _NoneCategorySelected(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_dialog.dart
@@ -93,11 +93,13 @@ class _ContentView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Stack(
         children: [
           child,
-          CreateNewProposalActionButtons(step: step),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: CreateNewProposalActionButtons(step: step),
+          ),
         ],
       ),
     );
@@ -109,7 +111,7 @@ class _CreateNewProposalDialogState extends State<CreateNewProposalDialog>
   @override
   Widget build(BuildContext context) {
     return VoicesDetailsDialog(
-      constraints: const BoxConstraints(maxHeight: 800, maxWidth: 1200),
+      constraints: const BoxConstraints.tightFor(height: 800, width: 1200),
       header: VoicesAlignTitleHeader(
         title: _getTitle(),
         padding: const EdgeInsets.all(24),


### PR DESCRIPTION
# Description

Small fix to accommodatea  wide screen to make the full height for the scroll in category selection.

## Related Issue(s)

N/A

## Description of Changes

- making the widget expandable rather than constrained to height

## Breaking Changes

N/A

## Screenshots

Before
![image](https://github.com/user-attachments/assets/a63244a1-06ce-430d-bad1-805fb0c9340b)

After
![image](https://github.com/user-attachments/assets/f6e4a556-9aa3-4f09-862d-512c9e3b5087)

## Related Pull Requests

N/A
## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
