### PR TITLE
feat(event-db): 

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -2,7 +2,7 @@ VERSION 0.8
 
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.4.7 AS mdlint-ci
 IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.4.7 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.4.7 AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:feat/optimise-postgres AS postgresql-ci
 
 FROM debian:stable-slim
 
@@ -28,7 +28,7 @@ check-spelling:
 
 # check if the sql files are properly formatted and pass lint quality checks.
 check-sqlfluff:
-    FROM postgresql-ci+postgres-base
+    FROM postgresql-ci+sqlfluff-base
 
     COPY . .
 

--- a/catalyst-gateway/event-db/Earthfile
+++ b/catalyst-gateway/event-db/Earthfile
@@ -3,7 +3,7 @@
 # the database and its associated software.
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.4.7 AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:feat/optimise-postgres AS postgresql-ci
 
 # cspell: words
 


### PR DESCRIPTION
# Description

Using the latest `catalyt-ci` postgres builder reduce event-db image size from `2.33GB` to `486MB`

## Related Pull Requests

https://github.com/input-output-hk/catalyst-ci/pull/420

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
