### PR TITLE
feat(cat-gateway): Propagate RBAC indexing 'fatal' errors

### DIFF
--- a/catalyst-gateway/bin/src/db/index/block/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/mod.rs
@@ -58,7 +58,7 @@ pub(crate) async fn index_block(block: &MultiEraBlock) -> anyhow::Result<()> {
         txo_index.index(block.network(), &txn, slot_no, txn_id, index);
 
         // Index RBAC 509 inside the transaction.
-        Box::pin(rbac509_index.index(txn_id, index, block, &mut rbac_context)).await;
+        Box::pin(rbac509_index.index(txn_id, index, block, &mut rbac_context)).await?;
     }
 
     // We then execute each batch of data from the block.

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod insert_rbac509_invalid;
 
 use std::{collections::HashSet, sync::Arc};
 
+use anyhow::Result;
 use cardano_blockchain_types::{MultiEraBlock, TransactionId, TxnIndex};
 use rbac_registration::cardano::cip509::Cip509;
 use scylla::Session;
@@ -55,7 +56,7 @@ impl Rbac509InsertQuery {
     /// Prepare Batch of Insert RBAC 509 Registration Data Queries
     pub(crate) async fn prepare_batch(
         session: &Arc<Session>, cfg: &EnvVars,
-    ) -> anyhow::Result<(SizedBatch, SizedBatch, SizedBatch, SizedBatch, SizedBatch)> {
+    ) -> Result<(SizedBatch, SizedBatch, SizedBatch, SizedBatch, SizedBatch)> {
         Ok((
             insert_rbac509::Params::prepare_batch(session, cfg).await?,
             insert_rbac509_invalid::Params::prepare_batch(session, cfg).await?,
@@ -70,13 +71,13 @@ impl Rbac509InsertQuery {
     pub(crate) async fn index(
         &mut self, txn_hash: TransactionId, index: TxnIndex, block: &MultiEraBlock,
         context: &mut RbacBlockIndexingContext,
-    ) {
+    ) -> Result<()> {
         let slot = block.slot();
         let cip509 = match Cip509::new(block, index, &[]) {
             Ok(Some(v)) => v,
             Ok(None) => {
                 // Nothing to index.
-                return;
+                return Ok(());
             },
             Err(e) => {
                 // This registration is either completely corrupted or someone else is using "our"
@@ -85,9 +86,10 @@ impl Rbac509InsertQuery {
                 debug!(
                     slot = ?slot,
                     index = ?index,
-                    "Invalid RBAC Registration Metadata in transaction: {e:?}"
+                    err = ?e,
+                    "Invalid RBAC Registration Metadata in transaction"
                 );
-                return;
+                return Ok(());
             },
         };
 
@@ -197,12 +199,27 @@ impl Rbac509InsertQuery {
             // is no Catalyst ID, then we cannot record this registration as invalid and can only
             // ignore (and log) it.
             Err(RbacValidationError::UnknownCatalystId) => {
-                debug!("Unable to determine Catalyst id for registration: slot = {slot:?}, index = {index:?}, txn_hash = {txn_hash:?}");
+                debug!(
+                    slot = ?slot,
+                    index = ?index,
+                    txn_hash = ?txn_hash,
+                    "Unable to determine Catalyst id for registration"
+                );
             },
-            Err(RbacValidationError::Other(e)) => {
-                error!("Error indexing RBAC registration: slot = {slot:?}, index = {index:?}, txn_hash = {txn_hash:?}: {e:?}");
+            Err(RbacValidationError::Fatal(e)) => {
+                error!(
+                   slot = ?slot,
+                   index = ?index,
+                   txn_hash = ?txn_hash,
+                   err = ?e,
+                   "Error indexing RBAC registration"
+                );
+                // Propagate an error.
+                return Err(e);
             },
         }
+
+        Ok(())
     }
 
     /// Execute the RBAC 509 Registration Indexing Queries.

--- a/catalyst-gateway/bin/src/rbac/validation_result.rs
+++ b/catalyst-gateway/bin/src/rbac/validation_result.rs
@@ -46,14 +46,17 @@ pub enum RbacValidationError {
     ///
     /// This can happen if a previous transaction ID in the registration is incorrect.
     UnknownCatalystId,
-    /// A different error occurred during validation.
+    /// A "fatal" error occurred during validation.
     ///
-    /// This error isn't processed specifically and is just logged.
-    Other(anyhow::Error),
+    /// This means that the validation wasn't performed properly (usually because of a
+    /// database failure) and we cannot process the given registration. This error is
+    /// propagated on a higher level, so there will be another attempt to index that
+    /// block.
+    Fatal(anyhow::Error),
 }
 
 impl From<anyhow::Error> for RbacValidationError {
     fn from(e: anyhow::Error) -> Self {
-        RbacValidationError::Other(e)
+        RbacValidationError::Fatal(e)
     }
 }


### PR DESCRIPTION
# Description

Propagate RBAC indexing errors and update log messages.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/3051 and https://github.com/input-output-hk/catalyst-voices/issues/3041.