### PR TITLE
fix(cat-gateway): Fixed mistakenly logged `error` 

### DIFF
--- a/catalyst-gateway/bin/src/settings/mod.rs
+++ b/catalyst-gateway/bin/src/settings/mod.rs
@@ -164,10 +164,13 @@ static ENV_VARS: LazyLock<EnvVars> = LazyLock::new(|| {
     let address = SocketAddr::from_str(address.as_str())
         .inspect_err(|err| {
             error!(
-                "Invalid binding address {}, err: {err}. Using default binding address value {ADDRESS_DEFAULT}.",
-                address.as_str(),
+                error = ?err,
+                default_addr = ?ADDRESS_DEFAULT,
+                invalid_addr = ?address,
+                "Invalid binding address. Using default binding address value.",
             );
-        }).unwrap_or(ADDRESS_DEFAULT);
+        })
+        .unwrap_or(ADDRESS_DEFAULT);
 
     let purge_backward_slot_buffer = StringEnvVar::new_as_int(
         "PURGE_BACKWARD_SLOT_BUFFER",

--- a/catalyst-gateway/bin/src/settings/str_env_var.rs
+++ b/catalyst-gateway/bin/src/settings/str_env_var.rs
@@ -186,7 +186,12 @@ impl StringEnvVar {
 
         DurationString::try_from(raw_value.clone())
             .inspect_err(|err| {
-                error!("Invalid Duration: {raw_value} : {err}. Defaulting to {default}.",);
+                error!(
+                    error = ?err,
+                    default = ?default,
+                    duration_str = raw_value,
+                    "Invalid Duration string. Defaulting to default value.",
+                );
             })
             .unwrap_or(default)
             .into()


### PR DESCRIPTION
# Description

- Fixed a mistakenly printed `error` log message for the `Invalid Duration` case
- Fixed a mistakenly printed `error` log message for the `Invalid binding address` case