### PR TITLE
feat(cat-gateway): Try to wrap RBAC cache values in Arc

### DIFF
--- a/catalyst-gateway/bin/src/db/index/queries/rbac/get_catalyst_id_from_public_key.rs
+++ b/catalyst-gateway/bin/src/db/index/queries/rbac/get_catalyst_id_from_public_key.rs
@@ -32,7 +32,7 @@ use crate::{
 const QUERY: &str = include_str!("../cql/get_catalyst_id_for_public_key.cql");
 
 /// A persistent cache instance.
-static PERSISTENT_CACHE: LazyLock<Cache<VerifyingKey, QueryResult>> = LazyLock::new(|| {
+static PERSISTENT_CACHE: LazyLock<Cache<VerifyingKey, Arc<CatalystId>>> = LazyLock::new(|| {
     Cache::builder()
         .eviction_policy(EvictionPolicy::lru())
         .max_capacity(Settings::rbac_cfg().persistent_pub_keys_cache_size)
@@ -40,19 +40,12 @@ static PERSISTENT_CACHE: LazyLock<Cache<VerifyingKey, QueryResult>> = LazyLock::
 });
 
 /// A volatile cache instance.
-static VOLATILE_CACHE: LazyLock<Cache<VerifyingKey, QueryResult>> = LazyLock::new(|| {
+static VOLATILE_CACHE: LazyLock<Cache<VerifyingKey, Arc<CatalystId>>> = LazyLock::new(|| {
     Cache::builder()
         .eviction_policy(EvictionPolicy::lru())
         .max_capacity(Settings::rbac_cfg().volatile_pub_keys_cache_size)
         .build()
 });
-
-/// A result of query execution.
-#[derive(Debug, Clone)]
-pub struct QueryResult {
-    /// A Catalyst ID.
-    pub catalyst_id: CatalystId,
-}
 
 /// Get Catalyst ID by public key query parameters.
 #[derive(SerializeRow)]
@@ -81,7 +74,7 @@ impl Query {
     /// Executes the query and returns a result for the given public key.
     pub(crate) async fn get(
         session: &CassandraSession, public_key: VerifyingKey,
-    ) -> Result<Option<QueryResult>> {
+    ) -> Result<Option<Arc<CatalystId>>> {
         let cache = cache(session.is_persistent());
 
         let res = cache.get(&public_key);
@@ -96,7 +89,7 @@ impl Query {
             })
             .await?
             .rows_stream::<Query>()?
-            .map_ok(Into::<QueryResult>::into)
+            .map_ok(|v| Arc::<CatalystId>::new(v.catalyst_id.into()))
             .next()
             .await
             .transpose()
@@ -106,14 +99,6 @@ impl Query {
                 }
             })
             .context("Failed to get Catalyst ID by public key query row")
-    }
-}
-
-impl From<Query> for QueryResult {
-    fn from(v: Query) -> Self {
-        Self {
-            catalyst_id: v.catalyst_id.into(),
-        }
     }
 }
 
@@ -130,7 +115,7 @@ pub fn public_keys_cache_size(is_persistent: bool) -> u64 {
 }
 
 /// Returns a persistent or a volatile cache instance depending on the parameter value.
-fn cache(is_persistent: bool) -> &'static Cache<VerifyingKey, QueryResult> {
+fn cache(is_persistent: bool) -> &'static Cache<VerifyingKey, Arc<CatalystId>> {
     if is_persistent {
         &PERSISTENT_CACHE
     } else {

--- a/catalyst-gateway/bin/src/rbac/get_chain.rs
+++ b/catalyst-gateway/bin/src/rbac/get_chain.rs
@@ -77,10 +77,10 @@ pub async fn latest_rbac_chain_by_address(address: &StakeAddress) -> Result<Opti
 
     // We always check the latest (volatile) data first.
     let id = match CatalystIdQuery::latest(&volatile_session, address).await? {
-        Some(id) => id.catalyst_id,
+        Some(id) => id,
         None => {
             match CatalystIdQuery::latest(&persistent_session, address).await? {
-                Some(id) => id.catalyst_id,
+                Some(id) => id,
                 None => return Ok(None),
             }
         },

--- a/catalyst-gateway/bin/src/rbac/validation.rs
+++ b/catalyst-gateway/bin/src/rbac/validation.rs
@@ -258,8 +258,8 @@ async fn catalyst_id_from_txn_id(
     // Then try to find in the persistent database.
     let session =
         CassandraSession::get(true).context("Failed to get Cassandra persistent session")?;
-    if let Some(r) = Query::get(&session, txn_id).await? {
-        return Ok(Some(r.catalyst_id));
+    if let Some(id) = Query::get(&session, txn_id).await? {
+        return Ok(Some((*id).clone()));
     };
 
     // Conditionally check the volatile database.
@@ -267,7 +267,7 @@ async fn catalyst_id_from_txn_id(
         let session =
             CassandraSession::get(false).context("Failed to get Cassandra volatile session")?;
         return Query::get(&session, txn_id)
-            .map_ok(|r| r.map(|r| r.catalyst_id))
+            .map_ok(|r| r.map(|id| (*id).clone()))
             .await;
     }
 
@@ -311,8 +311,8 @@ async fn catalyst_id_from_stake_address(
     // Then try to find in the persistent database.
     let session =
         CassandraSession::get(true).context("Failed to get Cassandra persistent session")?;
-    if let Some(r) = Query::latest(&session, address).await? {
-        return Ok(Some(r.catalyst_id));
+    if let Some(id) = Query::latest(&session, address).await? {
+        return Ok(Some((*id).clone()));
     };
 
     // Conditionally check the volatile database.
@@ -320,7 +320,7 @@ async fn catalyst_id_from_stake_address(
         let session =
             CassandraSession::get(false).context("Failed to get Cassandra volatile session")?;
         return Query::latest(&session, address)
-            .map_ok(|r| r.map(|r| r.catalyst_id))
+            .map_ok(|r| r.map(|id| (*id).clone()))
             .await;
     }
 
@@ -370,8 +370,8 @@ async fn catalyst_id_from_public_key(
     // Then try to find in the persistent database.
     let session =
         CassandraSession::get(true).context("Failed to get Cassandra persistent session")?;
-    if let Some(r) = Query::get(&session, key).await? {
-        return Ok(Some(r.catalyst_id));
+    if let Some(id) = Query::get(&session, key).await? {
+        return Ok(Some((*id).clone()));
     };
 
     // Conditionally check the volatile database.
@@ -379,7 +379,7 @@ async fn catalyst_id_from_public_key(
         let session =
             CassandraSession::get(false).context("Failed to get Cassandra volatile session")?;
         return Query::get(&session, key)
-            .map_ok(|r| r.map(|r| r.catalyst_id))
+            .map_ok(|r| r.map(|id| (*id).clone()))
             .await;
     }
 


### PR DESCRIPTION
# Description

Try to wrap RBAC cache values in Arc.

`Catalyst ID` type that is stored in RBAC caches seems heavy enough to benefit from wrapping in `Arc`. On the other hand it seems that should pass it as `Arc` almost everywhere in order to truly benefit from this change.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/2980.