### PR TITLE
fix(cat-gateway): Fix Catalyst IDs comparins in RBAC validation

### DIFF
--- a/catalyst-gateway/bin/src/db/index/schema/cql/rbac_registration.cql
+++ b/catalyst-gateway/bin/src/db/index/schema/cql/rbac_registration.cql
@@ -13,4 +13,4 @@ CREATE TABLE IF NOT EXISTS rbac_registration (
 
     PRIMARY KEY (catalyst_id, slot_no, txn_index)
 )
-WITH CLUSTERING ORDER BY (slot_no DESC, txn_index DESC);
+WITH CLUSTERING ORDER BY (slot_no ASC, txn_index ASC);

--- a/catalyst-gateway/bin/src/db/index/schema/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/schema/mod.rs
@@ -265,7 +265,7 @@ mod tests {
     /// This constant is ONLY used by Unit tests to identify when the schema version will
     /// change accidentally, and is NOT to be used directly to set the schema version of
     /// the table namespaces.
-    const SCHEMA_VERSION: &str = "1bccc428-09b0-8aaa-b0c9-9aa720108756";
+    const SCHEMA_VERSION: &str = "141f7b75-6a5f-8fe4-91cb-596e3584fd7d";
 
     #[test]
     /// This test is designed to fail if the schema version has changed.

--- a/catalyst-gateway/bin/src/metrics/rbac.rs
+++ b/catalyst-gateway/bin/src/metrics/rbac.rs
@@ -39,6 +39,7 @@ pub(crate) fn update() {
         .set(i64::try_from(persistent_rbac_chains_cache_size()).unwrap_or(-1));
 }
 
+/// Increments the `INDEXING_SYNCHRONIZATION_COUNT` metric.
 pub(crate) fn inc_index_sync() {
     let api_host_names = Settings::api_host_names().join(",");
     let service_id = Settings::service_id();

--- a/catalyst-gateway/bin/src/rbac/get_chain.rs
+++ b/catalyst-gateway/bin/src/rbac/get_chain.rs
@@ -25,13 +25,15 @@ use crate::{
 /// Returns the latest (including the volatile part) registration chain by the given
 /// Catalyst ID.
 pub async fn latest_rbac_chain(id: &CatalystId) -> Result<Option<ChainInfo>> {
+    let id = id.as_short_id();
+
     let volatile_session =
         CassandraSession::get(false).context("Failed to get volatile Cassandra session")?;
     // Get the persistent part of the chain and volatile registrations. Both of these parts
     // can be non-existing.
     let (chain, volatile_regs) = try_join(
-        persistent_rbac_chain(id),
-        indexed_regs(&volatile_session, id),
+        persistent_rbac_chain(&id),
+        indexed_regs(&volatile_session, &id),
     )
     .await?;
 
@@ -91,13 +93,15 @@ pub async fn latest_rbac_chain_by_address(address: &StakeAddress) -> Result<Opti
 
 /// Returns only the persistent part of a registration chain by the given Catalyst ID.
 pub async fn persistent_rbac_chain(id: &CatalystId) -> Result<Option<RegistrationChain>> {
-    if let Some(chain) = cached_persistent_rbac_chain(id) {
+    let id = id.as_short_id();
+
+    if let Some(chain) = cached_persistent_rbac_chain(&id) {
         return Ok(Some(chain));
     }
 
     let session = CassandraSession::get(true).context("Failed to get Cassandra session")?;
 
-    let regs = indexed_regs(&session, id).await?;
+    let regs = indexed_regs(&session, &id).await?;
     let chain = build_rbac_chain(regs).await?.inspect(|c| {
         cache_persistent_rbac_chain(id.clone(), c.clone());
     });

--- a/catalyst-gateway/bin/src/rbac/validation.rs
+++ b/catalyst-gateway/bin/src/rbac/validation.rs
@@ -340,7 +340,7 @@ async fn validate_public_keys(
             keys.insert(key);
             if let Some(previous) = catalyst_id_from_public_key(key, is_persistent, context).await?
             {
-                if &previous != catalyst_id {
+                if previous.as_short_id() != catalyst_id.as_short_id() {
                     report.functional_validation(
                         &format!("An update to {catalyst_id} registration chain uses the same public key ({key:?}) as {previous} chain"),
                         "It isn't allowed to use role 0 signing (certificate subject public) key in different chains",

--- a/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/cardano/rbac/registrations_get/mod.rs
@@ -44,7 +44,8 @@ pub(crate) async fn endpoint(
         .into();
     }
 
-    match chain_info(lookup, token).await {
+    // `Box::pin` is used here because of the future size (`clippy::large_futures` lint).
+    match Box::pin(chain_info(lookup, token)).await {
         Err(e) => AllResponses::handle_error(&e),
         Ok(Some(info)) => {
             match RbacRegistrationChain::new(&info) {

--- a/catalyst-gateway/bin/src/service/common/auth/rbac/scheme.rs
+++ b/catalyst-gateway/bin/src/service/common/auth/rbac/scheme.rs
@@ -140,17 +140,14 @@ async fn checker_api_catalyst_auth(
     let reg_chain = match latest_rbac_chain(token.catalyst_id()).await {
         Ok(Some(c)) => c.chain,
         Ok(None) => {
-            debug!(
-                "Unable to find registrations for {} Catalyst ID",
-                token.catalyst_id()
-            );
+            debug!(cat_id = %token.catalyst_id(), "Unable to find registrations for Catalyst ID");
             return Err(AuthTokenError::RegistrationNotFound.into());
         },
         Err(e) if e.is::<CassandraSessionError>() => return Err(ServiceUnavailableError(e).into()),
         Err(e) => {
             // This should never happen normally because we validate RBAC registration transactions
             // before adding them to the database.
-            error!("Unable to build a registration chain Catalyst ID: {e:?}");
+            error!(cat_id = %token.catalyst_id(), err = ?e, "Unable to build a registration chain");
             return Err(AuthTokenError::BuildRegChain(e.to_string()).into());
         },
     };


### PR DESCRIPTION
# Description

- Use short form of a Catalyst ID for comparison.
- Change sorting order in the `rbac_registration` table.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/3124.