### PR TITLE
fix(cat-gateway): Fixing incorrect `error!` message logging for `saturating_add` methods

### DIFF
--- a/catalyst-gateway/bin/src/service/common/types/cardano/ada_value.rs
+++ b/catalyst-gateway/bin/src/service/common/types/cardano/ada_value.rs
@@ -48,10 +48,13 @@ impl Display for AdaValue {
 impl AdaValue {
     /// Performs saturating addition.
     pub(crate) fn saturating_add(self, v: Self) -> Self {
-        self.0
-            .checked_add(v.0)
-            .inspect(|_| tracing::error!("Ada value overflow: {self} + {v}",))
-            .map_or(Self(u64::MAX), Self)
+        self.0.checked_add(v.0).map_or_else(
+            || {
+                tracing::error!("Ada value overflow: {self} + {v}",);
+                Self(u64::MAX)
+            },
+            Self,
+        )
     }
 }
 

--- a/catalyst-gateway/bin/src/service/common/types/cardano/asset_value.rs
+++ b/catalyst-gateway/bin/src/service/common/types/cardano/asset_value.rs
@@ -49,7 +49,7 @@ impl Display for AssetValue {
 
 impl AssetValue {
     /// Performs saturating addition.
-    pub(crate) fn saturating_add(&self, v: Self) -> Self {
+    pub(crate) fn saturating_add(&self, v: &Self) -> Self {
         self.0.checked_add(v.0).map_or_else(
             || {
                 tracing::error!("Asset value overflow: {self} + {v}",);

--- a/catalyst-gateway/bin/src/service/common/types/cardano/asset_value.rs
+++ b/catalyst-gateway/bin/src/service/common/types/cardano/asset_value.rs
@@ -49,11 +49,14 @@ impl Display for AssetValue {
 
 impl AssetValue {
     /// Performs saturating addition.
-    pub(crate) fn saturating_add(&self, v: &Self) -> Self {
-        self.0
-            .checked_add(v.0)
-            .inspect(|_| tracing::error!("Asset value overflow: {self} + {v}",))
-            .map_or(Self(i128::MAX), Self)
+    pub(crate) fn saturating_add(&self, v: Self) -> Self {
+        self.0.checked_add(v.0).map_or_else(
+            || {
+                tracing::error!("Asset value overflow: {self} + {v}",);
+                Self(i128::MAX)
+            },
+            Self,
+        )
     }
 }
 


### PR DESCRIPTION
# Description

- Fixed two `saturating_add` methods for `AssetValue` and `AdaValue` types. Was incorrect logging of addition overflow
