### PR TITLE
fix(cat-voices): freezed video

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/video_cache/app_video_manager.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/video_cache/app_video_manager.dart
@@ -19,7 +19,7 @@ class VideoManager extends ValueNotifier<VideoManagerState> {
     super.dispose();
   }
 
-  Future<VideoPlayerController> getOrCreateController(
+  Future<VideoPlayerController> createOrReinitializeController(
     VideoCacheKey asset,
   ) async {
     final key = _createKey(asset.name, asset.package);

--- a/catalyst_voices/apps/voices/lib/app/view/video_cache/app_video_manager.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/video_cache/app_video_manager.dart
@@ -24,7 +24,14 @@ class VideoManager extends ValueNotifier<VideoManagerState> {
   ) async {
     final key = _createKey(asset.name, asset.package);
     if (value.controllers.containsKey(key)) {
-      return value.controllers[key]!;
+      final controller = value.controllers[key]!;
+
+      // Re-initialize is needed to properly connect the cached controller
+      // to a new VideoPlayer widget instance, even though controller state remains unchanged
+      // it has to do with internal logic of VideoPlayer widget that is not exposed to us
+      await controller.initialize();
+      await controller.play();
+      return controller;
     }
     final controller = await _initializeController(asset.name, package: asset.package);
 

--- a/catalyst_voices/apps/voices/lib/widgets/video/video_player.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/video/video_player.dart
@@ -58,6 +58,6 @@ class _VoicesVideoPlayerState extends State<VoicesVideoPlayer> with AutomaticKee
   }
 
   Future<VideoPlayerController> _getController() {
-    return VideoManagerScope.of(context).getOrCreateController(widget.asset);
+    return VideoManagerScope.of(context).createOrReinitializeController(widget.asset);
   }
 }


### PR DESCRIPTION
# Description

For some reason when VideoPlayer widget is disposed and recreated, it won't interact withthe  previously initialized video controller.

## Related Issue(s)

#2722

## Description of Changes

- adding reinitialization logic

## Breaking Changes

N/A

## Screenshots

https://github.com/user-attachments/assets/f979e0ba-95f9-49cd-af43-05a1ff655bc4

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
