### PR TITLE
feat(cat-gateway): Async wait for needed indexed data

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -110,6 +110,7 @@ poem-openapi-derive = { version = "=5.1.4" }
 darling = { version = "=0.20.10" }
 
 [dev-dependencies]
+test-case = "3.3.1"
 
 [build-dependencies]
 build-info-build = "0.0.39"

--- a/catalyst-gateway/bin/src/cardano/channels/event.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/event.rs
@@ -1,6 +1,4 @@
-//! Event types for Chain Indexer.
-
-#![allow(dead_code)]
+//! multi-consumer, multi-producer Cardano Chain Indexer Events channel.
 
 use cardano_blockchain_types::Slot;
 

--- a/catalyst-gateway/bin/src/cardano/channels/event.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/event.rs
@@ -64,7 +64,7 @@ impl ChainIndexerEventSender {
     /// To subscribe on processing events and instantiate `ChainIndexerEventReceiver` call
     /// `subscribe` method of the `ChainIndexerEventSender`
     pub(crate) fn new() -> Self {
-        Self(tokio::sync::broadcast::channel(30).0)
+        Self(tokio::sync::broadcast::channel(1).0)
     }
 
     /// Dispatches an event to all registered listeners.

--- a/catalyst-gateway/bin/src/cardano/channels/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/mod.rs
@@ -1,4 +1,31 @@
 //! Definition of different channels for the Cardano Chain Indexer
 
+use std::{any::type_name, fmt::Debug};
+
 pub(crate) mod event;
 pub(crate) mod state;
+
+/// A helper function to dispatch some message through the
+/// `tokio::sync::broadcast::Sender::send`.
+fn dispatch_message<T: Debug>(s: &tokio::sync::broadcast::Sender<T>, msg: T) {
+    let msg_debug = format!("{msg:?}");
+    tracing::debug!(msg = msg_debug, "Dispatching message");
+    if let Err(err) = s.send(msg) {
+        tracing::error!(error=%err, msg = msg_debug, "Unable to dispatch message.");
+    }
+}
+
+/// A helper function to receive some message from the
+/// `tokio::sync::broadcast::Receiver::recv`.
+/// Return `None` if the channel is closed.
+async fn receive_msg<T: Debug + Clone>(r: &mut tokio::sync::broadcast::Receiver<T>) -> Option<T> {
+    loop {
+        match r.recv().await {
+            Ok(msg) => return Some(msg),
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(lag)) => {
+                tracing::debug!(lag = lag, msg_type = type_name::<T>(), "Receiver lagged");
+            },
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+        }
+    }
+}

--- a/catalyst-gateway/bin/src/cardano/channels/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/mod.rs
@@ -11,7 +11,7 @@ fn dispatch_message<T: Debug>(s: &tokio::sync::broadcast::Sender<T>, msg: T) {
     let msg_debug = format!("{msg:?}");
     tracing::debug!(msg = msg_debug, "Dispatching message");
     if let Err(err) = s.send(msg) {
-        tracing::error!(error=%err, msg = msg_debug, "Unable to dispatch message.");
+        tracing::error!(error=%err, msg = msg_debug, "Unable to dispatch message. No any active receivers.");
     }
 }
 

--- a/catalyst-gateway/bin/src/cardano/channels/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/mod.rs
@@ -1,0 +1,4 @@
+//! Definition of different channels for the Cardano Chain Indexer
+
+pub(crate) mod event;
+pub(crate) mod state;

--- a/catalyst-gateway/bin/src/cardano/channels/state.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/state.rs
@@ -1,13 +1,26 @@
 //! multi-consumer, multi-producer Cardano Chain Indexer State channel.
 
+use cardano_blockchain_types::Slot;
+
 use super::{dispatch_message, receive_msg};
+
+/// Chain Indexer State structure
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) struct ChainIndexerState {
+    /// The immutable tip slot.
+    pub immutable_tip_slot: Slot,
+
+    /// The live tip slot.
+    pub live_tip_slot: Slot,
+}
 
 /// Chain Indexer state sender multi-producer channel
 #[derive(Debug, Clone)]
-pub(crate) struct ChainIndexerStateSender(tokio::sync::broadcast::Sender<()>);
+pub(crate) struct ChainIndexerStateSender(tokio::sync::broadcast::Sender<ChainIndexerState>);
 #[derive(Debug)]
 /// Chain Indexer state receiver multi-consumer channel
-pub(crate) struct ChainIndexerStateReceiver(tokio::sync::broadcast::Receiver<()>);
+pub(crate) struct ChainIndexerStateReceiver(tokio::sync::broadcast::Receiver<ChainIndexerState>);
 
 impl ChainIndexerStateSender {
     /// Creates a multi-producer channel for processing
@@ -19,7 +32,7 @@ impl ChainIndexerStateSender {
     }
 
     /// Updates to the latest state to all registered listeners.
-    pub(crate) fn update_state(&self, state: ()) {
+    pub(crate) fn update_state(&self, state: ChainIndexerState) {
         dispatch_message(&self.0, state);
     }
 
@@ -33,7 +46,7 @@ impl ChainIndexerStateSender {
 impl ChainIndexerStateReceiver {
     /// Receives the latest Chain Indexer state from the channel.
     /// Return `None` if the channel is closed.
-    pub(crate) async fn latest_state(&mut self) -> Option<()> {
+    pub(crate) async fn latest_state(&mut self) -> Option<ChainIndexerState> {
         receive_msg(&mut self.0).await
     }
 }

--- a/catalyst-gateway/bin/src/cardano/channels/state.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/state.rs
@@ -1,1 +1,39 @@
 //! multi-consumer, multi-producer Cardano Chain Indexer State channel.
+
+use super::{dispatch_message, receive_msg};
+
+/// Chain Indexer state sender multi-producer channel
+#[derive(Debug, Clone)]
+pub(crate) struct ChainIndexerStateSender(tokio::sync::broadcast::Sender<()>);
+#[derive(Debug)]
+/// Chain Indexer state receiver multi-consumer channel
+pub(crate) struct ChainIndexerStateReceiver(tokio::sync::broadcast::Receiver<()>);
+
+impl ChainIndexerStateSender {
+    /// Creates a multi-producer channel for processing
+    /// Chain Indexer state events.
+    /// To subscribe on processing events and instantiate `ChainIndexerStateReceiver` call
+    /// `subscribe` method of the `ChainIndexerStateSender`
+    pub(crate) fn new() -> Self {
+        Self(tokio::sync::broadcast::channel(1).0)
+    }
+
+    /// Dispatches an state to all registered listeners.
+    pub(crate) fn dispatch_event(&self, state: ()) {
+        dispatch_message(&self.0, state);
+    }
+
+    /// Creates a new multi-consumer `ChainIndexerStateReceiver` that will receive values
+    /// sent **after** this call to `subscribe`.
+    pub(crate) fn subscribe(&self) -> ChainIndexerStateReceiver {
+        ChainIndexerStateReceiver(self.0.subscribe())
+    }
+}
+
+impl ChainIndexerStateReceiver {
+    /// Receives the latest Chain Indexer state from the channel.
+    /// Return `None` if the channel is closed.
+    pub(crate) async fn receive_event(&mut self) -> Option<()> {
+        receive_msg(&mut self.0).await
+    }
+}

--- a/catalyst-gateway/bin/src/cardano/channels/state.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/state.rs
@@ -52,7 +52,8 @@ pub(crate) struct ChainIndexerStateSender(broadcast::Sender<ChainIndexerState>);
 /// Chain Indexer state receiver multi-consumer channel
 #[derive(Debug)]
 pub(crate) struct ChainIndexerStateReceiver {
-    /// The chain indexer's state.
+    /// The chain indexer's stored state, from the last `latest_state` call from the
+    /// `receiver`.
     state: Option<ChainIndexerState>,
     /// A `ChainIndexerState` receiver.
     receiver: broadcast::Receiver<ChainIndexerState>,
@@ -83,8 +84,9 @@ impl ChainIndexerStateSender {
 }
 
 impl ChainIndexerStateReceiver {
-    /// Returns the currently stored state. Returns `None` if the state was never updated.
-    pub(crate) fn current_state(&self) -> Option<&ChainIndexerState> {
+    /// Returns the stored state, from the last `latest_state` call. Returns `None` if the
+    /// state was never updated.
+    pub(crate) fn stored_state(&self) -> Option<&ChainIndexerState> {
         self.state.as_ref()
     }
 
@@ -92,6 +94,6 @@ impl ChainIndexerStateReceiver {
     /// Return `None` if the channel is closed.
     pub(crate) async fn latest_state(&mut self) -> Option<&ChainIndexerState> {
         self.state = receive_msg(&mut self.receiver).await;
-        self.current_state()
+        self.stored_state()
     }
 }

--- a/catalyst-gateway/bin/src/cardano/channels/state.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/state.rs
@@ -18,8 +18,8 @@ impl ChainIndexerStateSender {
         Self(tokio::sync::broadcast::channel(1).0)
     }
 
-    /// Dispatches an state to all registered listeners.
-    pub(crate) fn dispatch_event(&self, state: ()) {
+    /// Updates to the latest state to all registered listeners.
+    pub(crate) fn update_state(&self, state: ()) {
         dispatch_message(&self.0, state);
     }
 
@@ -33,7 +33,7 @@ impl ChainIndexerStateSender {
 impl ChainIndexerStateReceiver {
     /// Receives the latest Chain Indexer state from the channel.
     /// Return `None` if the channel is closed.
-    pub(crate) async fn receive_event(&mut self) -> Option<()> {
+    pub(crate) async fn latest_state(&mut self) -> Option<()> {
         receive_msg(&mut self.0).await
     }
 }

--- a/catalyst-gateway/bin/src/cardano/channels/state.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/state.rs
@@ -1,0 +1,1 @@
+//! multi-consumer, multi-producer Cardano Chain Indexer State channel.

--- a/catalyst-gateway/bin/src/cardano/channels/state.rs
+++ b/catalyst-gateway/bin/src/cardano/channels/state.rs
@@ -55,8 +55,8 @@ impl ChainIndexerStateSender {
         Self(tokio::sync::broadcast::channel(1).0)
     }
 
-    /// Updates to the latest state to all registered listeners.
-    pub(crate) fn update_state(&self, state: ChainIndexerState) {
+    /// Dispatches the latest state to all registered listeners.
+    pub(crate) fn dispatch_state(&self, state: ChainIndexerState) {
         dispatch_message(&self.0, state);
     }
 

--- a/catalyst-gateway/bin/src/cardano/indexed_status.rs
+++ b/catalyst-gateway/bin/src/cardano/indexed_status.rs
@@ -1,0 +1,109 @@
+//! An `IndexedStatus` structure.
+
+use cardano_blockchain_types::Slot;
+
+use crate::db::index::queries::sync_status::get::SyncStatus;
+
+/// A helper indexed status structure.
+///
+/// Its a collection of sorted ranges of indexed chunks of blocks.
+/// The first value is always a start of the range and second value is the end of the
+/// range.
+/// E.g.:
+/// [(`block_0`, `block_100`), (`block_150`, `block_TIP`)],
+/// NOT indexed chunk is from `block_100` to `block_150`, the rest of the data is
+/// indexed already
+#[derive(Debug, Clone, Default)]
+pub(crate) struct IndexedStatus(Vec<(Slot, Slot)>);
+
+impl IntoIterator for IndexedStatus {
+    type IntoIter = <Vec<(Slot, Slot)> as IntoIterator>::IntoIter;
+    type Item = (Slot, Slot);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a IndexedStatus {
+    type IntoIter = <&'a Vec<(Slot, Slot)> as IntoIterator>::IntoIter;
+    type Item = &'a (Slot, Slot);
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl From<Vec<SyncStatus>> for IndexedStatus {
+    fn from(value: Vec<SyncStatus>) -> Self {
+        Self(merge_consecutive_indexed_chunks(
+            value
+                .into_iter()
+                .map(|v| (v.start_slot, v.end_slot))
+                .collect(),
+        ))
+    }
+}
+
+/// Merge consecutive indexed chunks, to make processing them easier.
+fn merge_consecutive_indexed_chunks(mut synced_chunks: Vec<(Slot, Slot)>) -> Vec<(Slot, Slot)> {
+    // Sort the chunks by the starting key, if the ending key overlaps, we will deal with that
+    // during the merge.
+    synced_chunks.sort_by_key(|rec| rec.0);
+
+    let mut best_sync: Vec<(Slot, Slot)> = vec![];
+    let mut current_status: Option<(Slot, Slot)> = None;
+    for rec in synced_chunks {
+        if let Some(current) = current_status.take() {
+            if rec.0 >= current.0 && rec.1 <= current.1 {
+                // The new record is contained fully within the previous one.
+                // We will ignore the new record and use the previous one instead.
+                current_status = Some(current);
+            } else if rec.0 <= u64::from(current.1).saturating_add(1).into() {
+                // Either overlaps, or is directly consecutive.
+                // But not fully contained within the previous one.
+                current_status = Some((current.0, rec.1));
+            } else {
+                // Not consecutive, so store it.
+                // And set a new current one.
+                best_sync.push(current);
+                current_status = Some(rec);
+            }
+        } else {
+            current_status = Some(rec);
+        }
+    }
+    // Could have the final one in current still, so store it
+    if let Some(current) = current_status.take() {
+        best_sync.push(current);
+    }
+
+    best_sync
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_consecutive_indexed_chunks() {
+        // Add some test records, out of order.
+        // Two mergeable groups
+        let synced_chunks: Vec<(Slot, Slot)> = vec![
+            (112_001.into(), 200_000.into()),
+            (0.into(), 12000.into()),
+            (56789.into(), 99000.into()),
+            (100_000.into(), 112_000.into()),
+            (12300.into(), 56789.into()),
+            (0.into(), 12345.into()),
+        ];
+
+        let merged_syncs_status = merge_consecutive_indexed_chunks(synced_chunks);
+
+        // Expected result
+        let expected: &[(Slot, Slot)] =
+            &[(0.into(), 99000.into()), (100_000.into(), 200_000.into())];
+
+        assert_eq!(merged_syncs_status.as_slice(), expected);
+    }
+}

--- a/catalyst-gateway/bin/src/cardano/indexed_status.rs
+++ b/catalyst-gateway/bin/src/cardano/indexed_status.rs
@@ -1,5 +1,7 @@
 //! An `IndexedStatus` structure.
 
+use std::ops::Deref;
+
 use cardano_blockchain_types::Slot;
 
 use crate::db::index::queries::sync_status::get::SyncStatus;
@@ -15,6 +17,24 @@ use crate::db::index::queries::sync_status::get::SyncStatus;
 /// indexed already
 #[derive(Debug, Clone, Default)]
 pub(crate) struct IndexedStatus(Vec<(Slot, Slot)>);
+
+impl IndexedStatus {
+    /// Apply an update by the provided index range
+    pub(crate) fn update(&mut self, start: Slot, end: Slot) {
+        let _ = self;
+        let _ = start;
+        let _ = end;
+        unimplemented!("TODO: in progress");
+    }
+}
+
+impl Deref for IndexedStatus {
+    type Target = Vec<(Slot, Slot)>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl IntoIterator for IndexedStatus {
     type IntoIter = <Vec<(Slot, Slot)> as IntoIterator>::IntoIter;
@@ -53,6 +73,7 @@ fn merge_consecutive_indexed_chunks(mut synced_chunks: Vec<(Slot, Slot)>) -> Vec
 
     let mut best_sync: Vec<(Slot, Slot)> = vec![];
     let mut current_status: Option<(Slot, Slot)> = None;
+
     for rec in synced_chunks {
         if let Some(current) = current_status.take() {
             if rec.0 >= current.0 && rec.1 <= current.1 {

--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -455,7 +455,7 @@ impl SyncTask {
     /// Add a new `SyncTask` to the queue.
     fn add_sync_task(&mut self, params: SyncParams) {
         let state_recv = self.state_channel.subscribe();
-        // immediately setting the latest state, do the `state_recv` will always have at least one
+        // immediately setting the latest state, so the `state_recv` will always have at least one
         // value
         self.dispatch_state();
 

--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -296,7 +296,13 @@ fn sync_subchain(
                 cardano_chain_follower::Kind::Block => {
                     let block = chain_update.block_data();
 
-                    if let Err(error) = index_block(block, &mut state_recv).await {
+                    if let Err(error) = index_block(
+                        block,
+                        &mut state_recv,
+                        params.actual_start().slot_or_default(),
+                    )
+                    .await
+                    {
                         let error_msg = format!("Failed to index block {}", block.point());
                         error!(chain=%params.chain, error=%error, params=%params, error_msg);
                         return params.done(
@@ -347,7 +353,13 @@ fn sync_subchain(
 
                         // Purge success, now index the current block
                         let block = chain_update.block_data();
-                        if let Err(error) = index_block(block, &mut state_recv).await {
+                        if let Err(error) = index_block(
+                            block,
+                            &mut state_recv,
+                            params.actual_start().slot_or_default(),
+                        )
+                        .await
+                        {
                             let error_msg =
                                 format!("Failed to index block after rollback {}", block.point());
                             error!(chain=%params.chain, error=%error, params=%params, error_msg);

--- a/catalyst-gateway/bin/src/cardano/mod.rs
+++ b/catalyst-gateway/bin/src/cardano/mod.rs
@@ -457,7 +457,7 @@ impl SyncTask {
         let state_recv = self.state_channel.subscribe();
         // immediately setting the latest state, do the `state_recv` will always have at least one
         // value
-        self.update_state();
+        self.dispatch_state();
 
         self.sync_tasks.push(sync_subchain(
             params,
@@ -581,7 +581,7 @@ impl SyncTask {
                                     live_slot: self.live_tip_slot,
                                 },
                             );
-                            self.update_state();
+                            self.dispatch_state();
                             info!(chain=%self.cfg.chain, report=%finished, "Chain Indexer finished reaching TIP.");
 
                             self.start_immutable_followers();
@@ -602,7 +602,7 @@ impl SyncTask {
                                     finished.start.slot_or_default(),
                                     finished.end.slot_or_default(),
                                 );
-                                self.update_state();
+                                self.dispatch_state();
 
                                 finished.last_indexed_block.as_ref().inspect(|block| {
                                     self.event_channel.dispatch_event(
@@ -736,13 +736,13 @@ impl SyncTask {
         Some((start_slot, Point::fuzzy(end)))
     }
 
-    /// Updates with the current state a `state_channel`
-    fn update_state(&self) {
+    /// Dispatches the current state through the `state_channel`
+    fn dispatch_state(&self) {
         let state = ChainIndexerState {
             immutable_tip_slot: self.immutable_tip_slot,
             immutable_indexed_status: self.immutable_indexed_status.clone(),
         };
-        self.state_channel.update_state(state);
+        self.state_channel.dispatch_state(state);
     }
 }
 

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -292,7 +292,7 @@ async fn wait_for_indexing_up_to_block(
                 break;
             }
         } else if state.is_reached_immutable_tip() {
-            // for the live block we should until the whole immutable part would be indexed, we are
+            // for the live block we should wait until the whole immutable part would be indexed, we are
             // not waiting for the live part to be indexed, because in any case its indexing
             // sequentially
             break;

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -106,7 +106,7 @@ impl Rbac509InsertQuery {
         }
 
         // Need to wait until the `cip509.previous_transaction` would be definitely indexed
-        let (mithril_tip, _) =
+        let (_mithril_tip, _) =
             cardano_chain_follower::ChainFollower::get_tips(block.network()).await;
 
         let previous_transaction = cip509.previous_transaction();

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -107,15 +107,12 @@ impl Rbac509InsertQuery {
             );
         }
 
-        // Slots arithmetic has saturating semantic, so this is ok.
-        #[allow(clippy::arithmetic_side_effects)]
-        let wait_to = range_start - 1.into();
         // There are multiple parallel tasks that are indexing ranges of blocks such as `0..100`,
         // `100..200`, etc. We need to wait for all previous ranges to be indexed before
         // processing a RBAC registration.
         wait_for_indexing_up_to_block(
             indexer_state,
-            wait_to,
+            range_start,
             cip509.txn_hash(),
             block.is_immutable(),
         )

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -288,13 +288,13 @@ async fn wait_for_indexing_up_to_block(
         if block.is_immutable() {
             // for the immutable block we need to wait when everything would be indexed up to the
             // current block
-            if state.is_immutable_indexed(block.slot()) {
+            if state.is_immutable_fully_indexed_up_to(block.slot()) {
                 break;
             }
         } else if state.is_reached_immutable_tip() {
-            // for the live block we should wait until the whole immutable part would be indexed, we are
-            // not waiting for the live part to be indexed, because in any case its indexing
-            // sequentially
+            // for the live block we should wait until the whole immutable part would be indexed, we
+            // are not waiting for the live part to be indexed, because in any case its
+            // indexing sequentially
             break;
         }
     }

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -105,6 +105,10 @@ impl Rbac509InsertQuery {
             );
         }
 
+        // Need to wait until the `cip509.previous_transaction` would be definitely indexed
+        let (mithril_tip, _) =
+            cardano_chain_follower::ChainFollower::get_tips(block.network()).await;
+
         let previous_transaction = cip509.previous_transaction();
         match Box::pin(validate_rbac_registration(
             cip509,

--- a/catalyst-gateway/bin/src/metrics/chain_indexer.rs
+++ b/catalyst-gateway/bin/src/metrics/chain_indexer.rs
@@ -3,7 +3,7 @@
 use std::ops::Sub;
 
 use crate::{
-    cardano::event::{ChainIndexerEvent as Event, ChainIndexerEventReceiver},
+    cardano::channels::event::{ChainIndexerEvent as Event, ChainIndexerEventReceiver},
     settings::Settings,
 };
 

--- a/catalyst-gateway/bin/src/metrics/chain_indexer.rs
+++ b/catalyst-gateway/bin/src/metrics/chain_indexer.rs
@@ -7,7 +7,7 @@ use crate::{
     settings::Settings,
 };
 
-/// Spawn an updater backround task, which follows `ChainIndexerEvent` from the provided
+/// Spawn an updater background task, which follows `ChainIndexerEvent` from the provided
 /// channel and updates the corresponding metrics
 pub(crate) fn run_updater(mut event_channel: ChainIndexerEventReceiver) {
     let api_host_names = Settings::api_host_names().join(",");

--- a/catalyst-gateway/bin/src/metrics/chain_indexer.rs
+++ b/catalyst-gateway/bin/src/metrics/chain_indexer.rs
@@ -1,5 +1,101 @@
 //! Metrics related to Chain Indexer analytics.
 
+use std::ops::Sub;
+
+use crate::{
+    cardano::event::{ChainIndexerEvent as Event, ChainIndexerEventReceiver},
+    settings::Settings,
+};
+
+/// Spawn an updater backround task, which follows `ChainIndexerEvent` from the provided
+/// channel and updates the corresponding metrics
+pub(crate) fn run_updater(mut event_channel: ChainIndexerEventReceiver) {
+    let api_host_names = Settings::api_host_names().join(",");
+    let service_id = Settings::service_id();
+    let network = Settings::cardano_network().to_string();
+
+    tokio::spawn(async move {
+        while let Some(event) = event_channel.receive_event().await {
+            if let Event::SyncLiveChainStarted = event {
+                reporter::LIVE_REACHED_TIP
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(0);
+            }
+            if let Event::SyncImmutableChainStarted = event {
+                reporter::IMMUTABLE_REACHED_TIP
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(0);
+            }
+            if let Event::SyncLiveChainCompleted = event {
+                reporter::LIVE_REACHED_TIP
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(1);
+            }
+            if let Event::SyncImmutableChainCompleted = event {
+                reporter::IMMUTABLE_REACHED_TIP
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(1);
+            }
+            if let Event::SyncTasksChanged { current_sync_tasks } = event {
+                reporter::RUNNING_INDEXER_TASKS_COUNT
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(From::from(current_sync_tasks));
+            }
+            if let Event::LiveTipSlotChanged {
+                live_slot,
+                immutable_slot,
+            } = event
+            {
+                reporter::CURRENT_LIVE_TIP_SLOT
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(i64::try_from(u64::from(live_slot)).unwrap_or(-1));
+                reporter::SLOT_TIP_DIFF
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(
+                        u64::from(live_slot.sub(immutable_slot))
+                            .try_into()
+                            .unwrap_or(-1),
+                    );
+            }
+            if let Event::ImmutableTipSlotChanged {
+                live_slot,
+                immutable_slot,
+            } = event
+            {
+                reporter::CURRENT_IMMUTABLE_TIP_SLOT
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(i64::try_from(u64::from(immutable_slot)).unwrap_or(-1));
+
+                reporter::SLOT_TIP_DIFF
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(
+                        u64::from(live_slot.sub(immutable_slot))
+                            .try_into()
+                            .unwrap_or(-1),
+                    );
+            }
+            if let Event::IndexedSlotProgressed { slot } = event {
+                reporter::HIGHEST_COMPLETE_INDEXED_SLOT
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(i64::try_from(u64::from(slot)).unwrap_or(-1));
+            }
+            if let Event::BackwardDataPurged = event {
+                reporter::TRIGGERED_BACKWARD_PURGES_COUNT
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .inc();
+            }
+            if let Event::ForwardDataPurged { purge_slots } = event {
+                reporter::TRIGGERED_FORWARD_PURGES_COUNT
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .inc();
+                reporter::PURGED_SLOTS
+                    .with_label_values(&[&api_host_names, service_id, &network])
+                    .set(i64::try_from(purge_slots).unwrap_or(-1));
+            }
+        }
+    });
+}
+
 /// All the related Chain Indexer reporting metrics to the Prometheus service are inside
 /// this module.
 pub(crate) mod reporter {


### PR DESCRIPTION
# Description

- Added new `ChainIndexerState` channel, for propagating a chain indexer state
- Refactored `ChainIndexerEvent` channel.
- Added new `IndexedStatus(Vec<(Slot, Slot)>)` structure, which is a replacement of `SyncStatus` under the `SyncTask` type. It is needed to dynamically update the state of synchronised chunks, so correctly propagate a correct state through the channel.
- Added `wait_for_indexing_up_to_block` function for waiting and using information from the `ChainIndexerState` channel, wait until all necessary blocks behind the current one are indexed.