### PR TITLE
feat(cat-gateway): Update RBAC indexing to use latest iteration of RBAC cache

### DIFF
--- a/catalyst-gateway/bin/src/db/index/block/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/mod.rs
@@ -18,6 +18,7 @@ use txi::TxiInsertQuery;
 use txo::TxoInsertQuery;
 
 use super::{queries::FallibleQueryTasks, session::CassandraSession};
+use crate::rbac::RbacIndexingContext;
 
 /// Add all data needed from the block into the indexes.
 pub(crate) async fn index_block(block: &MultiEraBlock) -> anyhow::Result<()> {
@@ -34,6 +35,8 @@ pub(crate) async fn index_block(block: &MultiEraBlock) -> anyhow::Result<()> {
     let mut txo_index = TxoInsertQuery::new();
 
     let slot_no = block.point().slot_or_default();
+
+    let mut rbac_context = RbacIndexingContext::new();
 
     // We add all transactions in the block to their respective index data sets.
     for (index, txn) in block.enumerate_txs() {
@@ -55,7 +58,9 @@ pub(crate) async fn index_block(block: &MultiEraBlock) -> anyhow::Result<()> {
         txo_index.index(block.network(), &txn, slot_no, txn_id, index);
 
         // Index RBAC 509 inside the transaction.
-        rbac509_index.index(txn_id, index, block);
+        rbac509_index
+            .index(txn_id, index, block, &mut rbac_context)
+            .await;
     }
 
     // We then execute each batch of data from the block.

--- a/catalyst-gateway/bin/src/rbac/chains_cache.rs
+++ b/catalyst-gateway/bin/src/rbac/chains_cache.rs
@@ -1,6 +1,6 @@
 //! A cache of RBAC chains.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use catalyst_types::catalyst_id::CatalystId;
 use moka::{policy::EvictionPolicy, sync::Cache};

--- a/catalyst-gateway/bin/src/rbac/indexing_context.rs
+++ b/catalyst-gateway/bin/src/rbac/indexing_context.rs
@@ -1,0 +1,19 @@
+//! A RBAC context used during indexing.
+
+/// A RBAC context used during indexing.
+///
+/// During indexing the information is written to the database only after processing the
+/// whole block. If there are multiple RBAC registrations in one block, then when
+/// validating subsequent transactions we wouldn't be able to find information about the
+/// previous ones in the database. This context is used to hold such information during
+/// block processing in order to mitigate that issue.
+pub struct RbacIndexingContext {
+    //  TODO: FIXME:
+}
+
+impl RbacIndexingContext {
+    /// Creates a new context issue.
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/catalyst-gateway/bin/src/rbac/mod.rs
+++ b/catalyst-gateway/bin/src/rbac/mod.rs
@@ -7,7 +7,13 @@
 mod chain_info;
 mod chains_cache;
 mod get_chain;
+mod indexing_context;
+mod validate;
+mod validate_result;
 
 pub use chain_info::ChainInfo;
 pub use chains_cache::{cache_persistent_rbac_chain, persistent_rbac_chains_cache_size};
 pub use get_chain::{latest_rbac_chain, latest_rbac_chain_by_address, persistent_rbac_chain};
+pub use indexing_context::RbacIndexingContext;
+pub use validate::validate_rbac_registration;
+pub use validate_result::{RbacValidationError, RbacValidationResult, RbacValidationSuccess};

--- a/catalyst-gateway/bin/src/rbac/validate.rs
+++ b/catalyst-gateway/bin/src/rbac/validate.rs
@@ -1,0 +1,219 @@
+//! Utilities for RBAC registrations validation.
+
+use anyhow::Result;
+use cardano_blockchain_types::TransactionId;
+use catalyst_types::catalyst_id::CatalystId;
+use rbac_registration::{cardano::cip509::Cip509, registration::cardano::RegistrationChain};
+use tracing::error;
+
+use crate::rbac::{
+    latest_rbac_chain, persistent_rbac_chain, RbacIndexingContext, RbacValidationError,
+    RbacValidationResult,
+};
+
+/// Validates a new registration by either starting a new chain or adding it to the
+/// existing one.
+///
+/// In case of failure a problem report from the given registration is updated and
+/// returned.
+pub async fn validate_rbac_registration(
+    reg: Cip509, is_persistent: bool, context: &mut RbacIndexingContext,
+) -> RbacValidationResult {
+    match reg.previous_transaction() {
+        Some(previous_txn) => update_chain(reg, previous_txn),
+        None => start_new_chain(reg, is_persistent).await,
+    }
+}
+
+fn update_chain(reg: Cip509, previous_txn: TransactionId) -> RbacValidationResult {
+    let purpose = reg.purpose();
+    let report = reg.report().to_owned();
+
+    // TODO: FIXME:
+
+    // // Find a chain this registration belongs to.
+    // let catalyst_id = self.transactions.get(&previous_txn).ok_or_else(|| {
+    //     debug!("Unable to find previous transaction {previous_txn} in the RBAC cache");
+    //     // We are unable to determine a Catalyst ID, so there is no sense to update the
+    //     // problem report because we would be unable to store this registration anyway.
+    //     RbacCacheAddError::UnknownCatalystId
+    // })?;
+    // let chain = self.chains.get(&catalyst_id).ok_or_else(|| {
+    //     // This means the cache is broken. This should never normally happen.
+    //     error!("Broken RBAC cache: {catalyst_id} is present in TRANSACTIONS cache, but
+    // missing in CHAINS");     RbacCacheAddError::InvalidRegistration {
+    //         catalyst_id: catalyst_id.clone(),
+    //         purpose,
+    //         report: report.clone(),
+    //     }
+    // })?;
+    //
+    // // Check that addresses from the new registration aren't used in other chains.
+    // let previous_addresses = chain.role_0_stake_addresses();
+    // let registration_addresses = registration.role_0_stake_addresses();
+    // let new_addresses: Vec<_> = registration_addresses
+    //     .difference(&previous_addresses)
+    //     .collect();
+    // for address in &new_addresses {
+    //     if self.active_addresses.get(address).is_some() {
+    //         report.functional_validation(
+    //             &format!("{address} stake addresses is already used"),
+    //             "It isn't allowed to use same stake address in multiple registration
+    // chains",         );
+    //     }
+    // }
+    //
+    // // Try to add a new registration to the chain.
+    // let new_chain = chain.update(registration).map_err(|e| {
+    //     report.other(
+    //         &format!("{e:?}"),
+    //         "Failed to apply update the registration chain",
+    //     );
+    //     RbacCacheAddError::InvalidRegistration {
+    //         catalyst_id: catalyst_id.clone(),
+    //         purpose,
+    //         report: report.clone(),
+    //     }
+    // })?;
+    //
+    // self.verify_public_keys(&new_chain, &report);
+    //
+    // if report.is_problematic() {
+    //     return Err(RbacCacheAddError::InvalidRegistration {
+    //         catalyst_id,
+    //         purpose,
+    //         report,
+    //     });
+    // }
+    //
+    // // Everything is fine: update caches.
+    // for address in new_addresses {
+    //     self.active_addresses
+    //         .insert(address.to_owned(), catalyst_id.clone());
+    // }
+    // self.transactions
+    //     .insert(new_chain.current_tx_id_hash(), catalyst_id.clone());
+    // if let Some((key, _)) = new_chain.get_latest_signing_pk_for_role(&RoleId::Role0) {
+    //     self.public_keys.insert(key, catalyst_id.clone());
+    // }
+    // self.chains.insert(catalyst_id.clone(), new_chain);
+    //
+    // Ok(RbacCacheAddSuccess { catalyst_id })
+    todo!()
+}
+
+async fn start_new_chain(reg: Cip509, is_persistent: bool) -> RbacValidationResult {
+    let catalyst_id = reg.catalyst_id().cloned();
+    let purpose = reg.purpose();
+    let report = reg.report().to_owned();
+
+    let new_chain = RegistrationChain::new(reg).map_err(|e| {
+        report.other(&format!("{e:?}"), "Failed to start a registration chain");
+        if let Some(catalyst_id) = catalyst_id {
+            RbacValidationError::InvalidRegistration {
+                catalyst_id,
+                purpose,
+                report: report.clone(),
+            }
+        } else {
+            RbacValidationError::UnknownCatalystId
+        }
+    })?;
+
+    let catalyst_id = new_chain.catalyst_id().to_owned();
+    // // TODO: FIXME: Check context and instead of building full chain just check the
+    // presence // of any information in the database!
+    // match chain(&catalyst_id, is_persistent).await {
+    //     Err(e) => {
+    //         error!("Error finding a chain for {catalyst_id}: {e:?}");
+    //     },
+    //     Ok(Some(_)) => {
+    //         report.functional_validation(
+    //             &format!("{catalyst_id} is already used"),
+    //             "It isn't allowed to use same Catalyst ID (certificate subject public key)
+    // in multiple registration chains",         );
+    //         return Err(RbacValidationError::InvalidRegistration {
+    //             catalyst_id,
+    //             purpose,
+    //             report,
+    //         });
+    //     },
+    //     Ok(None) => {},
+    // }
+    // if self.chains.get(&catalyst_id).is_some() {
+    //     report.functional_validation(
+    //         &format!("{catalyst_id} is already used"),
+    //         "It isn't allowed to use same Catalyst ID (certificate subject public key)
+    // in multiple registration chains",
+    //     );
+    //     return Err(RbacValidationError::InvalidRegistration {
+    //         catalyst_id,
+    //         purpose,
+    //         report,
+    //     });
+    // }
+
+    // let new_addresses = new_chain.role_0_stake_addresses();
+    // for address in &new_addresses {
+    //     if let Some(id) = self.active_addresses.get(address) {
+    //         let previous_chain = self.chains.get(&id).ok_or_else(|| {
+    //             // This means the cache is broken. This should never normally happen.
+    //             error!("Broken RBAC cache: {id} is present in ACTIVE_ADDRESSES cache,
+    // but missing in CHAINS");             RbacCacheAddError::InvalidRegistration {
+    //                 catalyst_id: catalyst_id.clone(),
+    //                 purpose,
+    //                 report: report.clone(),
+    //             }
+    //         })?;
+    //
+    //         if previous_chain.get_latest_signing_pk_for_role(&RoleId::Role0)
+    //             == new_chain.get_latest_signing_pk_for_role(&RoleId::Role0)
+    //         {
+    //             report.functional_validation(
+    //                 &format!("A new registration ({catalyst_id}) uses the same public
+    // key as the previous one ({})",
+    // previous_chain.catalyst_id()),                 "It is only allowed to override
+    // the existing chain by using different public key",             );
+    //         }
+    //     }
+    // }
+    //
+    // self.verify_public_keys(&new_chain, &report);
+    //
+    // if report.is_problematic() {
+    //     return Err(RbacCacheAddError::InvalidRegistration {
+    //         catalyst_id,
+    //         purpose,
+    //         report,
+    //     });
+    // }
+    //
+    // // Everything is fine: update caches.
+    // for address in new_addresses {
+    //     self.active_addresses
+    //         .insert(address.clone(), catalyst_id.clone());
+    // }
+    // self.transactions
+    //     .insert(new_chain.current_tx_id_hash(), catalyst_id.clone());
+    // if let Some((key, _)) = new_chain.get_latest_signing_pk_for_role(&RoleId::Role0) {
+    //     self.public_keys.insert(key, catalyst_id.clone());
+    // } else {
+    //     // A root registration should always contain role 0 with a signing key. The
+    // registration     // must already be validated, so this should never happen.
+    //     error!("{catalyst_id} root registration doesn't have a signing key");
+    // }
+    // self.chains.insert(catalyst_id.clone(), new_chain);
+    //
+    // Ok(RbacCacheAddSuccess { catalyst_id })
+    todo!()
+}
+
+/// Returns either persistent or "latest" (persistent + volatile) registration chain for
+/// the given Catalyst ID.
+async fn chain(id: &CatalystId, is_persistent: bool) -> Result<Option<RegistrationChain>> {
+    if is_persistent {
+        persistent_rbac_chain(id).await
+    } else {
+        Ok(latest_rbac_chain(id).await?.map(|i| i.chain))
+    }
+}

--- a/catalyst-gateway/bin/src/rbac/validate_result.rs
+++ b/catalyst-gateway/bin/src/rbac/validate_result.rs
@@ -1,0 +1,32 @@
+//! Types related to validation of new RBAC registrations.
+
+use catalyst_types::{catalyst_id::CatalystId, problem_report::ProblemReport, uuid::UuidV4};
+
+/// A return value of the `validate_rbac_registration` method.
+pub type RbacValidationResult = Result<RbacValidationSuccess, RbacValidationError>;
+
+/// A value returned from the `validate_rbac_registration` on happy path.
+///
+/// It is used to insert a registration data to the `rbac_registration` table.
+pub struct RbacValidationSuccess {
+    /// A Catalyst ID.
+    pub catalyst_id: CatalystId,
+}
+
+/// An error returned from the `validate_rbac_registration` method.
+#[allow(clippy::large_enum_variant)]
+pub enum RbacValidationError {
+    /// A registration is invalid (`report.is_problematic()` returns `true`).
+    ///
+    /// This variant is inserted to the `rbac_invalid_registration` table.
+    InvalidRegistration {
+        /// A Catalyst ID.
+        catalyst_id: CatalystId,
+        /// A registration purpose.
+        purpose: Option<UuidV4>,
+        /// A problem report.
+        report: ProblemReport,
+    },
+    /// Unable to determine a Catalyst ID of the registration.
+    UnknownCatalystId,
+}

--- a/catalyst-gateway/bin/src/rbac_cache/mod.rs
+++ b/catalyst-gateway/bin/src/rbac_cache/mod.rs
@@ -2,6 +2,7 @@
 
 // The whole module will be eventually removed anyway.
 #![allow(dead_code)]
+#![allow(unused_imports)]
 
 mod add_result;
 mod cache;


### PR DESCRIPTION
# Description

Update RBAC indexing to use latest iteration of RBAC cache(s).

## Related Issue(s)

Closes:
- https://github.com/input-output-hk/catalyst-voices/issues/2152
- https://github.com/input-output-hk/catalyst-voices/issues/2432
- https://github.com/input-output-hk/catalyst-voices/issues/2561
- https://github.com/input-output-hk/catalyst-voices/issues/2650
- https://github.com/input-output-hk/catalyst-voices/issues/2687
