### PR TITLE
feat(cat-voices): read only mode proposal view

### DIFF
--- a/catalyst_voices/apps/voices/lib/app/view/app_content.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_content.dart
@@ -80,6 +80,7 @@ final class _AppContent extends StatelessWidget {
                   // screen behavior.
                   child: AppSplashScreenManager(
                     child: AppMobileAccessRestriction(
+                      routerConfig: routerConfig,
                       child: DefaultShareManager(
                         child: child ?? const SizedBox.shrink(),
                       ),

--- a/catalyst_voices/apps/voices/lib/app/view/app_mobile_access_restriction.dart
+++ b/catalyst_voices/apps/voices/lib/app/view/app_mobile_access_restriction.dart
@@ -19,41 +19,54 @@ typedef _LayoutData = ({
 });
 
 class AppMobileAccessRestriction extends StatelessWidget {
+  final RouterConfig<Object> routerConfig;
   final Widget child;
 
   const AppMobileAccessRestriction({
     super.key,
+    required this.routerConfig,
     required this.child,
   });
 
   @override
   Widget build(BuildContext context) {
-    return PlatformAwareBuilder<Widget>(
-      mobileWeb: ResponsiveBuilder<_LayoutData>(
-        xs: (
-          titleStyle: context.textTheme.displayMedium?.copyWith(
-            color: context.colorScheme.primary,
+    final provider = routerConfig.routeInformationProvider!;
+
+    return ListenableBuilder(
+      listenable: provider,
+      builder: (context, _) {
+        final currentPath = provider.value.uri.path;
+        final isProposalRoute = currentPath.contains('/proposal/');
+
+        return PlatformAwareBuilder<Widget>(
+          enabled: !isProposalRoute,
+          mobileWeb: ResponsiveBuilder<_LayoutData>(
+            xs: (
+              titleStyle: context.textTheme.displayMedium?.copyWith(
+                color: context.colorScheme.primary,
+              ),
+              subtitleStyle: context.textTheme.titleSmall,
+              descriptionStyle: context.textTheme.bodyMedium,
+              isMobile: true,
+            ),
+            other: (
+              titleStyle: context.textTheme.displayMedium?.copyWith(
+                color: context.colorScheme.primary,
+                fontSize: 78,
+                height: 1.15,
+              ),
+              subtitleStyle: context.textTheme.titleMedium,
+              descriptionStyle: context.textTheme.bodyLarge,
+              isMobile: false,
+            ),
+            builder: (context, data) => _MobileSplashScreen(
+              data: data,
+            ),
           ),
-          subtitleStyle: context.textTheme.titleSmall,
-          descriptionStyle: context.textTheme.bodyMedium,
-          isMobile: true,
-        ),
-        other: (
-          titleStyle: context.textTheme.displayMedium?.copyWith(
-            color: context.colorScheme.primary,
-            fontSize: 78,
-            height: 1.15,
-          ),
-          subtitleStyle: context.textTheme.titleMedium,
-          descriptionStyle: context.textTheme.bodyLarge,
-          isMobile: false,
-        ),
-        builder: (context, data) => _MobileSplashScreen(
-          data: data,
-        ),
-      ),
-      other: child,
-      builder: (context, child) => child!,
+          other: child,
+          builder: (context, child) => child!,
+        );
+      },
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/common/constants/constants.dart
+++ b/catalyst_voices/apps/voices/lib/common/constants/constants.dart
@@ -3,6 +3,7 @@ import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.da
 abstract class VoicesConstants {
   static const _docs = 'https://docs.projectcatalyst.io';
   static const _catalystApp = '$_docs/catalyst-tools/catalyst-app';
+  static const _projectCatalyst = 'https://projectcatalyst.io';
 
   /// External urls
   static const supportedWalletsUrl = '$_docs/current-fund/voter-registration/supported-wallets';
@@ -44,6 +45,7 @@ abstract class VoicesConstants {
   static const campaignTimeline = '$_docs/current-fund/fund-basics/fund-timeline';
   static const milestoneGuideline =
       '$_docs/current-fund/project-onboarding/milestone-based-proposals';
+  static const projectCatalystFund14Url = '$_projectCatalyst/funds/14';
 
   static String cardanoScanStakeAddressUrl(ShelleyAddress stakeAddress) {
     switch (stakeAddress.network) {

--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
@@ -17,8 +17,10 @@ import 'package:catalyst_voices/routes/routes.dart';
 import 'package:catalyst_voices/widgets/modals/comment/submit_comment_error_dialog.dart';
 import 'package:catalyst_voices/widgets/snackbar/voices_snackbar.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -47,17 +49,20 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
     final readOnlyMode = context.select<ProposalCubit, bool>((cubit) => cubit.state.readOnlyMode);
 
     return VoicesAppBar(
-      leading: NavigationBack(
-        isCompact: true,
-        onCanNotPop: (context, _) => const ProposalsRoute().go(context),
-      ),
+      leading: !(readOnlyMode || CatalystPlatform.isMobileWeb)
+          ? NavigationBack(
+              isCompact: true,
+              onCanNotPop: (context, _) => const ProposalsRoute().go(context),
+            )
+          : null,
+      enableBackHome: !(readOnlyMode || CatalystPlatform.isMobileWeb),
       actions: [
         Offstage(
-          offstage: readOnlyMode,
+          offstage: readOnlyMode || CatalystPlatform.isMobileWeb,
           child: const SessionActionHeader(),
         ),
         Offstage(
-          offstage: readOnlyMode,
+          offstage: readOnlyMode || CatalystPlatform.isMobileWeb,
           child: const SessionStateHeader(),
         ),
       ],
@@ -81,6 +86,8 @@ class _ProposalPageState extends State<ProposalPage>
       child: Scaffold(
         appBar: const _AppBar(),
         endDrawer: const OpportunitiesDrawer(),
+        floatingActionButton:
+            _ScrollToTopButton(segmentsScrollController: _segmentsScrollController),
         body: ProposalHeaderWrapper(
           child: ProposalSidebars(
             navPanel: const ProposalNavigationPanel(),
@@ -188,5 +195,74 @@ class _ProposalPageState extends State<ProposalPage>
         : state.updateSegments(data);
 
     _segmentsController.value = newState;
+  }
+}
+
+class _ScrollToTopButton extends StatefulWidget {
+  final ItemScrollController segmentsScrollController;
+
+  const _ScrollToTopButton({
+    required this.segmentsScrollController,
+  });
+
+  @override
+  State<_ScrollToTopButton> createState() => _ScrollToTopButtonState();
+}
+
+class _ScrollToTopButtonState extends State<_ScrollToTopButton> {
+  ScrollNotificationObserverState? _scrollNotificationObserver;
+  bool _showButton = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Offstage(
+      offstage: !_showButton,
+      child: FloatingActionButton(
+        onPressed: _scrollToTop,
+        child: VoicesAssets.icons.arrowUp.buildIcon(),
+      ),
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _scrollNotificationObserver?.removeListener(_handleScrollNotification);
+    _scrollNotificationObserver = ScrollNotificationObserver.maybeOf(context);
+    _scrollNotificationObserver?.addListener(_handleScrollNotification);
+  }
+
+  @override
+  void dispose() {
+    _scrollNotificationObserver?.removeListener(_handleScrollNotification);
+    _scrollNotificationObserver = null;
+    super.dispose();
+  }
+
+  void _handleScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollUpdateNotification) {
+      final element = notification.context as Element?;
+
+      // Only react to content scroll from ProposalContent, not menu
+      if (element?.findAncestorWidgetOfExactType<ProposalContent>() != null) {
+        final oldShowButton = _showButton;
+        final metrics = notification.metrics;
+
+        _showButton = metrics.extentBefore > 50;
+
+        if (_showButton != oldShowButton) {
+          setState(() {});
+        }
+      }
+    }
+  }
+
+  Future<void> _scrollToTop() async {
+    await widget.segmentsScrollController.scrollTo(
+      index: 0,
+      duration: const Duration(milliseconds: 300),
+      alignment: 1.5,
+    );
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/proposal/snack_bar/viewing_older_version_snack_bar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/snack_bar/viewing_older_version_snack_bar.dart
@@ -21,11 +21,13 @@ final class ViewingOlderVersionSnackBar extends VoicesSnackBar {
         },
         child: Text(context.l10n.viewLatestDocumentVersion),
       ),
+      title: context.l10n.headsUpTitle,
     );
   }
 
   ViewingOlderVersionSnackBar._({
     required super.message,
+    super.title,
     required Widget action,
   }) : super(
           type: VoicesSnackBarType.warning,

--- a/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_metadata_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_metadata_tile.dart
@@ -52,7 +52,7 @@ class ProposalMetadataTile extends StatelessWidget {
           children: <Widget>[
             ProposalPublishChip(proposalPublish: status),
             const SizedBox(width: 8),
-            const ProposalVersion(readOnly: true),
+            ProposalVersion(readOnly: !CatalystPlatform.isMobileWeb),
             if (createdAt != null) ...[
               const SizedBox(width: 16),
               _CreatedAtText(

--- a/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_overview_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_overview_tile.dart
@@ -1,6 +1,8 @@
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_favorite_button.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_share_button.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter/material.dart';
 
 class ProposalOverviewTile extends StatelessWidget {
@@ -47,7 +49,12 @@ class ProposalOverviewTile extends StatelessWidget {
             const SizedBox(width: 16),
             const ProposalShareButton(),
             const SizedBox(width: 8),
-            const ProposalFavoriteButton(),
+            // TODO(LynxLynxx): Remove when we support mobile web
+            Offstage(
+              offstage: context.select<ProposalCubit, bool>((cubit) => cubit.state.readOnlyMode) ||
+                  CatalystPlatform.isMobileWeb,
+              child: const ProposalFavoriteButton(),
+            ),
           ],
         ),
         const SizedBox(height: 16),

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_app_closed.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_app_closed.dart
@@ -1,0 +1,184 @@
+import 'package:catalyst_voices/common/constants/constants.dart';
+import 'package:catalyst_voices/common/ext/build_context_ext.dart';
+import 'package:catalyst_voices/pages/proposal/proposal_content.dart';
+import 'package:catalyst_voices/widgets/widgets.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+import 'package:flutter/material.dart';
+
+class ProposalAppClosed extends StatefulWidget {
+  const ProposalAppClosed({
+    super.key,
+  });
+
+  @override
+  State<ProposalAppClosed> createState() => _ProposalAppClosedState();
+}
+
+class _AppCloseText extends StatelessWidget {
+  final MainAxisSize mainAxisSize;
+  const _AppCloseText({this.mainAxisSize = MainAxisSize.min});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: mainAxisSize,
+      spacing: 16,
+      children: [
+        VoicesAvatar(
+          icon: VoicesAssets.icons.exclamation.buildIcon(
+            color: context.colors.iconsError,
+          ),
+          backgroundColor: context.colors.onSurfaceError08,
+        ),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                context.l10n.catalystAppClosed,
+                style: context.textTheme.titleMedium,
+              ),
+              Text(
+                context.l10n.browseProposalsOnProjectCatalyst,
+                style: context.textTheme.bodyMedium?.copyWith(
+                  color: context.colors.textOnPrimaryLevel1,
+                ),
+                maxLines: 2,
+                softWrap: true,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Button extends StatelessWidget with LaunchUrlMixin {
+  const _Button();
+
+  @override
+  Widget build(BuildContext context) {
+    return VoicesFilledButton(
+      trailing: VoicesAssets.icons.externalLink.buildIcon(),
+      child: Text(
+        context.l10n.browseFund14Proposals,
+      ),
+      onTap: () async {
+        await launchUri(VoicesConstants.projectCatalystFund14Url.getUri());
+      },
+    );
+  }
+}
+
+class _ProposalAppClosedState extends State<ProposalAppClosed> {
+  ScrollNotificationObserverState? _scrollNotificationObserver;
+  double _opacity = 1;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<ProposalCubit, ProposalState, bool>(
+      selector: (state) {
+        return state.readOnlyMode;
+      },
+      builder: (context, readOnlyMode) {
+        return Offstage(
+          offstage: !readOnlyMode || _opacity == 0,
+          child: AnimatedOpacity(
+            opacity: _opacity,
+            duration: const Duration(milliseconds: 200),
+            child: ResponsiveBuilder<double>(
+              xs: 0,
+              sm: 16,
+              md: 32,
+              other: 56,
+              builder: (context, spacing) => Padding(
+                padding: EdgeInsets.only(left: spacing / 2, right: spacing, top: 12),
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(16),
+                    color: context.colors.elevationsOnSurfaceNeutralLv0,
+                  ),
+                  padding: const EdgeInsets.all(12),
+                  width: double.infinity,
+                  child: ResponsiveChild(
+                    xs: (context) => const _SmallView(),
+                    other: (context) => const Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      spacing: 16,
+                      children: [
+                        Expanded(child: _AppCloseText()),
+                        _Button(),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _scrollNotificationObserver?.removeListener(_handleScrollNotification);
+    _scrollNotificationObserver = ScrollNotificationObserver.maybeOf(context);
+    _scrollNotificationObserver?.addListener(_handleScrollNotification);
+  }
+
+  @override
+  void dispose() {
+    _scrollNotificationObserver?.removeListener(_handleScrollNotification);
+    _scrollNotificationObserver = null;
+    super.dispose();
+  }
+
+  void _handleScrollNotification(ScrollNotification notification) {
+    if (notification is ScrollUpdateNotification) {
+      final element = notification.context as Element?;
+
+      // Only react to content scroll from ProposalContent, not menu
+      if (element?.findAncestorWidgetOfExactType<ProposalContent>() != null) {
+        final metrics = notification.metrics;
+
+        const fadeDistance = 75.0;
+        final scrollOffset = metrics.extentBefore;
+        final newOpacity = (1.0 - (scrollOffset / fadeDistance)).clamp(0.0, 1.0);
+
+        if ((_opacity - newOpacity).abs() > 0.01) {
+          setState(() {
+            _opacity = newOpacity;
+          });
+        }
+      }
+    }
+  }
+}
+
+class _SmallView extends StatelessWidget {
+  const _SmallView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 16,
+      children: [
+        _AppCloseText(mainAxisSize: MainAxisSize.max),
+        SizedBox(
+          width: double.infinity,
+          child: _Button(),
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_header.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_header.dart
@@ -1,5 +1,6 @@
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/proposal/proposal_content.dart';
+import 'package:catalyst_voices/pages/proposal/widget/proposal_app_closed.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_favorite_button.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_share_button.dart';
 import 'package:catalyst_voices/pages/proposal/widget/proposal_version.dart';
@@ -44,6 +45,7 @@ class ProposalHeaderWrapper extends StatelessWidget {
     return Stack(
       children: [
         child,
+        const ProposalAppClosed(),
         const ProposalHeader(),
       ],
     );
@@ -55,14 +57,21 @@ class _ProposalControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Row(
-      mainAxisSize: MainAxisSize.min,
-      spacing: 8,
-      children: [
-        ProposalVersion(),
-        ProposalShareButton(),
-        ProposalFavoriteButton(),
-      ],
+    // TODO(LynxLynxx): Remove when we support mobile web
+    return ResponsiveChild(
+      xs: (context) => const SizedBox(),
+      other: (context) => Row(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
+        children: [
+          const ProposalVersion(),
+          const ProposalShareButton(),
+          Offstage(
+            offstage: context.select<ProposalCubit, bool>((cubit) => cubit.state.readOnlyMode),
+            child: const ProposalFavoriteButton(),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_sidebars.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_sidebars.dart
@@ -15,14 +15,19 @@ class ProposalSidebars extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ResponsiveBuilder<double>(
+      xs: 0,
       sm: 16,
       md: 32,
       other: 56,
       builder: (context, spacing) {
         return SidebarScaffold(
-          leftRail: Padding(
-            padding: EdgeInsets.symmetric(horizontal: spacing / 2),
-            child: navPanel,
+          // TODO(LynxLynxx): Remove when we support mobile web
+          leftRail: Offstage(
+            offstage: CatalystPlatform.isMobileWeb,
+            child: Padding(
+              padding: EdgeInsets.only(left: spacing / 2, right: spacing / 2, top: 40),
+              child: navPanel,
+            ),
           ),
           spacing: 0,
           body: Padding(

--- a/catalyst_voices/apps/voices/lib/widgets/app_bar/voices_app_bar.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/app_bar/voices_app_bar.dart
@@ -25,6 +25,7 @@ class VoicesAppBar extends StatelessWidget implements PreferredSizeWidget {
   final bool showSearch;
   final bool automaticallyImplyLeading;
   final Color? backgroundColor;
+  final bool enableBackHome;
 
   const VoicesAppBar({
     super.key,
@@ -33,6 +34,7 @@ class VoicesAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.showSearch = false,
     this.automaticallyImplyLeading = true,
     this.backgroundColor,
+    this.enableBackHome = true,
   });
 
   @override
@@ -56,7 +58,7 @@ class VoicesAppBar extends StatelessWidget implements PreferredSizeWidget {
                 leadingWidth: 48.0 + spacing,
                 automaticallyImplyLeading: false,
                 backgroundColor: backgroundColor,
-                title: _Title(showSearch: showSearch),
+                title: _Title(showSearch: showSearch, enableBackHome: enableBackHome),
                 actions: [
                   _Actions(children: actions),
                 ],
@@ -133,14 +135,16 @@ class _Actions extends StatelessWidget {
 }
 
 class _BrandPicture extends StatelessWidget {
-  const _BrandPicture();
+  final bool enableBackHome;
+
+  const _BrandPicture({required this.enableBackHome});
 
   @override
   Widget build(BuildContext context) {
     return DevToolsEnabler(
       child: VoicesGestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: () => GoRouter.of(context).go(Routes.initialLocation),
+        onTap: () => enableBackHome ? GoRouter.of(context).go(Routes.initialLocation) : null,
         child: Theme.of(context).brandAssets.brand.logo(context).buildPicture(),
       ),
     );
@@ -169,8 +173,9 @@ class _Theme extends StatelessWidget {
 
 class _Title extends StatelessWidget {
   final bool showSearch;
+  final bool enableBackHome;
 
-  const _Title({required this.showSearch});
+  const _Title({required this.showSearch, required this.enableBackHome});
 
   @override
   Widget build(BuildContext context) {
@@ -189,13 +194,13 @@ class _Title extends StatelessWidget {
         ),
         xs: (
           widgets: [
-            const _BrandPicture(),
+            _BrandPicture(enableBackHome: enableBackHome),
           ],
           itemGap: 8
         ),
         sm: (
           widgets: [
-            const _BrandPicture(),
+            _BrandPicture(enableBackHome: enableBackHome),
             if (showSearch)
               SearchButton(
                 onPressed: () {},
@@ -205,7 +210,7 @@ class _Title extends StatelessWidget {
         ),
         other: (
           widgets: [
-            const _BrandPicture(),
+            _BrandPicture(enableBackHome: enableBackHome),
             if (showSearch)
               SearchButton(
                 onPressed: () {},

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -3201,5 +3201,21 @@
         "type": "String"
       }
     }
+  },
+  "catalystAppClosed": "The Catalyst app is closed.",
+  "@catalystAppClosed": {
+    "description": "Text shown when Catalyst app is closed"
+  },
+  "browseProposalsOnProjectCatalyst": "Please browse other Catalyst Fund14 proposals on ProjectCatalyst.io",
+  "@browseProposalsOnProjectCatalyst": {
+    "description": "Text shown when Catalyst app is closed"
+  },
+  "browseFund14Proposals": "Browse Fund14 proposals",
+  "@browseFund14Proposals": {
+    "description": "Text shown when Catalyst app is closed"
+  },
+  "headsUpTitle": "Heads Up",
+  "@headsUpTitle": {
+    "description": "Text to tell user that something important is happening"
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/lib/src/platform_aware_builder/platform_aware_builder.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/lib/src/platform_aware_builder/platform_aware_builder.dart
@@ -46,6 +46,7 @@ import 'package:flutter/widgets.dart';
 class PlatformAwareBuilder<T> extends StatelessWidget {
   final Widget Function(BuildContext context, T? data) builder;
   final Map<PlatformKey, T?> _platformData;
+  final bool enabled;
 
   PlatformAwareBuilder({
     super.key,
@@ -61,6 +62,7 @@ class PlatformAwareBuilder<T> extends StatelessWidget {
     T? web,
     T? webDesktop,
     T? windows,
+    this.enabled = true,
     required T other,
   }) : _platformData = {
           PlatformKey.android: android,
@@ -79,6 +81,9 @@ class PlatformAwareBuilder<T> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!enabled) {
+      return builder(context, _platformData[PlatformKey.other]);
+    }
     return builder(context, _getPlatformData());
   }
 


### PR DESCRIPTION
# Description

Adding read view mode to proposal viewer

## Related Issue(s)

Closes #2607 

## Description of Changes

- overrride app restriction for proposal view route

## Breaking Changes

N/A

## Screenshots

App open, mobile view:

https://github.com/user-attachments/assets/cc14977d-9de6-444a-bd9f-046b25f6d4b2

App closed mobile view:

https://github.com/user-attachments/assets/cd2d3206-a34f-4a55-a98d-fc73a291cf39

App closed desktop view:

https://github.com/user-attachments/assets/36e6dd14-514c-446f-b0b8-eff2823dbc94


## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
