### PR TITLE
feat(cat-gateway): Invalid RBAC registration metric counter

### DIFF
--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         queries::{FallibleQueryTasks, PreparedQuery, SizedBatch},
         session::CassandraSession,
     },
+    metrics,
     settings::cassandra_db::EnvVars,
 };
 
@@ -145,6 +146,7 @@ impl Rbac509InsertQuery {
                 }
             },
             Err(report) => {
+                metrics::rbac::inc_invalid_rbac_reg_count();
                 self.invalid.push(insert_rbac509_invalid::Params::new(
                     catalyst_id,
                     txn_hash,

--- a/catalyst-gateway/bin/src/metrics/mod.rs
+++ b/catalyst-gateway/bin/src/metrics/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod chain_indexer;
 pub(crate) mod endpoint;
 pub(crate) mod health;
 pub(crate) mod memory;
+pub(crate) mod rbac;
 
 /// Initialize Prometheus metrics.
 ///

--- a/catalyst-gateway/bin/src/metrics/rbac.rs
+++ b/catalyst-gateway/bin/src/metrics/rbac.rs
@@ -28,8 +28,8 @@ pub(crate) mod reporter {
     pub(crate) static INVALID_RBAC_REGISTRATION_COUNT: LazyLock<IntCounterVec> =
         LazyLock::new(|| {
             register_int_counter_vec!(
-                "indexing_synchronization_count",
-                "Number of RBAC indexing synchronizations",
+                "invalid_rbac_registration_count",
+                "Number of Invalid RBAC registrations found during indexing",
                 &METRIC_LABELS
             )
             .unwrap()

--- a/catalyst-gateway/bin/src/metrics/rbac.rs
+++ b/catalyst-gateway/bin/src/metrics/rbac.rs
@@ -1,0 +1,37 @@
+//! Metrics related to RBAC Registration Chain analytics.
+
+use crate::settings::Settings;
+
+/// Increments the `INVALID_RBAC_REGISTRATION_COUNT` metric.
+pub(crate) fn inc_invalid_rbac_reg_count() {
+    let api_host_names = Settings::api_host_names().join(",");
+    let service_id = Settings::service_id();
+    let network = Settings::cardano_network().to_string();
+
+    reporter::INVALID_RBAC_REGISTRATION_COUNT
+        .with_label_values(&[&api_host_names, service_id, &network])
+        .inc();
+}
+
+/// All the related RBAC Registration Chain metrics to the Prometheus
+/// service are inside this module.
+pub(crate) mod reporter {
+    use std::sync::LazyLock;
+
+    use prometheus::{register_int_counter_vec, IntCounterVec};
+
+    /// Labels for the metrics.
+    const METRIC_LABELS: [&str; 3] = ["api_host_names", "service_id", "network"];
+
+    /// This counter increases every when we found invalid RBAC registration during
+    /// indexing.
+    pub(crate) static INVALID_RBAC_REGISTRATION_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "indexing_synchronization_count",
+                "Number of RBAC indexing synchronizations",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
+}


### PR DESCRIPTION
# Description

- Added a new metric counter, to track the number of invalid RBAC registrations appeared during indexing.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
