### PR TITLE
fix(general): Revert applying catalyst-forge version to the catalyst-ci

### DIFF
--- a/.github/workflows/branch-delete-cleanup.yml
+++ b/.github/workflows/branch-delete-cleanup.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   ci:
-    uses: input-output-hk/catalyst-ci/.github/workflows/branch-pages-delete.yml@ci/v1.8.0
+    uses: input-output-hk/catalyst-ci/.github/workflows/branch-pages-delete.yml@master
     with:
       aws_role_arn: arn:aws:iam::332405224602:role/ci
       aws_region: eu-central-1

--- a/.github/workflows/semantic_pull_request.yml
+++ b/.github/workflows/semantic_pull_request.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Validate PR title
-    uses: input-output-hk/catalyst-ci/.github/workflows/semantic_pull_request.yml@ci/v1.8.0
+    uses: input-output-hk/catalyst-ci/.github/workflows/semantic_pull_request.yml@master
     with:
       requireScope: false
       scopes: |


### PR DESCRIPTION
# Description

- Fixing a few github workflows to the based on the `catalyst-ci` version, which was wrongly established as a `catalyst-forge` repo release