### PR TITLE
fix(cat-voices): increase dev tools enable debounce time

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/dev_tools/dev_tools_bloc.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/dev_tools/dev_tools_bloc.dart
@@ -116,7 +116,7 @@ final class DevToolsBloc extends Bloc<DevToolsEvent, DevToolsState>
     emit(state.copyWith(enableTapCount: count));
 
     _resetCountTimer = Timer(
-      const Duration(seconds: 1),
+      const Duration(seconds: 2),
       () => add(const DevToolsEnablerTapResetEvent()),
     );
   }


### PR DESCRIPTION
# Description

Because we switched to long press reset timer have to be longer too
