### PR TITLE
feat(cat-gateway): PUT `v1/document` endpoint, apply older validation rules for the deprecated documents

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 cardano-chain-follower = { version = "0.0.11", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower-v0.0.11" }
 rbac-registration = { version = "0.0.6", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "rbac-registration-v0.0.6" }
 catalyst-signed-doc = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc-v0.0.5" }
+catalyst-signed-doc-v1 = { package = "catalyst-signed-doc", version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }
 cardano-blockchain-types = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-blockchain-types-v0.0.5" }
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "c509-certificate-v0.0.3" }
 catalyst-types = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types-v0.0.5" }

--- a/catalyst-gateway/bin/src/service/api/documents/common/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/common/mod.rs
@@ -11,13 +11,13 @@ use crate::{
     settings::Settings,
 };
 
-/// Get document from the database
-pub(crate) async fn get_document(
+/// Get document cbor bytes from the database
+pub(crate) async fn get_document_cbor_bytes(
     document_id: &uuid::Uuid, version: Option<&uuid::Uuid>,
-) -> anyhow::Result<CatalystSignedDocument> {
+) -> anyhow::Result<Vec<u8>> {
     // If doesn't exist in the static templates, try to find it in the database
     let db_doc = FullSignedDoc::retrieve(document_id, version).await?;
-    db_doc.raw().try_into()
+    Ok(db_doc.raw().to_vec())
 }
 
 /// A struct which implements a
@@ -30,8 +30,8 @@ impl catalyst_signed_doc::providers::CatalystSignedDocumentProvider for DocProvi
     ) -> anyhow::Result<Option<CatalystSignedDocument>> {
         let id = doc_ref.id().uuid();
         let ver = doc_ref.ver().uuid();
-        match get_document(&id, Some(&ver)).await {
-            Ok(doc) => Ok(Some(doc)),
+        match get_document_cbor_bytes(&id, Some(&ver)).await {
+            Ok(doc_cbor_bytes) => Ok(Some(doc_cbor_bytes.as_slice().try_into()?)),
             Err(err) if err.is::<NotFoundError>() => Ok(None),
             Err(err) => Err(err),
         }
@@ -45,6 +45,32 @@ impl catalyst_signed_doc::providers::CatalystSignedDocumentProvider for DocProvi
     fn past_threshold(&self) -> Option<std::time::Duration> {
         let signed_doc_cfg = Settings::signed_doc_cfg();
         Some(signed_doc_cfg.past_threshold())
+    }
+}
+
+impl catalyst_signed_doc_v1::providers::CatalystSignedDocumentProvider for DocProvider {
+    async fn try_get_doc(
+        &self, doc_ref: &catalyst_signed_doc_v1::DocumentRef,
+    ) -> anyhow::Result<Option<catalyst_signed_doc_v1::CatalystSignedDocument>> {
+        let id = doc_ref.id.uuid();
+        let ver = doc_ref.ver.uuid();
+        match get_document_cbor_bytes(&id, Some(&ver)).await {
+            Ok(doc_cbor_bytes) => Ok(Some(doc_cbor_bytes.as_slice().try_into()?)),
+            Err(err) if err.is::<NotFoundError>() => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn future_threshold(&self) -> Option<std::time::Duration> {
+        <Self as catalyst_signed_doc::providers::CatalystSignedDocumentProvider>::future_threshold(
+            self,
+        )
+    }
+
+    fn past_threshold(&self) -> Option<std::time::Duration> {
+        <Self as catalyst_signed_doc::providers::CatalystSignedDocumentProvider>::past_threshold(
+            self,
+        )
     }
 }
 

--- a/catalyst-gateway/bin/src/service/api/documents/get_document.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/get_document.rs
@@ -28,13 +28,8 @@ pub(crate) type AllResponses = WithErrorResponses<Responses>;
 
 /// # GET `/document`
 pub(crate) async fn endpoint(document_id: uuid::Uuid, version: Option<uuid::Uuid>) -> AllResponses {
-    match common::get_document(&document_id, version.as_ref()).await {
-        Ok(doc) => {
-            match doc.try_into() {
-                Ok(doc_cbor_bytes) => Responses::Ok(Cbor(doc_cbor_bytes)).into(),
-                Err(err) => AllResponses::handle_error(&err),
-            }
-        },
+    match common::get_document_cbor_bytes(&document_id, version.as_ref()).await {
+        Ok(doc_cbor_bytes) => Responses::Ok(Cbor(doc_cbor_bytes)).into(),
         Err(err) if err.is::<NotFoundError>() => Responses::NotFound.into(),
         Err(err) => AllResponses::handle_error(&err),
     }


### PR DESCRIPTION
# Description

Allow for the  PUT `v1/document` endpoint to submit older format Catalyst Signed Documents and applying to them old validation rules

## Related Issue(s)

Part of https://github.com/input-output-hk/catalyst-voices/issues/3026

## Description of Changes

- Update `endpoint` for the `v1/document` endpoint. based on the `doc.is_deprecated()` apply newest or older validation rules
- add `catalyst-signed-documents` crate dependency pointing to the old version

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
