### PR TITLE
fix(cat-gateway): Correct `immutable_tip` notifying behaviour, when index-db is already indexed

### DIFF
--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -523,7 +523,7 @@ impl SyncTask {
         self.dispatch_event(event::ChainIndexerEvent::SyncLiveChainStarted);
 
         self.start_immutable_followers();
-        // IF there is only 1 chain follower spaw, then the immutable state already indexed and
+        // IF there is only 1 chain follower spawn, then the immutable state already indexed and
         // filled in the db.
         if self.sync_tasks.len() == 1 {
             if !immutable_follower_has_first_reached_tip() {

--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -24,7 +24,6 @@ use crate::{
         session::CassandraSession,
     },
     service::utilities::health::{
-        immutable_follower_has_first_reached_tip, live_follower_has_first_reached_tip,
         set_follower_immutable_first_reached_tip, set_follower_live_first_reached_tip,
     },
     settings::{chain_follower, Settings},
@@ -306,8 +305,7 @@ fn sync_subchain(
                         );
                     }
 
-                    if chain_update.tip && !live_follower_has_first_reached_tip() {
-                        set_follower_live_first_reached_tip();
+                    if chain_update.tip && !set_follower_live_first_reached_tip() {
                         let _ = event_sender.send(event::ChainIndexerEvent::SyncLiveChainCompleted);
                     }
 
@@ -526,9 +524,7 @@ impl SyncTask {
         // IF there is only 1 chain follower spawn, then the immutable state already indexed and
         // filled in the db.
         if self.sync_tasks.len() == 1 {
-            if !immutable_follower_has_first_reached_tip() {
-                set_follower_immutable_first_reached_tip();
-            }
+            set_follower_immutable_first_reached_tip();
             self.dispatch_event(event::ChainIndexerEvent::SyncImmutableChainCompleted);
         } else {
             self.dispatch_event(event::ChainIndexerEvent::SyncImmutableChainStarted);
@@ -625,9 +621,7 @@ impl SyncTask {
             // between the live chain and immutable chain.  This gap should be
             // a parameter.
             if self.sync_tasks.len() == 1 {
-                if !immutable_follower_has_first_reached_tip() {
-                    set_follower_immutable_first_reached_tip();
-                }
+                set_follower_immutable_first_reached_tip();
                 self.dispatch_event(event::ChainIndexerEvent::SyncImmutableChainCompleted);
 
                 // Purge data up to this slot

--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -245,7 +245,7 @@ fn sync_subchain(
 
         // Wait for indexing DB to be ready before continuing.
         drop(CassandraSession::wait_until_ready(INDEXING_DB_READY_WAIT_INTERVAL, true).await);
-        info!(chain=%params.chain, params=%params,"Starting Chain Indexing");
+        info!(chain=%params.chain, params=%params,"Starting Chain Indexing Task");
 
         let mut first_indexed_block = params.first_indexed_block.clone();
         let mut first_immutable = params.first_is_immutable;
@@ -675,9 +675,6 @@ impl SyncTask {
                     break;
                 }
             }
-            // `start_slot` is still used, because it is used to keep syncing chunks as required
-            // while each immutable sync task finishes.
-            info!(chain=%self.cfg.chain, tasks=self.current_sync_tasks, until=?self.start_slot, "Persistent Indexing DB tasks started");
         }
     }
 

--- a/catalyst-gateway/bin/src/service/utilities/health/start.rs
+++ b/catalyst-gateway/bin/src/service/utilities/health/start.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{
     Ordering::{Acquire, Release},
 };
 
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Flag to determine if the service has started
 static STARTED: AtomicBool = AtomicBool::new(false);
@@ -86,6 +86,7 @@ pub(crate) fn live_follower_has_first_reached_tip() -> bool {
 ///
 /// This value can not be set to `false` afterwards.
 pub(crate) fn set_follower_immutable_first_reached_tip() {
+    info!("Follower has reached IMMUTABLE TIP for the first time");
     INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED.store(true, Release);
 }
 
@@ -93,5 +94,6 @@ pub(crate) fn set_follower_immutable_first_reached_tip() {
 ///
 /// This value can not be set to `false` afterwards.
 pub(crate) fn set_follower_live_first_reached_tip() {
+    info!("Follower has reached LIVE TIP for the first time");
     INITIAL_LIVE_FOLLOWER_TIP_REACHED.store(true, Release);
 }

--- a/catalyst-gateway/bin/src/service/utilities/health/start.rs
+++ b/catalyst-gateway/bin/src/service/utilities/health/start.rs
@@ -83,7 +83,7 @@ pub(crate) fn live_follower_has_first_reached_tip() -> bool {
 }
 
 /// Set the `INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED` as `true`.
-/// returning the previous `INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED` value.
+/// returns the previous `INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED` value.
 ///
 /// This value can not be set to `false` afterwards.
 pub(crate) fn set_follower_immutable_first_reached_tip() -> bool {
@@ -95,7 +95,7 @@ pub(crate) fn set_follower_immutable_first_reached_tip() -> bool {
 }
 
 /// Set the `INITIAL_LIVE_FOLLOWER_TIP_REACHED` as `true`,
-/// returning the previous `INITIAL_LIVE_FOLLOWER_TIP_REACHED` value.
+/// returns the previous `INITIAL_LIVE_FOLLOWER_TIP_REACHED` value.
 ///
 /// This value can not be set to `false` afterwards.
 pub(crate) fn set_follower_live_first_reached_tip() -> bool {

--- a/catalyst-gateway/bin/src/service/utilities/health/start.rs
+++ b/catalyst-gateway/bin/src/service/utilities/health/start.rs
@@ -2,7 +2,7 @@
 
 use std::sync::atomic::{
     AtomicBool,
-    Ordering::{Acquire, Release},
+    Ordering::{Acquire, Relaxed, Release},
 };
 
 use tracing::{debug, info};
@@ -83,17 +83,25 @@ pub(crate) fn live_follower_has_first_reached_tip() -> bool {
 }
 
 /// Set the `INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED` as `true`.
+/// returning the previous `INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED` value.
 ///
 /// This value can not be set to `false` afterwards.
-pub(crate) fn set_follower_immutable_first_reached_tip() {
-    info!("Follower has reached IMMUTABLE TIP for the first time");
-    INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED.store(true, Release);
+pub(crate) fn set_follower_immutable_first_reached_tip() -> bool {
+    let prev_value = INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED.swap(true, Relaxed);
+    if !prev_value {
+        info!("Follower has reached IMMUTABLE TIP for the first time");
+    }
+    prev_value
 }
 
-/// Set the `INITIAL_LIVE_FOLLOWER_TIP_REACHED` as `true`.
+/// Set the `INITIAL_LIVE_FOLLOWER_TIP_REACHED` as `true`,
+/// returning the previous `INITIAL_LIVE_FOLLOWER_TIP_REACHED` value.
 ///
 /// This value can not be set to `false` afterwards.
-pub(crate) fn set_follower_live_first_reached_tip() {
-    info!("Follower has reached LIVE TIP for the first time");
-    INITIAL_LIVE_FOLLOWER_TIP_REACHED.store(true, Release);
+pub(crate) fn set_follower_live_first_reached_tip() -> bool {
+    let prev_value = INITIAL_LIVE_FOLLOWER_TIP_REACHED.swap(true, Relaxed);
+    if !prev_value {
+        info!("Follower has reached LIVE TIP for the first time");
+    }
+    prev_value
 }


### PR DESCRIPTION
# Description

- Fixed issue for notifying and setting flag `INITIAL_IMMUTABLE_FOLLOWER_TIP_REACHED` and emitting event `SyncImmutableChainCompleted`
- Cleaned logging 

## Related Issue(s)

Closes #2945