### PR TITLE
feat(cat-voices): proposal detail voting on latest final version

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_content.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_content.dart
@@ -6,6 +6,7 @@ import 'package:catalyst_voices/pages/proposal/tiles/proposal_document_section_t
 import 'package:catalyst_voices/pages/proposal/tiles/proposal_document_segment_title.dart';
 import 'package:catalyst_voices/pages/proposal/tiles/proposal_metadata_tile.dart';
 import 'package:catalyst_voices/pages/proposal/tiles/proposal_overview_tile.dart';
+import 'package:catalyst_voices/pages/proposal/tiles/proposal_voting_overview.dart';
 import 'package:catalyst_voices/widgets/comment/proposal_add_comment_tile.dart';
 import 'package:catalyst_voices/widgets/comment/proposal_comments_header_tile.dart';
 import 'package:catalyst_voices/widgets/tiles/specialized/proposal_tile_decoration.dart';
@@ -109,6 +110,7 @@ class _SegmentsListView extends StatelessWidget {
         final isNextSectionOrComment = nextItem is Section || isNextComment;
         final isCommentsSegment = item is ProposalCommentsSegment;
         final isNotEmptyCommentsSegment = isCommentsSegment && item.hasComments;
+        final isVotingStatusSection = item is ProposalVotingStatusSection;
 
         return ProposalTileDecoration(
           key: ValueKey('Proposal.${item.id.value}.Tile'),
@@ -118,7 +120,8 @@ class _SegmentsListView extends StatelessWidget {
           ),
           verticalPadding: (
             isFirst: isSegment,
-            isLast: !isNextSectionOrComment || isNotEmptyCommentsSegment,
+            isLast:
+                (!isNextSectionOrComment && !isVotingStatusSection) || isNotEmptyCommentsSegment,
           ),
           child: _buildItem(context, item, readOnlyModeOrMobile),
         );
@@ -143,7 +146,7 @@ class _SegmentsListView extends StatelessWidget {
           return const SizedBox(height: 32);
         }
 
-        if (nextItem is Segment) {
+        if (nextItem is Segment && item is! ProposalVotingStatusSection) {
           return const VoicesDivider.expanded(height: 1);
         }
 
@@ -154,13 +157,19 @@ class _SegmentsListView extends StatelessWidget {
 
   Widget _buildItem(BuildContext context, SegmentsListViewItem item, bool readOnlyModeOrMobile) {
     return switch (item) {
+      ProposalVotingOverviewSegment() => const SizedBox.shrink(),
+      ProposalVotingOverviewSection() => switch (item) {
+          ProposalVotingStatusSection(:final data) => ProposalVotingOverview(data),
+        },
       ProposalOverviewSegment(
         :final categoryName,
         :final proposalTitle,
+        :final isVotingStage,
       ) =>
         ProposalOverviewTile(
           categoryName: categoryName,
           proposalTitle: proposalTitle,
+          isVotingStage: isVotingStage,
         ),
       ProposalOverviewSection() => switch (item) {
           ProposalMetadataSection(:final data) => ProposalMetadataTile(

--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
@@ -19,6 +19,7 @@ import 'package:catalyst_voices/widgets/snackbar/voices_snackbar.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
@@ -140,6 +141,9 @@ class _ProposalPageState extends State<ProposalPage>
       case ViewingOlderVersionSignal():
         VoicesSnackBar.hideCurrent(context);
         ViewingOlderVersionSnackBar(context).show(context);
+      case ViewingOlderVersionWhileVotingSignal():
+        VoicesSnackBar.hideCurrent(context);
+        ViewingOlderVersionSnackBar(context, message: context.l10n.viewingOlderDocumentVersionWhileVoting).show(context);
       case ChangeVersionSignal():
         _changeVersion(signal.to);
       case UsernameUpdatedSignal():

--- a/catalyst_voices/apps/voices/lib/pages/proposal/snack_bar/viewing_older_version_snack_bar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/snack_bar/viewing_older_version_snack_bar.dart
@@ -7,9 +7,9 @@ import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 
 final class ViewingOlderVersionSnackBar extends VoicesSnackBar {
-  factory ViewingOlderVersionSnackBar(BuildContext context) {
+  factory ViewingOlderVersionSnackBar(BuildContext context, {String? message}) {
     return ViewingOlderVersionSnackBar._(
-      message: context.l10n.viewingOlderDocumentVersion,
+      message: message ?? context.l10n.viewingOlderDocumentVersion,
       action: VoicesSnackBarPrimaryAction(
         type: VoicesSnackBarType.warning,
         onPressed: () {
@@ -33,5 +33,6 @@ final class ViewingOlderVersionSnackBar extends VoicesSnackBar {
           type: VoicesSnackBarType.warning,
           icon: VoicesAssets.icons.reply.buildIcon(),
           actions: [action],
+          duration: const Duration(seconds: 6),
         );
 }

--- a/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_overview_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_overview_tile.dart
@@ -8,11 +8,13 @@ import 'package:flutter/material.dart';
 class ProposalOverviewTile extends StatelessWidget {
   final String categoryName;
   final String proposalTitle;
+  final bool isVotingStage;
 
   const ProposalOverviewTile({
     super.key,
     required this.categoryName,
     required this.proposalTitle,
+    required this.isVotingStage,
   });
 
   @override
@@ -47,14 +49,17 @@ class ProposalOverviewTile extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 16),
-            const ProposalShareButton(),
-            const SizedBox(width: 8),
-            // TODO(LynxLynxx): Remove when we support mobile web
-            Offstage(
-              offstage: context.select<ProposalCubit, bool>((cubit) => cubit.state.readOnlyMode) ||
-                  CatalystPlatform.isMobileWeb,
-              child: const ProposalFavoriteButton(),
-            ),
+            if (!isVotingStage) ...[
+              const ProposalShareButton(),
+              const SizedBox(width: 8),
+              // TODO(LynxLynxx): Remove when we support mobile web
+              Offstage(
+                offstage:
+                    context.select<ProposalCubit, bool>((cubit) => cubit.state.readOnlyMode) ||
+                        CatalystPlatform.isMobileWeb,
+                child: const ProposalFavoriteButton(),
+              ),
+            ],
           ],
         ),
         const SizedBox(height: 16),

--- a/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_voting_overview.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_voting_overview.dart
@@ -1,0 +1,29 @@
+import 'package:catalyst_voices/pages/proposal/widget/proposal_favorite_button.dart';
+import 'package:catalyst_voices/pages/proposal/widget/proposal_share_button.dart';
+import 'package:catalyst_voices/widgets/voting/vote_button.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter/material.dart';
+
+class ProposalVotingOverview extends StatelessWidget {
+  final ProposalViewVoting data;
+
+  const ProposalVotingOverview(this.data, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const ProposalShareButton(),
+        const SizedBox(width: 8),
+        const ProposalFavoriteButton(),
+        const Spacer(),
+        VoteButton(
+          onSelected: (action) {
+            // TODO(LynxLynxx): Implement when voting ballot builder is implemented
+          },
+          data: data.voteButtonData,
+        ),
+      ],
+    );
+  }
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit_cache.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit_cache.dart
@@ -9,6 +9,8 @@ final class ProposalCubitCache extends Equatable {
   final CommentTemplate? commentTemplate;
   final List<CommentWithReplies>? comments;
   final bool? isFavorite;
+  final bool? isVotingStage;
+  final bool? readOnlyMode;
 
   const ProposalCubitCache({
     this.activeAccountId,
@@ -18,6 +20,8 @@ final class ProposalCubitCache extends Equatable {
     this.commentTemplate,
     this.comments,
     this.isFavorite,
+    this.isVotingStage,
+    this.readOnlyMode,
   });
 
   @override
@@ -29,6 +33,8 @@ final class ProposalCubitCache extends Equatable {
         commentTemplate,
         comments,
         isFavorite,
+        isVotingStage,
+        readOnlyMode,
       ];
 
   ProposalCubitCache copyWith({
@@ -39,6 +45,8 @@ final class ProposalCubitCache extends Equatable {
     Optional<CommentTemplate>? commentTemplate,
     Optional<List<CommentWithReplies>>? comments,
     Optional<bool>? isFavorite,
+    Optional<bool>? isVotingStage,
+    Optional<bool>? readOnlyMode,
   }) {
     return ProposalCubitCache(
       activeAccountId: activeAccountId.dataOr(this.activeAccountId),
@@ -48,6 +56,8 @@ final class ProposalCubitCache extends Equatable {
       commentTemplate: commentTemplate.dataOr(this.commentTemplate),
       comments: comments.dataOr(this.comments),
       isFavorite: isFavorite.dataOr(this.isFavorite),
+      isVotingStage: isVotingStage.dataOr(this.isVotingStage),
+      readOnlyMode: readOnlyMode.dataOr(this.readOnlyMode),
     );
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_signal.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_signal.dart
@@ -25,3 +25,7 @@ final class UsernameUpdatedSignal extends ProposalSignal {
 final class ViewingOlderVersionSignal extends ProposalSignal {
   const ViewingOlderVersionSignal();
 }
+
+final class ViewingOlderVersionWhileVotingSignal extends ProposalSignal {
+  const ViewingOlderVersionWhileVotingSignal();
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -3354,5 +3354,17 @@
   "removeFromVoteList": "Remove from Vote List",
   "@removeFromVoteList": {
     "description": "When vote is added but not casted yet it can be removed."
+  },
+  "viewingOlderDocumentVersionWhileVoting": "You are viewing an older version of this document while voting. Please view the latest version if you want to vote.",
+  "@viewingOlderDocumentVersionWhileVoting": {
+    "description": "Text shown when user is viewing an older version of a document while voting stage is active"
+  },
+  "votingOverview": "Voting Overview",
+  "@votingOverview": {
+    "description": "Text shown in voting overview segment"
+  },
+  "votingStatus": "Voting Status",
+  "@votingStatus": {
+    "description": "Text shown in voting status section"
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/catalyst_voices_view_models.dart
@@ -40,6 +40,8 @@ export 'proposal/proposal_version_view_model.dart';
 export 'proposal/proposal_view_data.dart';
 export 'proposal/proposal_view_header.dart';
 export 'proposal/proposal_view_metadata.dart';
+export 'proposal/proposal_view_voting.dart';
+export 'proposal/proposal_voting_overview_segment.dart';
 export 'proposal/user_proposal_overview.dart';
 export 'proposal_builder/exception/proposal_builder_exception.dart';
 export 'proposal_builder/proposal_builder_menu_item_data.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_overview_segment.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_overview_segment.dart
@@ -30,17 +30,20 @@ sealed class ProposalOverviewSection extends BaseSection {
 final class ProposalOverviewSegment extends BaseSegment<ProposalOverviewSection> {
   final String categoryName;
   final String proposalTitle;
+  final bool isVotingStage;
 
   const ProposalOverviewSegment({
     required super.id,
     required this.categoryName,
     required this.proposalTitle,
+    required this.isVotingStage,
     required super.sections,
   });
 
   ProposalOverviewSegment.build({
     required this.categoryName,
     required this.proposalTitle,
+    required this.isVotingStage,
     required ProposalViewMetadata data,
   }) : super(
           id: const NodeId('overview'),

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_view_voting.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_view_voting.dart
@@ -1,0 +1,11 @@
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:equatable/equatable.dart';
+
+final class ProposalViewVoting extends Equatable {
+  final VoteButtonData voteButtonData;
+
+  const ProposalViewVoting(this.voteButtonData);
+
+  @override
+  List<Object?> get props => [voteButtonData];
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_voting_overview_segment.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_voting_overview_segment.dart
@@ -1,0 +1,48 @@
+import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter/material.dart';
+
+sealed class ProposalVotingOverviewSection extends BaseSection {
+  const ProposalVotingOverviewSection({
+    required super.id,
+  });
+}
+
+final class ProposalVotingOverviewSegment extends BaseSegment<ProposalVotingOverviewSection> {
+  const ProposalVotingOverviewSegment({
+    required super.id,
+    required super.sections,
+  });
+
+  ProposalVotingOverviewSegment.build({
+    required ProposalViewVoting data,
+  }) : super(
+          id: const NodeId('voting_overview'),
+          sections: [
+            ProposalVotingStatusSection(
+              id: const NodeId('voting_overview.status'),
+              data: data,
+            ),
+          ],
+        );
+
+  @override
+  String resolveTitle(BuildContext context) {
+    return context.l10n.votingOverview;
+  }
+}
+
+final class ProposalVotingStatusSection extends ProposalVotingOverviewSection {
+  final ProposalViewVoting data;
+
+  const ProposalVotingStatusSection({
+    required super.id,
+    required this.data,
+  });
+
+  @override
+  String resolveTitle(BuildContext context) {
+    return context.l10n.votingStatus;
+  }
+}


### PR DESCRIPTION

# Description

User can now vote in proposal detail page when he is viewing latest final version and is login

## Related Issue(s)

Resolves #2976 

## Description of Changes

- adding new segment and section regarding a voting overview
- user can change version but he can vote only on the latest one!

## Breaking Changes

N/A

## Screenshots


https://github.com/user-attachments/assets/55565eb2-eba5-4fc1-ae44-8360ad2853c7



## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
