### PR TITLE
fix(cat-voices): assign proposal category id instead of category id

### DIFF
--- a/catalyst-gateway/bin/src/service/api/documents/templates/data.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/data.rs
@@ -8,25 +8,23 @@ const EMPTY_JSON_OBJECT_BYTES: &[u8] = b"{}";
 pub(crate) struct CategoryDocData(
     /// ID and Version
     &'static str,
-    /// Content bytes
-    &'static [u8],
 );
 /// List of category documents, 12 categories for Fund 14.
 // TODO: Fix Content once it is added
 #[rustfmt::skip]
 pub(crate) const CATEGORY_DOCUMENTS: [CategoryDocData; 12] = [
-    CategoryDocData("0194d490-30bf-7473-81c8-a0eaef369619", include_bytes!("./docs/category/f14_partner_product.schema.json")),
-    CategoryDocData("0194d490-30bf-7043-8c5c-f0e09f8a6d8c", include_bytes!("./docs/category/f14_concepts.schema.json")),
-    CategoryDocData("0194d490-30bf-7e75-95c1-a6cf0e8086d9", include_bytes!("./docs/category/f14_developers.schema.json")),
-    CategoryDocData("0194d490-30bf-7703-a1c0-83a916b001e7", include_bytes!("./docs/category/f14_ecosystem.schema.json")),
-    CategoryDocData("0194d490-30bf-79d1-9a0f-84943123ef38", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-706d-91c6-0d4707f74cdf", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-759e-b729-304306fbaa5e", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-7e27-b5fd-de3133b54bf6", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-7f9e-8a5d-91fb67c078f2", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-7676-9658-36c0b67e656e", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-7978-b031-7aa2ccc5e3fd", EMPTY_JSON_OBJECT_BYTES),
-    CategoryDocData("0194d490-30bf-7d34-bba9-8498094bd627", EMPTY_JSON_OBJECT_BYTES),
+    CategoryDocData("0194d490-30bf-7473-81c8-a0eaef369619"),
+    CategoryDocData("0194d490-30bf-7043-8c5c-f0e09f8a6d8c"),
+    CategoryDocData("0194d490-30bf-7e75-95c1-a6cf0e8086d9"),
+    CategoryDocData("0194d490-30bf-7703-a1c0-83a916b001e7"),
+    CategoryDocData("0194d490-30bf-79d1-9a0f-84943123ef38"),
+    CategoryDocData("0194d490-30bf-706d-91c6-0d4707f74cdf"),
+    CategoryDocData("0194d490-30bf-759e-b729-304306fbaa5e"),
+    CategoryDocData("0194d490-30bf-7e27-b5fd-de3133b54bf6"),
+    CategoryDocData("0194d490-30bf-7f9e-8a5d-91fb67c078f2"),
+    CategoryDocData("0194d490-30bf-7676-9658-36c0b67e656e"),
+    CategoryDocData("0194d490-30bf-7978-b031-7aa2ccc5e3fd"),
+    CategoryDocData("0194d490-30bf-7d34-bba9-8498094bd627"),
 ];
 
 impl From<CategoryDocData> for SignedDocData {
@@ -35,7 +33,7 @@ impl From<CategoryDocData> for SignedDocData {
             id: value.0,
             ver: value.0,
             doc_type: catalyst_signed_doc::doc_types::CATEGORY_DOCUMENT_UUID_TYPE,
-            content: value.1,
+            content: EMPTY_JSON_OBJECT_BYTES,
             category_id: None,
         }
     }
@@ -47,22 +45,25 @@ pub(crate) struct ProposalTemplateDocData(
     &'static str,
     /// Category ID
     &'static str,
+    /// Content bytes
+    &'static [u8],
 );
+
 /// List of proposal templates, 12 proposals each of which is uniquely associated with one of the predefined categories.
 #[rustfmt::skip]
 pub(crate) const PROPOSAL_TEMPLATES: [ProposalTemplateDocData; 12] = [
-    ProposalTemplateDocData("0194d492-1daa-75b5-b4a4-5cf331cd8d1a", CATEGORY_DOCUMENTS[0].0),
-    ProposalTemplateDocData("0194d492-1daa-7371-8bd3-c15811b2b063", CATEGORY_DOCUMENTS[1].0),
-    ProposalTemplateDocData("0194d492-1daa-79c7-a222-2c3b581443a8", CATEGORY_DOCUMENTS[2].0),
-    ProposalTemplateDocData("0194d492-1daa-716f-a04e-f422f08a99dc", CATEGORY_DOCUMENTS[3].0),
-    ProposalTemplateDocData("0194d492-1daa-78fc-818a-bf20fc3e9b87", CATEGORY_DOCUMENTS[4].0),
-    ProposalTemplateDocData("0194d492-1daa-7d98-a3aa-c57d99121f78", CATEGORY_DOCUMENTS[5].0),
-    ProposalTemplateDocData("0194d492-1daa-77be-a1a5-c238fe25fe4f", CATEGORY_DOCUMENTS[6].0),
-    ProposalTemplateDocData("0194d492-1daa-7254-a512-30a4cdecfb90", CATEGORY_DOCUMENTS[7].0),
-    ProposalTemplateDocData("0194d492-1daa-7de9-b535-1a0b0474ed4e", CATEGORY_DOCUMENTS[8].0),
-    ProposalTemplateDocData("0194d492-1daa-7fce-84ee-b872a4661075", CATEGORY_DOCUMENTS[9].0),
-    ProposalTemplateDocData("0194d492-1daa-7878-9bcc-2c79fef0fc13", CATEGORY_DOCUMENTS[10].0),
-    ProposalTemplateDocData("0194d492-1daa-722f-94f4-687f2c068a5d", CATEGORY_DOCUMENTS[11].0),
+    ProposalTemplateDocData("0194d492-1daa-75b5-b4a4-5cf331cd8d1a", CATEGORY_DOCUMENTS[0].0, include_bytes!("./docs/proposal/f14_partner_product.schema.json")),
+    ProposalTemplateDocData("0194d492-1daa-7371-8bd3-c15811b2b063", CATEGORY_DOCUMENTS[1].0, include_bytes!("./docs/proposal/f14_concept.schema.json")),
+    ProposalTemplateDocData("0194d492-1daa-79c7-a222-2c3b581443a8", CATEGORY_DOCUMENTS[2].0, include_bytes!("./docs/proposal/f14_developer.schema.json")),
+    ProposalTemplateDocData("0194d492-1daa-716f-a04e-f422f08a99dc", CATEGORY_DOCUMENTS[3].0, include_bytes!("./docs/proposal/f14_ecosystem.schema.json")),
+    ProposalTemplateDocData("0194d492-1daa-78fc-818a-bf20fc3e9b87", CATEGORY_DOCUMENTS[4].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-7d98-a3aa-c57d99121f78", CATEGORY_DOCUMENTS[5].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-77be-a1a5-c238fe25fe4f", CATEGORY_DOCUMENTS[6].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-7254-a512-30a4cdecfb90", CATEGORY_DOCUMENTS[7].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-7de9-b535-1a0b0474ed4e", CATEGORY_DOCUMENTS[8].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-7fce-84ee-b872a4661075", CATEGORY_DOCUMENTS[9].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-7878-9bcc-2c79fef0fc13", CATEGORY_DOCUMENTS[10].0, EMPTY_JSON_OBJECT_BYTES),
+    ProposalTemplateDocData("0194d492-1daa-722f-94f4-687f2c068a5d", CATEGORY_DOCUMENTS[11].0, EMPTY_JSON_OBJECT_BYTES),
 ];
 
 impl From<ProposalTemplateDocData> for SignedDocData {
@@ -71,7 +72,7 @@ impl From<ProposalTemplateDocData> for SignedDocData {
             id: value.0,
             ver: value.0,
             doc_type: catalyst_signed_doc::doc_types::PROPOSAL_TEMPLATE_UUID_TYPE,
-            content: include_bytes!("./docs/f14_proposal_template.schema.json"),
+            content: value.2,
             category_id: Some(value.1),
         }
     }

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_concepts.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_concepts.schema.json
@@ -1,1 +1,0 @@
-../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7043-8c5c-f0e09f8a6d8c.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_developers.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_developers.schema.json
@@ -1,1 +1,0 @@
-../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7e75-95c1-a6cf0e8086d9.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_ecosystem.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_ecosystem.schema.json
@@ -1,1 +1,0 @@
-../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7703-a1c0-83a916b001e7.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_partner_product.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/category/f14_partner_product.schema.json
@@ -1,1 +1,0 @@
-../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7473-81c8-a0eaef369619.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/f14_proposal_template.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/f14_proposal_template.schema.json
@@ -1,1 +1,0 @@
-../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0ce8ab38-9258-4fbc-a62e-7faa6e58318f.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_concept.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_concept.schema.json
@@ -1,0 +1,1 @@
+../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-7371-8bd3-c15811b2b063.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_developer.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_developer.schema.json
@@ -1,0 +1,1 @@
+../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-79c7-a222-2c3b581443a8.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_ecosystem.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_ecosystem.schema.json
@@ -1,0 +1,1 @@
+../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-716f-a04e-f422f08a99dc.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_partner_product.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_partner_product.schema.json
@@ -1,0 +1,1 @@
+../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-75b5-b4a4-5cf331cd8d1a.schema.json

--- a/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_proposal_template.schema.json
+++ b/catalyst-gateway/bin/src/service/api/documents/templates/docs/proposal/f14_proposal_template.schema.json
@@ -1,0 +1,1 @@
+../../../../../../../../../docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0ce8ab38-9258-4fbc-a62e-7faa6e58318f.schema.json

--- a/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-716f-a04e-f422f08a99dc.schema.json
+++ b/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-716f-a04e-f422f08a99dc.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7e75-95c1-a6cf0e8086d9.schema.json",
-    "title": "F14 Cardano Open: Developers",
-    "description": "Schema for the F14 Cardano Open: Developers",
+    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-716f-a04e-f422f08a99dc.schema.json",
+    "title": "F14 Cardano Open: Ecosystem Form",
+    "description": "Schema for the F14 Cardano Open: Ecosystem Form",
     "maintainers": [{ "name": "Catalyst Team", "url": "https://projectcatalyst.io/" }],
     "x-changelog": {
         "2025-06-02": [
@@ -342,10 +342,10 @@
                             "$ref": "#/definitions/tokenValueCardanoADA",
                             "title": "Enter the amount of funding you are requesting in ADA",
                             "description": "The amount of funding requested for your proposal",
-                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
+                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Open: Ecosystem: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Open: Ecosystem: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
                             "x-placeholder": "Enter the amount of funding you are requesting in ADA",
                             "minimum": 15000,
-                            "maximum": 100000
+                            "maximum": 60000
                         }
                     },
                     "required": [
@@ -533,37 +533,37 @@
                     "description": "Answer the following questions to determine the eligibility of your proposal.",
                     "x-guidance": "General Guidance\n\nIn consideration of the Reviewers assessing your proposal, be concise and use bulleted lists where possible.",
                     "properties": {
-                        "license_information": {
+                        "target_market": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Mention your open-source License and describe your open-source license rationale.",
+                            "title": "Who you’re targeting, how you’ll reach them, and why this matters for Cardano.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your open-source license rationale.",
-                            "x-guidance": "- For instance, any recognized open-source license (MIT, Apache 2.0, GPL or other).\n- Explain why this license fits your project goals (e.g. broad use, contribution rules, commercial compatibility).\n- Avoid vague terms like “custom license” without justification.",
+                            "description": "Please provide your rationale for your target market.",
+                            "x-guidance": "- Number of new wallets created or ADA transactions initiated.\n- Growth in local/regional community participation.\n- Partnerships formed with local organizations, schools, or groups.",
                             "minLength": 200,
                             "maxLength": 600
                         },
-                        "source_code_accessibility": {
+                        "key_activities": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "How do you make sure your source code is accessible to the public from project start, and people are informed?",
+                            "title": "Provide a list of key activities of your project?",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for how you make sure your source code is accessible to the public from project start, and people are informed.",
-                            "x-guidance": "- Share a public repository link (e.g. GitHub, GitLab) early.\n- Use version control and quality commits regularly.\n- Set clear expectations on progression and communication.",
+                            "description": "Please provide your rationale for your key activities.",
+                            "x-guidance": "- Number of educational sessions, workshops, or webinars held.\n- Total number of participants reached or trained, and retention rates.\n- Increase in Cardano-related knowledge (measured via pre/post surveys or quizzes).",
                             "minLength": 200,
                             "maxLength": 600
                         },
-                         "documentation_quality": {
+                         "performance_metrics": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "How will you provide high quality documentation?",
+                            "title": "What are your success metrics?",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your quality documentation.",
-                            "x-guidance": "- User and developer documentation (README, setup guide, API docs).\n- Use clear structure, visuals, and examples.\n- Mention tools or standards (e.g. Docusaurus, Markdown, OpenAPI).",
+                            "description": "Please provide your rationale for your success metrics.",
+                            "x-guidance": "- Number of new community groups or meetups formed.\n- Number of events or meetups organized.\n- Event attendance and retention rates (in-person or online).\n- Participant feedback scores or testimonials.\n- Social media growth (followers, engagement rates).\n- Mailing list or community channel sign-ups.",
                             "minLength": 200,
                             "maxLength": 600
                         }
                         
                     },
-                    "required": ["license_information", "source_code_accessibility", "documentation_quality"],
-                    "x-order": ["license_information", "source_code_accessibility", "documentation_quality"]
+                    "required": ["target_market", "key_activities", "performance_metrics"],
+                    "x-order": ["target_market", "key_activities", "performance_metrics"]
                 }
             },
             "x-order": ["category_details", "category_questions"]

--- a/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-7371-8bd3-c15811b2b063.schema.json
+++ b/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-7371-8bd3-c15811b2b063.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7473-81c8-a0eaef369619.schema.json",
-    "title": "F14 Cardano Use Cases: Partners & Products Form",
-    "description": "Schema for the F14 Cardano Use Cases: Partners & Products Form",
+    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-7371-8bd3-c15811b2b063.schema.json",
+    "title": "F14 Cardano Use Cases: Concepts Form",
+    "description": "Schema for the F14 Cardano Use Cases: Concepts Form",
     "maintainers": [{ "name": "Catalyst Team", "url": "https://projectcatalyst.io/" }],
     "x-changelog": {
         "2025-06-02": [
@@ -342,10 +342,10 @@
                             "$ref": "#/definitions/tokenValueCardanoADA",
                             "title": "Enter the amount of funding you are requesting in ADA",
                             "description": "The amount of funding requested for your proposal",
-                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Use Cases: Partners & Products: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Use Cases: Partners & Products: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
+                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
                             "x-placeholder": "Enter the amount of funding you are requesting in ADA",
-                            "minimum": 250000,
-                            "maximum": 1000000
+                            "minimum": 15000,
+                            "maximum": 100000
                         }
                     },
                     "required": [
@@ -533,37 +533,37 @@
                     "description": "Answer the following questions to determine the eligibility of your proposal.",
                     "x-guidance": "General Guidance\n\nIn consideration of the Reviewers assessing your proposal, be concise and use bulleted lists where possible.",
                     "properties": {
-                        "established_partnership": {
+                        "innovative_idea": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Describe your established partnerships.",
+                            "title": "Describe what makes your idea innovative compared to what has been previously funded.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your established partnerships.",
-                            "x-guidance": "- For instance, agreements, letters of intent, or public endorsements.\n- If confidential, contact the Catalyst team.\n- Clearly state the partners and describe their role in your project.",
+                            "description": "Please provide your rationale for your innovative idea.",
+                            "x-guidance": "- Clearly state how your idea is new to Cardano or the blockchain space.\n- Highlight what innovation or unique approach your idea brings.\n- Avoid rehashing funded work without clear improvements.",
                             "minLength": 200,
                             "maxLength": 600
                         },
-                        "funding_commitments": {
+                        "prototype_information": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Describe matching funding commitments and/or partners.",
+                            "title": "Describe what your prototype or MVP will demonstrate, and where it can be accessed.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your funding commitments and/or matching partners.",
-                            "x-guidance": "- For instance, financial or in-kind contributions (time, resources, services).\n- Clearly state contributors, the kind of contribution, the amount,  and how it will be managed.\n- Avoid general claims without named partners.",
+                            "description": "Please provide your rationale for your prototype or MVP.",
+                            "x-guidance": "- Make sure your prototype or MVP is deployed or testable on-chain by the end of project phase.\n- Consider how the community could help test your prototype or MVP.",
                             "minLength": 200,
                             "maxLength": 600
                         },
                          "performance_metrics": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Describe your key performance metrics.",
+                            "title": "Describe realistic measures of success, ideally with on-chain metrics.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your key performance metrics.",
-                            "x-guidance": "- For instance, data (user numbers, transactions, traffic, adoption rates), screenshots of dashboards or live analytics.\n- Contextualize why your KPIs matter for your project goals.",
+                            "description": "Please provide your rationale for realistic measures of success.",
+                            "x-guidance": "- Estimate how many users, transactions, or smart contract calls your project expects.\n- Tie projections to Cardano network metrics or similar use cases.\n- Avoid inflated claims—keep it data-based and credible.",
                             "minLength": 200,
                             "maxLength": 600
                         }
                         
                     },
-                    "required": ["established_partnership", "funding_commitments", "performance_metrics"],
-                    "x-order": ["established_partnership", "funding_commitments", "performance_metrics"]
+                    "required": ["innovative_idea", "prototype_information", "performance_metrics"],
+                    "x-order": ["innovative_idea", "prototype_information", "performance_metrics"]
                 }
             },
             "x-order": ["category_details", "category_questions"]

--- a/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-75b5-b4a4-5cf331cd8d1a.schema.json
+++ b/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-75b5-b4a4-5cf331cd8d1a.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7043-8c5c-f0e09f8a6d8c.schema.json",
-    "title": "F14 Cardano Use Cases: Concepts Form",
-    "description": "Schema for the F14 Cardano Use Cases: Concepts Form",
+    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-75b5-b4a4-5cf331cd8d1a.schema.json",
+    "title": "F14 Cardano Use Cases: Partners & Products Form",
+    "description": "Schema for the F14 Cardano Use Cases: Partners & Products Form",
     "maintainers": [{ "name": "Catalyst Team", "url": "https://projectcatalyst.io/" }],
     "x-changelog": {
         "2025-06-02": [
@@ -342,10 +342,10 @@
                             "$ref": "#/definitions/tokenValueCardanoADA",
                             "title": "Enter the amount of funding you are requesting in ADA",
                             "description": "The amount of funding requested for your proposal",
-                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
+                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Use Cases: Partners & Products: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Use Cases: Partners & Products: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
                             "x-placeholder": "Enter the amount of funding you are requesting in ADA",
-                            "minimum": 15000,
-                            "maximum": 100000
+                            "minimum": 250000,
+                            "maximum": 1000000
                         }
                     },
                     "required": [
@@ -533,37 +533,37 @@
                     "description": "Answer the following questions to determine the eligibility of your proposal.",
                     "x-guidance": "General Guidance\n\nIn consideration of the Reviewers assessing your proposal, be concise and use bulleted lists where possible.",
                     "properties": {
-                        "innovative_idea": {
+                        "established_partnership": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Describe what makes your idea innovative compared to what has been previously funded.",
+                            "title": "Describe your established partnerships.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your innovative idea.",
-                            "x-guidance": "- Clearly state how your idea is new to Cardano or the blockchain space.\n- Highlight what innovation or unique approach your idea brings.\n- Avoid rehashing funded work without clear improvements.",
+                            "description": "Please provide your rationale for your established partnerships.",
+                            "x-guidance": "- For instance, agreements, letters of intent, or public endorsements.\n- If confidential, contact the Catalyst team.\n- Clearly state the partners and describe their role in your project.",
                             "minLength": 200,
                             "maxLength": 600
                         },
-                        "prototype_information": {
+                        "funding_commitments": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Describe what your prototype or MVP will demonstrate, and where it can be accessed.",
+                            "title": "Describe matching funding commitments and/or partners.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your prototype or MVP.",
-                            "x-guidance": "- Make sure your prototype or MVP is deployed or testable on-chain by the end of project phase.\n- Consider how the community could help test your prototype or MVP.",
+                            "description": "Please provide your rationale for your funding commitments and/or matching partners.",
+                            "x-guidance": "- For instance, financial or in-kind contributions (time, resources, services).\n- Clearly state contributors, the kind of contribution, the amount,  and how it will be managed.\n- Avoid general claims without named partners.",
                             "minLength": 200,
                             "maxLength": 600
                         },
                          "performance_metrics": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Describe realistic measures of success, ideally with on-chain metrics.",
+                            "title": "Describe your key performance metrics.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for realistic measures of success.",
-                            "x-guidance": "- Estimate how many users, transactions, or smart contract calls your project expects.\n- Tie projections to Cardano network metrics or similar use cases.\n- Avoid inflated claims—keep it data-based and credible.",
+                            "description": "Please provide your rationale for your key performance metrics.",
+                            "x-guidance": "- For instance, data (user numbers, transactions, traffic, adoption rates), screenshots of dashboards or live analytics.\n- Contextualize why your KPIs matter for your project goals.",
                             "minLength": 200,
                             "maxLength": 600
                         }
                         
                     },
-                    "required": ["innovative_idea", "prototype_information", "performance_metrics"],
-                    "x-order": ["innovative_idea", "prototype_information", "performance_metrics"]
+                    "required": ["established_partnership", "funding_commitments", "performance_metrics"],
+                    "x-order": ["established_partnership", "funding_commitments", "performance_metrics"]
                 }
             },
             "x-order": ["category_details", "category_questions"]

--- a/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-79c7-a222-2c3b581443a8.schema.json
+++ b/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-79c7-a222-2c3b581443a8.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d490-30bf-7703-a1c0-83a916b001e7.schema.json",
-    "title": "F14 Cardano Open: Ecosystem Form",
-    "description": "Schema for the F14 Cardano Open: Ecosystem Form",
+    "$id": "https://raw.githubusercontent.com/input-output-hk/catalyst-voices/refs/heads/main/docs/src/architecture/08_concepts/document_templates/proposal/F14-Generic/0194d492-1daa-79c7-a222-2c3b581443a8.schema.json",
+    "title": "F14 Cardano Open: Developers",
+    "description": "Schema for the F14 Cardano Open: Developers",
     "maintainers": [{ "name": "Catalyst Team", "url": "https://projectcatalyst.io/" }],
     "x-changelog": {
         "2025-06-02": [
@@ -342,10 +342,10 @@
                             "$ref": "#/definitions/tokenValueCardanoADA",
                             "title": "Enter the amount of funding you are requesting in ADA",
                             "description": "The amount of funding requested for your proposal",
-                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Open: Ecosystem: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Open: Ecosystem: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
+                            "x-guidance": "Each funding category has a minimum and maximum amount of funding a single proposal can request.\n\nMinimum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳250k**\n- Cardano Uses Cases: Concepts: **₳15K**\n- Cardano Open: Developers: **₳15K**\n- Cardano Open: Ecosystem: **₳15K**\n\nMaximum Funding Amount per proposal:\n\n- Cardano Use Cases: Concepts: **₳1M**\n- Cardano Uses Cases: Concepts: **₳100K**\n- Cardano Open: Developers: **₳100K**\n- Cardano Open: Ecosystem: **₳60K**",
                             "x-placeholder": "Enter the amount of funding you are requesting in ADA",
                             "minimum": 15000,
-                            "maximum": 60000
+                            "maximum": 100000
                         }
                     },
                     "required": [
@@ -533,37 +533,37 @@
                     "description": "Answer the following questions to determine the eligibility of your proposal.",
                     "x-guidance": "General Guidance\n\nIn consideration of the Reviewers assessing your proposal, be concise and use bulleted lists where possible.",
                     "properties": {
-                        "target_market": {
+                        "license_information": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Who you’re targeting, how you’ll reach them, and why this matters for Cardano.",
+                            "title": "Mention your open-source License and describe your open-source license rationale.",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your target market.",
-                            "x-guidance": "- Number of new wallets created or ADA transactions initiated.\n- Growth in local/regional community participation.\n- Partnerships formed with local organizations, schools, or groups.",
+                            "description": "Please provide your open-source license rationale.",
+                            "x-guidance": "- For instance, any recognized open-source license (MIT, Apache 2.0, GPL or other).\n- Explain why this license fits your project goals (e.g. broad use, contribution rules, commercial compatibility).\n- Avoid vague terms like “custom license” without justification.",
                             "minLength": 200,
                             "maxLength": 600
                         },
-                        "key_activities": {
+                        "source_code_accessibility": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "Provide a list of key activities of your project?",
+                            "title": "How do you make sure your source code is accessible to the public from project start, and people are informed?",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your key activities.",
-                            "x-guidance": "- Number of educational sessions, workshops, or webinars held.\n- Total number of participants reached or trained, and retention rates.\n- Increase in Cardano-related knowledge (measured via pre/post surveys or quizzes).",
+                            "description": "Please provide your rationale for how you make sure your source code is accessible to the public from project start, and people are informed.",
+                            "x-guidance": "- Share a public repository link (e.g. GitHub, GitLab) early.\n- Use version control and quality commits regularly.\n- Set clear expectations on progression and communication.",
                             "minLength": 200,
                             "maxLength": 600
                         },
-                         "performance_metrics": {
+                         "documentation_quality": {
                             "$ref": "#/definitions/multiLineTextEntryMarkdown",
-                            "title": "What are your success metrics?",
+                            "title": "How will you provide high quality documentation?",
                             "x-placeholder": "Please provide your rationale.",
-                            "description": "Please provide your rationale for your success metrics.",
-                            "x-guidance": "- Number of new community groups or meetups formed.\n- Number of events or meetups organized.\n- Event attendance and retention rates (in-person or online).\n- Participant feedback scores or testimonials.\n- Social media growth (followers, engagement rates).\n- Mailing list or community channel sign-ups.",
+                            "description": "Please provide your quality documentation.",
+                            "x-guidance": "- User and developer documentation (README, setup guide, API docs).\n- Use clear structure, visuals, and examples.\n- Mention tools or standards (e.g. Docusaurus, Markdown, OpenAPI).",
                             "minLength": 200,
                             "maxLength": 600
                         }
                         
                     },
-                    "required": ["target_market", "key_activities", "performance_metrics"],
-                    "x-order": ["target_market", "key_activities", "performance_metrics"]
+                    "required": ["license_information", "source_code_accessibility", "documentation_quality"],
+                    "x-order": ["license_information", "source_code_accessibility", "documentation_quality"]
                 }
             },
             "x-order": ["category_details", "category_questions"]


### PR DESCRIPTION
# Description

Proposal template ref were named with category id instead of the proper proposal category id. 

https://github.com/input-output-hk/catalyst-voices/blob/main/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/constant_documents_refs.dart

## Related Issue(s)

N/A

## Description of Changes

- named proposal template files with proper category proposal id 

## Breaking Changes

N/A

## Screenshots

N/A

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
