### PR TITLE
fix(cat-voices): align category cards

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/campaign_categories.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/campaign_categories.dart
@@ -16,27 +16,24 @@ class CampaignCategories extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 120),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Center(
-            child: Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: categories
-                  .map(
-                    (e) => Skeletonizer(
-                      enabled: isLoading,
-                      child: CampaignCategoryCard(category: e),
-                    ),
-                  )
-                  .toList(),
-            ),
-          ),
-          const SizedBox(height: 24),
-        ],
+      padding: const EdgeInsets.only(
+        left: 120,
+        right: 120,
+        bottom: 24,
+      ),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        children: categories
+            .map(
+              (e) => IntrinsicHeight(
+                child: Skeletonizer(
+                  enabled: isLoading,
+                  child: CampaignCategoryCard(category: e),
+                ),
+              ),
+            )
+            .toList(),
       ),
     );
   }

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/campaign_categories_state_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/campaign_categories_state_selector.dart
@@ -52,9 +52,7 @@ class _CampaignCategoriesData extends StatelessWidget {
       builder: (context, state) {
         return Offstage(
           offstage: state.isEmpty,
-          child: CampaignCategories(
-            state,
-          ),
+          child: CampaignCategories(state),
         );
       },
     );


### PR DESCRIPTION
# Description

Align category cards.

## Related Issue(s)

Closes #2717

## Screenshots

![Screenshot 2025-06-08 at 19 47 29](https://github.com/user-attachments/assets/ab0ba38f-0f6d-435a-a5b7-493c080bc29d)
![Screenshot 2025-06-08 at 19 47 38](https://github.com/user-attachments/assets/a60ed6a0-c02e-4f1d-b291-15e162271a3d)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
