### PR TITLE
chore(cat-voices): remove unnecessary colour from category do's and don'ts

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_document_widgets.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_document_widgets.dart
@@ -39,7 +39,6 @@ class _CategoryDetails extends StatelessWidget {
             CategoryRequirementsList(
               dos: category.dos,
               donts: category.donts,
-              iconColor: context.colors.primaryContainer,
             ),
           ],
         );

--- a/catalyst_voices/apps/voices/lib/widgets/list/category_requirements_list.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/list/category_requirements_list.dart
@@ -7,13 +7,11 @@ import 'package:flutter/material.dart';
 class CategoryRequirementsList extends StatelessWidget {
   final List<String> dos;
   final List<String> donts;
-  final Color? iconColor;
 
   const CategoryRequirementsList({
     super.key,
     required this.dos,
     required this.donts,
-    this.iconColor,
   });
 
   @override
@@ -33,14 +31,13 @@ class CategoryRequirementsList extends StatelessWidget {
           if (dos.isNotEmpty)
             VoicesList(
               items: dos,
-              icon: VoicesAssets.icons.check
-                  .buildIcon(color: iconColor ?? context.colors.iconsPrimary),
+              icon: VoicesAssets.icons.check.buildIcon(color: context.colors.iconsPrimary),
             ),
           if (donts.isNotEmpty) ...[
             const SizedBox(height: 12),
             VoicesList(
               items: donts,
-              icon: VoicesAssets.icons.x.buildIcon(color: iconColor ?? context.colors.iconsPrimary),
+              icon: VoicesAssets.icons.x.buildIcon(color: context.colors.iconsPrimary),
             ),
           ],
         ],


### PR DESCRIPTION
# Description

Design resigned from the additional (different color) in the proposal builder for the category dos and don'ts

## Related Issue(s)

Resolves #2778

## Screenshots

<img width="811" alt="image" src="https://github.com/user-attachments/assets/91f8afb2-2826-4886-abe7-c6479ba2c68f" />

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
