### PR TITLE
feat(cat-gateway): replace `CounterVec` with more performant `IntCounterVec`

### DIFF
--- a/catalyst-gateway/bin/src/metrics/caches/native_assets.rs
+++ b/catalyst-gateway/bin/src/metrics/caches/native_assets.rs
@@ -9,7 +9,9 @@ mod reporter {
     //! Prometheus reporter metrics.
     use std::sync::LazyLock;
 
-    use prometheus::{register_counter_vec, register_int_gauge_vec, CounterVec, IntGaugeVec};
+    use prometheus::{
+        register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec,
+    };
 
     /// Labels for the metrics
     const METRIC_LABELS: [&str; 3] = ["api_host_names", "service_id", "network"];
@@ -36,19 +38,20 @@ mod reporter {
         });
 
     /// Number of hits in the Native Assets cache.
-    pub(crate) static NATIVE_ASSETS_CACHE_HIT_COUNT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "cache_native_assets_hits_count",
-            "Returns the number of hits (entries found) in the Native Assets cache",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static NATIVE_ASSETS_CACHE_HIT_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "cache_native_assets_hits_count",
+                "Returns the number of hits (entries found) in the Native Assets cache",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 
     /// Number of misses in the Native Assets cache.
-    pub(crate) static NATIVE_ASSETS_CACHE_MISSES_COUNT: LazyLock<CounterVec> =
+    pub(crate) static NATIVE_ASSETS_CACHE_MISSES_COUNT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "cache_native_assets_misses_count",
                 "Returns the number of misses (entries not found) in the Native Assets cache",
                 &METRIC_LABELS

--- a/catalyst-gateway/bin/src/metrics/caches/txo_assets.rs
+++ b/catalyst-gateway/bin/src/metrics/caches/txo_assets.rs
@@ -9,7 +9,9 @@ mod reporter {
     //! Prometheus reporter metrics.
     use std::sync::LazyLock;
 
-    use prometheus::{register_counter_vec, register_int_gauge_vec, CounterVec, IntGaugeVec};
+    use prometheus::{
+        register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec,
+    };
 
     /// Labels for the metrics
     const METRIC_LABELS: [&str; 3] = ["api_host_names", "service_id", "network"];
@@ -35,8 +37,8 @@ mod reporter {
     });
 
     /// Number of hits in the TXO Assets cache.
-    pub(crate) static TXO_ASSETS_CACHE_HIT_COUNT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
+    pub(crate) static TXO_ASSETS_CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec!(
             "cache_txo_assets_hits_count",
             "Returns the number of hits (entries found) in the TXO Assets cache",
             &METRIC_LABELS
@@ -45,14 +47,15 @@ mod reporter {
     });
 
     /// Number of misses in the TXO Assets cache.
-    pub(crate) static TXO_ASSETS_CACHE_MISSES_COUNT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "cache_txo_assets_misses_count",
-            "Returns the number of misses (entries not found) in the TXO Assets cache",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static TXO_ASSETS_CACHE_MISSES_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "cache_txo_assets_misses_count",
+                "Returns the number of misses (entries not found) in the TXO Assets cache",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 }
 
 /// Update Cache metrics

--- a/catalyst-gateway/bin/src/metrics/chain_indexer.rs
+++ b/catalyst-gateway/bin/src/metrics/chain_indexer.rs
@@ -5,7 +5,9 @@
 pub(crate) mod reporter {
     use std::sync::LazyLock;
 
-    use prometheus::{register_counter_vec, register_int_gauge_vec, CounterVec, IntGaugeVec};
+    use prometheus::{
+        register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec,
+    };
 
     /// Labels for the metrics.
     const METRIC_LABELS: [&str; 3] = ["api_host_names", "service_id", "network"];
@@ -51,24 +53,26 @@ pub(crate) mod reporter {
     });
 
     /// Chain Indexer number of times triggering backward data purge.
-    pub(crate) static TRIGGERED_BACKWARD_PURGES_COUNT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "indexer_triggered_backward_purges_count",
-            "Chain Indexer number of times triggering backward data purge",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static TRIGGERED_BACKWARD_PURGES_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "indexer_triggered_backward_purges_count",
+                "Chain Indexer number of times triggering backward data purge",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 
     /// Chain Indexer number of times triggering forward data purge.
-    pub(crate) static TRIGGERED_FORWARD_PURGES_COUNT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "indexer_triggered_forward_purges_count",
-            "Chain Indexer number of times triggering forward data purge",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static TRIGGERED_FORWARD_PURGES_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "indexer_triggered_forward_purges_count",
+                "Chain Indexer number of times triggering forward data purge",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 
     /// Chain Indexer number of purged slots.
     pub(crate) static PURGED_SLOTS: LazyLock<IntGaugeVec> = LazyLock::new(|| {

--- a/catalyst-gateway/bin/src/metrics/rbac.rs
+++ b/catalyst-gateway/bin/src/metrics/rbac.rs
@@ -55,15 +55,17 @@ pub(crate) fn inc_index_sync() {
 pub(crate) mod reporter {
     use std::sync::LazyLock;
 
-    use prometheus::{register_counter_vec, register_int_gauge_vec, CounterVec, IntGaugeVec};
+    use prometheus::{
+        register_int_counter_vec, register_int_gauge_vec, IntCounterVec, IntGaugeVec,
+    };
 
     /// Labels for the metrics.
     const METRIC_LABELS: [&str; 3] = ["api_host_names", "service_id", "network"];
 
     /// A total count of the persistent public keys cache hits.
-    pub(crate) static PERSISTENT_PUBLIC_KEYS_CACHE_HIT: LazyLock<CounterVec> =
+    pub(crate) static PERSISTENT_PUBLIC_KEYS_CACHE_HIT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_persistent_public_keys_cache_hit",
                 "A total count of persistent public keys cache hits",
                 &METRIC_LABELS
@@ -72,9 +74,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the persistent public keys cache misses.
-    pub(crate) static PERSISTENT_PUBLIC_KEYS_CACHE_MISS: LazyLock<CounterVec> =
+    pub(crate) static PERSISTENT_PUBLIC_KEYS_CACHE_MISS: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_persistent_public_keys_cache_miss",
                 "A total count of persistent public keys cache misses",
                 &METRIC_LABELS
@@ -94,24 +96,26 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the volatile public keys cache hits.
-    pub(crate) static VOLATILE_PUBLIC_KEYS_CACHE_HIT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "rbac_volatile_public_keys_cache_hit",
-            "A total count of volatile public keys cache hits",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static VOLATILE_PUBLIC_KEYS_CACHE_HIT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "rbac_volatile_public_keys_cache_hit",
+                "A total count of volatile public keys cache hits",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 
     /// A total count of the volatile public keys cache misses.
-    pub(crate) static VOLATILE_PUBLIC_KEYS_CACHE_MISS: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "rbac_volatile_public_keys_cache_miss",
-            "A total count of volatile public keys cache misses",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static VOLATILE_PUBLIC_KEYS_CACHE_MISS: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "rbac_volatile_public_keys_cache_miss",
+                "A total count of volatile public keys cache misses",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 
     /// An estimated size of the volatile public keys cache.
     pub(crate) static VOLATILE_PUBLIC_KEYS_CACHE_SIZE: LazyLock<IntGaugeVec> =
@@ -125,9 +129,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the persistent stake addresses cache hits.
-    pub(crate) static PERSISTENT_STAKE_ADDRESSES_CACHE_HIT: LazyLock<CounterVec> =
+    pub(crate) static PERSISTENT_STAKE_ADDRESSES_CACHE_HIT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_persistent_stake_addresses_cache_hit",
                 "A total count of the persistent stake addresses cache hits",
                 &METRIC_LABELS
@@ -136,9 +140,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the persistent stake addresses cache misses.
-    pub(crate) static PERSISTENT_STAKE_ADDRESSES_CACHE_MISS: LazyLock<CounterVec> =
+    pub(crate) static PERSISTENT_STAKE_ADDRESSES_CACHE_MISS: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_persistent_stake_addresses_cache_miss",
                 "A total count of the persistent stake addresses cache misses",
                 &METRIC_LABELS
@@ -158,9 +162,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the volatile stake addresses cache hits.
-    pub(crate) static VOLATILE_STAKE_ADDRESSES_CACHE_HIT: LazyLock<CounterVec> =
+    pub(crate) static VOLATILE_STAKE_ADDRESSES_CACHE_HIT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_volatile_stake_addresses_cache_hit",
                 "A total count of the volatile stake addresses cache hits",
                 &METRIC_LABELS
@@ -169,9 +173,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the volatile stake addresses cache misses.
-    pub(crate) static VOLATILE_STAKE_ADDRESSES_CACHE_MISS: LazyLock<CounterVec> =
+    pub(crate) static VOLATILE_STAKE_ADDRESSES_CACHE_MISS: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_volatile_stake_addresses_cache_miss",
                 "A total count of the volatile stake addresses cache misses",
                 &METRIC_LABELS
@@ -191,9 +195,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the persistent transaction IDs cache hits.
-    pub(crate) static PERSISTENT_TRANSACTION_IDS_CACHE_HIT: LazyLock<CounterVec> =
+    pub(crate) static PERSISTENT_TRANSACTION_IDS_CACHE_HIT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_persistent_transaction_ids_cache_hit",
                 "A total count of the persistent transaction IDs cache hits",
                 &METRIC_LABELS
@@ -202,9 +206,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the persistent transaction IDs cache misses.
-    pub(crate) static PERSISTENT_TRANSACTION_IDS_CACHE_MISS: LazyLock<CounterVec> =
+    pub(crate) static PERSISTENT_TRANSACTION_IDS_CACHE_MISS: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_persistent_transaction_ids_cache_miss",
                 "A total count of the persistent transaction IDs cache misses",
                 &METRIC_LABELS
@@ -224,9 +228,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the volatile transaction IDs cache hits.
-    pub(crate) static VOLATILE_TRANSACTION_IDS_CACHE_HIT: LazyLock<CounterVec> =
+    pub(crate) static VOLATILE_TRANSACTION_IDS_CACHE_HIT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_volatile_transaction_ids_cache_hit",
                 "A total count of volatile transaction IDs cache hits",
                 &METRIC_LABELS
@@ -235,9 +239,9 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the volatile transaction IDs cache misses.
-    pub(crate) static VOLATILE_TRANSACTION_IDS_CACHE_MISS: LazyLock<CounterVec> =
+    pub(crate) static VOLATILE_TRANSACTION_IDS_CACHE_MISS: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
-            register_counter_vec!(
+            register_int_counter_vec!(
                 "rbac_volatile_transaction_ids_cache_miss",
                 "A total count of the volatile transaction IDs cache misses",
                 &METRIC_LABELS
@@ -257,8 +261,8 @@ pub(crate) mod reporter {
         });
 
     /// A total count of the persistent RBAC chains cache hits.
-    pub(crate) static PERSISTENT_CHAINS_CACHE_HIT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
+    pub(crate) static PERSISTENT_CHAINS_CACHE_HIT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec!(
             "rbac_persistent_chains_cache_hit",
             "A total count of the persistent RBAC chains cache hits",
             &METRIC_LABELS
@@ -267,8 +271,8 @@ pub(crate) mod reporter {
     });
 
     /// A total count of the persistent RBAC chains cache misses.
-    pub(crate) static PERSISTENT_CHAINS_CACHE_MISS: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
+    pub(crate) static PERSISTENT_CHAINS_CACHE_MISS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec!(
             "rbac_persistent_chains_cache_miss",
             "A total count of the persistent RBAC chains cache misses",
             &METRIC_LABELS
@@ -288,12 +292,13 @@ pub(crate) mod reporter {
 
     /// This counter increases every time we need to synchronize RBAC indexing by waiting
     /// for other tasks to finish before processing a new registration.
-    pub(crate) static INDEXING_SYNCHRONIZATION_COUNT: LazyLock<CounterVec> = LazyLock::new(|| {
-        register_counter_vec!(
-            "indexing_synchronization_count",
-            "Number of RBAC indexing synchronizations",
-            &METRIC_LABELS
-        )
-        .unwrap()
-    });
+    pub(crate) static INDEXING_SYNCHRONIZATION_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "indexing_synchronization_count",
+                "Number of RBAC indexing synchronizations",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
 }


### PR DESCRIPTION
# Description

Replacing `CounterVec` with more performant `IntCounterVec` prometheus metric counter.

## Related Issue(s)

Closes https://github.com/input-output-hk/catalyst-voices/issues/3122

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
