### PR TITLE
fix(cat-gateway): Fixing `convert_network` function, processing  cardano `mainnet` network

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -110,6 +110,7 @@ poem-openapi-derive = { version = "=5.1.4" }
 darling = { version = "=0.20.10" }
 
 [dev-dependencies]
+test-case = "3.3.1"
 
 [build-dependencies]
 build-info-build = "0.0.39"


### PR DESCRIPTION
# Description

- Fixed an issue with processing a valid RBAC token without providing a subnet for mainnet case according to the spec https://input-output-hk.github.io/catalyst-libs/architecture/08_concepts/rbac_id_uri/catalyst-id-uri/#authority.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/3130


## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
