### PR TITLE
fix(cat-voices): toggling comments replies

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
@@ -185,7 +185,7 @@ class _ProposalPageState extends State<ProposalPage>
 
     final newState = state.segments.isEmpty
         ? SegmentsControllerState.initial(segments: data)
-        : state.copyWith(segments: data);
+        : state.updateSegments(data);
 
     _segmentsController.value = newState;
   }

--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_page.dart
@@ -418,10 +418,7 @@ class _ProposalBuilderBodyState extends State<_ProposalBuilderBody>
             segments: data,
             activeSectionId: activeSectionId,
           )
-        : state.copyWith(
-            segments: data,
-            activeSectionId: Optional(activeSectionId),
-          );
+        : state.updateSegments(data).copyWith(activeSectionId: Optional(activeSectionId));
 
     _segmentsController.value = newState;
   }

--- a/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_with_replies_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/comment/proposal_comment_with_replies_card.dart
@@ -33,11 +33,14 @@ class ProposalCommentWithRepliesCard extends StatelessWidget {
 
   bool get _showReplies => showReplies[comment.ref] ?? true;
 
-  bool get _showToggleReplies => comment.replies.isEmpty;
+  bool get _showToggleReplies => comment.replies.isNotEmpty;
 
   @override
   Widget build(BuildContext context) {
     final repliesIndent = 56 * comment.depth;
+
+    final showReplies = _showReplies;
+    final showToggleReplies = _showToggleReplies;
 
     return Column(
       mainAxisSize: MainAxisSize.min,
@@ -53,17 +56,17 @@ class ProposalCommentWithRepliesCard extends StatelessWidget {
               ? Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (_showToggleReplies)
+                    if (showToggleReplies)
                       _ToggleRepliesChip(
                         repliesCount: comment.replies.length,
-                        hide: _showReplies,
-                        onTap: () => onToggleReplies(!_showReplies),
+                        hide: showReplies,
+                        onTap: () => onToggleReplies(!showReplies),
                       ),
                   ],
                 )
               : null,
         ),
-        if (_showReplies)
+        if (showReplies)
           Padding(
             padding: EdgeInsets.only(left: repliesIndent.toDouble()),
             child: Column(
@@ -74,7 +77,7 @@ class ProposalCommentWithRepliesCard extends StatelessWidget {
                   _RepliesCard(
                     key: ValueKey('ReplyComment.${reply.comment.metadata.selfRef.id}'),
                     comment: reply,
-                    showReplies: showReplies,
+                    showReplies: this.showReplies,
                     onSubmit: onSubmit,
                     onCancel: onCancel,
                     onToggleBuilder: onToggleBuilder,

--- a/catalyst_voices/apps/voices/lib/widgets/segments/segments_controller.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/segments/segments_controller.dart
@@ -233,4 +233,23 @@ final class SegmentsControllerState extends Equatable {
   bool isEditing(NodeId stepId) {
     return editSectionId.contains(stepId);
   }
+
+  /// Making a copy with [segments] as well as adding any new segments
+  /// to [openedSegments] by default.
+  SegmentsControllerState updateSegments(List<Segment> segments) {
+    final ids = segments.map((e) => e.id);
+    final currentIds = this.segments.map((e) => e.id);
+
+    final newSegmentsIds = ids.whereNot(currentIds.contains);
+
+    final openedSegments = {
+      ...this.openedSegments,
+      ...newSegmentsIds,
+    };
+
+    return copyWith(
+      segments: segments,
+      openedSegments: openedSegments,
+    );
+  }
 }


### PR DESCRIPTION
# Description

Fixes comment replies toggling

## Related Issue(s)

Fixes #3002 

## Description of Changes

- Fixes showing and toggling comment replies
- Opening by default any added segments (bug when refreshing page) 

## Demo

https://github.com/user-attachments/assets/6b5d8374-6ba8-4315-a184-e3faf00368ed

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
