### PR TITLE
fix(cat-voices): normalize relative base uri

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/config/app_environment.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/config/app_environment.dart
@@ -81,7 +81,7 @@ enum AppEnvironmentType {
 
       /// [AppEnvironmentType.relative] type does not now where its backends
       /// are hosted.
-      AppEnvironmentType.relative => Uri.base,
+      AppEnvironmentType.relative => normalizedBaseUri(),
     };
   }
 
@@ -91,7 +91,7 @@ enum AppEnvironmentType {
       AppEnvironmentType.prod => _getBaseUrl('reviews'),
       AppEnvironmentType.relative => _getBaseUrl(
           'reviews',
-          envName: tryUriBaseEnvName(from: Uri.base.toString()),
+          envName: tryUriBaseEnvName(from: normalizedBaseUri().toString()),
         ),
     };
   }
@@ -122,5 +122,16 @@ enum AppEnvironmentType {
     }
 
     return null;
+  }
+
+  @visibleForTesting
+  static Uri normalizedBaseUri([Uri? base]) {
+    base ??= Uri.base;
+
+    return Uri(
+      scheme: base.scheme,
+      host: base.host,
+      port: base.port,
+    );
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_models/test/config/app_environment_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/test/config/app_environment_test.dart
@@ -40,5 +40,33 @@ void main() {
         expect(envName, expectedEnv);
       });
     });
+
+    group('normalizedBaseUri', () {
+      test('removes path params', () {
+        // Given
+        const host = 'https://app.dev.projectcatalyst.io';
+        final base = Uri.parse('$host/discovery');
+        final expectedBase = Uri.parse(host);
+
+        // When
+        final normalizedBase = AppEnvironmentType.normalizedBaseUri(base);
+
+        // Then
+        expect(normalizedBase, expectedBase);
+      });
+
+      test('keeps original when no path provided', () {
+        // Given
+        const host = 'https://app.dev.projectcatalyst.io';
+        final base = Uri.parse(host);
+        final expectedBase = Uri.parse(host);
+
+        // When
+        final normalizedBase = AppEnvironmentType.normalizedBaseUri(base);
+
+        // Then
+        expect(normalizedBase, expectedBase);
+      });
+    });
   });
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/config/remote_config_source.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/config/remote_config_source.dart
@@ -18,8 +18,13 @@ final class ApiConfigSource implements RemoteConfigSource {
     return _api.gateway
         .apiGatewayV1ConfigFrontendGet()
         .successBodyOrThrow()
-        .then((value) => value is String ? value : '{}')
-        .then((value) => jsonDecode(value) as Map<String, dynamic>)
+        .then((value) {
+          if (value is Map<String, dynamic>) {
+            return value;
+          }
+          final encoded = value is String ? value : '{}';
+          return jsonDecode(encoded) as Map<String, dynamic>;
+        })
         .catchError((_) => <String, dynamic>{})
         .then(RemoteConfig.fromJson);
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/config/remote_config_source_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/test/src/config/remote_config_source_test.dart
@@ -74,6 +74,24 @@ void main() {
       expect(config.sentry, isNull);
       expect(config.cache, isNull);
     });
+
+    test('a json map is passed thru not changed', () async {
+      // Given
+      const configJson = <String, dynamic>{
+        'blockchain': {
+          'networkId': 'mainnet',
+        },
+      };
+      final response = Response<Object>(http.Response('', 200), configJson);
+
+      // When
+      when(gateway.apiGatewayV1ConfigFrontendGet).thenAnswer((_) => Future.value(response));
+
+      // Then
+      final config = await source.get();
+
+      expect(config.blockchain?.networkId, 'mainnet');
+    });
   });
 }
 


### PR DESCRIPTION
# Description

Makes relative base url do not append path params.

## Related Issue(s)

Fixes: #3114

## Description of Changes

- makes relative base url do not append path params (eg. when opening `https://app.preprod.projectcatalyst.io/discovery` it will only use `https://app.preprod.projectcatalyst.io` as base.
- allow decoded json as response for `frontend/config`
