### PR TITLE
fix(cat-voices): wrong amount of max final proposals in proposal submission window dialog

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/workspace/submission_closing_warning_dialog.dart
+++ b/catalyst_voices/apps/voices/lib/pages/workspace/submission_closing_warning_dialog.dart
@@ -5,6 +5,7 @@ import 'package:catalyst_voices/widgets/text/proposal_submission_closes_text.dar
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 
@@ -202,7 +203,7 @@ class _RightSide extends StatelessWidget {
         ProposalSubmissionClosesText(dateTime: date),
         const SizedBox(height: 12),
         _HeadsUpInfo(context.l10n.submitProposalBeforeClosing),
-        _HeadsUpInfo(context.l10n.checkMaxProposal),
+        _HeadsUpInfo(context.l10n.checkMaxProposal(ProposalDocument.maxSubmittedProposalsPerUser)),
         _HeadsUpInfo(
           context.l10n.catalystAppNotAvailableAfterSubmissionCloses,
           isBold: true,

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -2521,9 +2521,14 @@
   "@submitProposalBeforeClosing": {
     "description": "Information for user to submit proposal before the submission window closes"
   },
-  "checkMaxProposal": "Check your finals (max 6) in My proposals.",
+  "checkMaxProposal": "Check your finals (max {count}) in My proposals.",
   "@checkMaxProposal": {
-    "description": "Information for user to check their final proposals before submission window closes"
+    "description": "Information for user to check their final proposals before submission window closes",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "catalystAppNotAvailableAfterSubmissionCloses": "The Catalyst App won’t be available after submission close.",
   "@catalystAppNotAvailableAfterSubmissionCloses": {


### PR DESCRIPTION
# Description

- Actual: 5 final proposals
- Expected: 6 final proposals

## Related Issue(s)

Closes #2732

## Screenshots

![Screenshot 2025-06-08 at 20 50 54](https://github.com/user-attachments/assets/3a45b6b7-6872-4b12-b248-ea484bb6cb7b)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
