### PR TITLE
feat(cat-voices): move proposal back arrow to AppBar

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
@@ -47,7 +47,10 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
     final readOnlyMode = context.select<ProposalCubit, bool>((cubit) => cubit.state.readOnlyMode);
 
     return VoicesAppBar(
-      automaticallyImplyLeading: false,
+      leading: NavigationBack(
+        isCompact: true,
+        onCanNotPop: (context, _) => const ProposalsRoute().go(context),
+      ),
       actions: [
         Offstage(
           offstage: readOnlyMode,

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_navigation_controls.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_navigation_controls.dart
@@ -1,11 +1,8 @@
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_version.dart';
-import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
-import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 
 class ProposalNavigationControls extends StatelessWidget {
   final VoidCallback onToggleTap;
@@ -30,30 +27,6 @@ class ProposalNavigationControls extends StatelessWidget {
   }
 }
 
-class _BackButton extends StatelessWidget {
-  final bool isCompact;
-
-  const _BackButton({
-    this.isCompact = false,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return NavigationBack(
-      label: context.l10n.backToList,
-      isCompact: isCompact,
-      onTap: () {
-        final router = GoRouter.of(context);
-        if (router.canPop()) {
-          router.pop();
-        } else {
-          const ProposalsRoute().go(context);
-        }
-      },
-    );
-  }
-}
-
 class _CompactControls extends StatelessWidget {
   final VoidCallback onToggleTap;
 
@@ -67,8 +40,7 @@ class _CompactControls extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        const SizedBox(height: 56),
-        const _BackButton(isCompact: true),
+        const SizedBox(height: 82),
         _ToggleRailButton(onTap: onToggleTap),
       ],
     );
@@ -100,9 +72,7 @@ class _StandardControls extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: 8),
-        const _BackButton(),
-        const SizedBox(height: 20),
+        const SizedBox(height: 76),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [

--- a/catalyst_voices/apps/voices/lib/widgets/app_bar/voices_app_bar.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/app_bar/voices_app_bar.dart
@@ -1,9 +1,7 @@
 import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices/widgets/app_bar/actions/search_button.dart';
-import 'package:catalyst_voices/widgets/buttons/voices_buttons.dart';
 import 'package:catalyst_voices/widgets/dev_tools/dev_tools_enabler.dart';
-import 'package:catalyst_voices/widgets/gesture/voices_gesture_detector.dart';
-import 'package:catalyst_voices/widgets/separators/voices_divider.dart';
+import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
@@ -81,7 +79,7 @@ class VoicesAppBar extends StatelessWidget implements PreferredSizeWidget {
 
     final child = leading ??
         (canImplyDrawerToggleButton ? const DrawerToggleButton() : null) ??
-        (canImplyPopButton ? const NavigationPopButton() : null);
+        (canImplyPopButton ? const NavigationBack(isCompact: true) : null);
 
     if (child == null) {
       return null;

--- a/catalyst_voices/apps/voices/lib/widgets/buttons/navigation_back.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/buttons/navigation_back.dart
@@ -6,23 +6,31 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-class NavigationBack extends StatelessWidget {
+void _goInitialLocation(BuildContext context, GoRouterState? state) {
+  GoRouter.of(context).go(Routes.initialLocation);
+}
+
+typedef NavigationBackCallback = void Function(BuildContext context, GoRouterState? state);
+
+class NavigationBack<T extends Object?> extends StatelessWidget {
   final String? label;
   final bool isCompact;
-  final VoidCallback? onTap;
+  final NavigationBackCallback onCanNotPop;
+  final ValueGetter<T>? resultGetter;
 
   const NavigationBack({
     super.key,
     this.label,
     this.isCompact = false,
-    this.onTap,
+    this.onCanNotPop = _goInitialLocation,
+    this.resultGetter,
   });
 
   @override
   Widget build(BuildContext context) {
     return VoicesTextButton(
       key: const Key('NavigationBackBtn'),
-      onTap: onTap ?? () => _popRoute(context),
+      onTap: () => _popRoute(context),
       leading: isCompact ? null : VoicesAssets.icons.arrowLeft.buildIcon(),
       style: TextButton.styleFrom(
         foregroundColor: context.colors.textOnPrimaryLevel1,
@@ -36,10 +44,12 @@ class NavigationBack extends StatelessWidget {
   }
 
   void _popRoute(BuildContext context) {
-    if (Navigator.canPop(context)) {
-      Navigator.pop(context);
-    } else {
-      GoRouter.of(context).go(Routes.initialLocation);
+    final router = GoRouter.maybeOf(context);
+    if (router != null && router.canPop()) {
+      router.pop(resultGetter?.call());
+      return;
     }
+
+    onCanNotPop(context, router?.state);
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/buttons/voices_buttons.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/buttons/voices_buttons.dart
@@ -157,7 +157,7 @@ class LeftArrowButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return VoicesIconButton(
       onTap: onTap,
-      child: VoicesAssets.icons.arrowNarrowLeft.buildIcon(),
+      child: VoicesAssets.icons.arrowLeft.buildIcon(),
     );
   }
 }
@@ -175,17 +175,6 @@ class MoreOptionsButton extends StatelessWidget {
     return VoicesIconButton(
       onTap: onTap,
       child: VoicesAssets.icons.dotsVertical.buildIcon(),
-    );
-  }
-}
-
-class NavigationPopButton extends StatelessWidget {
-  const NavigationPopButton({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return LeftArrowButton(
-      onTap: () => unawaited(Navigator.maybeOf(context)?.maybePop()),
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/widgets.dart
@@ -1,6 +1,7 @@
 export 'app_bar/voices_app_bar.dart';
 export 'avatars/space_avatar.dart';
 export 'avatars/voices_avatar.dart';
+export 'buttons/navigation_back.dart';
 export 'buttons/voices_buttons.dart';
 export 'buttons/voices_filled_button.dart';
 export 'buttons/voices_icon_button.dart';
@@ -21,7 +22,6 @@ export 'cards/role_chooser_card.dart';
 export 'chips/voices_chip.dart';
 export 'common/delayed_widget.dart';
 export 'common/infrastructure/voices_loadable.dart';
-export 'common/navigation_back.dart';
 export 'common/navigation_location.dart';
 export 'common/page_overflow.dart';
 export 'common/shortcut_activator_view.dart';


### PR DESCRIPTION
# Description

Moved proposal page "back to list" to the AppBar because it was hidden by sticky header when scrolled. 

## Related Issue(s)

Resolves #2690 

## Screenshot

<img width="1725" alt="1" src="https://github.com/user-attachments/assets/632753b1-7557-478a-8a2c-8904b9aa7ebe" />
<img width="1724" alt="2" src="https://github.com/user-attachments/assets/17bfc8a5-e30d-4687-84f1-5d826eaadfb1" />
<img width="1723" alt="3" src="https://github.com/user-attachments/assets/52c198ad-157e-47a5-8028-70dc03a9aab0" />
