### PR TITLE
fix(cat-voices): title in edit state for tag widget in proposal builder

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/value/single_grouped_tag_selector_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/value/single_grouped_tag_selector_widget.dart
@@ -60,6 +60,7 @@ class _SingleGroupedTagSelectorWidgetState extends State<SingleGroupedTagSelecto
       onChanged: _onChanged,
       validator: _validator,
       enabled: widget.isEditMode,
+      title: widget.schema.title,
     );
   }
 
@@ -203,6 +204,7 @@ class _TagSelector extends StatelessWidget {
   final String? hintText;
   final String? errorText;
   final bool isRequired;
+  final String title;
 
   const _TagSelector({
     required this.groupedTags,
@@ -212,6 +214,7 @@ class _TagSelector extends StatelessWidget {
     required this.hintText,
     required this.errorText,
     required this.isRequired,
+    required this.title,
   });
 
   GroupedTags? get _selectedGroupedTags {
@@ -232,7 +235,7 @@ class _TagSelector extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         DocumentPropertyBuilderTitle(
-          title: context.l10n.singleGroupedTagSelectorTitle,
+          title: title,
           isRequired: isRequired,
         ),
         const SizedBox(height: 4),
@@ -277,6 +280,7 @@ class _TagWidget extends VoicesFormField<GroupedTagsSelection> {
     required List<GroupedTags> groupedTags,
     required String? hintText,
     required bool isRequired,
+    required String title,
   }) : super(
           builder: (field) {
             final selection = field.value ?? const GroupedTagsSelection();
@@ -304,6 +308,7 @@ class _TagWidget extends VoicesFormField<GroupedTagsSelection> {
                 onGroupChanged: onGroupChanged,
                 onSelectionChanged: onSelectionChanged,
                 hintText: hintText,
+                title: title,
                 errorText: field.errorText,
                 isRequired: isRequired,
               );

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -1570,7 +1570,6 @@
   "@noTagSelected": {
     "description": "For example in context of document builder"
   },
-  "singleGroupedTagSelectorTitle": "Please choose the most relevant theme and tags (as many that apply) related to the outcomes of your proposal.",
   "singleGroupedTagSelectorRelevantTag": "Select the most relevant tag",
   "noUrlAdded": "No URL added",
   "addUrl": "Add URL",


### PR DESCRIPTION
# Description

Title in edit state and in view mode is not the same. Title in edit state was taken from intl files and not from the json schema for Tag widget

## Related Issue(s)

N/A

## Description of Changes

N/A

## Breaking Changes

N/A

## Screenshots

Befor fix

https://github.com/user-attachments/assets/8e6c2028-2338-400e-a4b2-343ce037ea5f

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
