### PR TITLE
feat(cat-gateway): Invalid RBAC registration metric counter [PORT]

### DIFF
--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         queries::{FallibleQueryTasks, PreparedQuery, SizedBatch},
         session::CassandraSession,
     },
-    metrics::rbac::inc_index_sync,
+    metrics::{self, rbac::inc_index_sync},
     rbac::{
         validate_rbac_registration, RbacBlockIndexingContext, RbacValidationError,
         RbacValidationSuccess,
@@ -196,6 +196,7 @@ impl Rbac509InsertQuery {
                 purpose,
                 report,
             }) => {
+                metrics::rbac::inc_invalid_rbac_reg_count();
                 self.invalid.push(insert_rbac509_invalid::Params::new(
                     catalyst_id,
                     txn_hash,

--- a/catalyst-gateway/bin/src/metrics/rbac.rs
+++ b/catalyst-gateway/bin/src/metrics/rbac.rs
@@ -50,6 +50,17 @@ pub(crate) fn inc_index_sync() {
         .inc();
 }
 
+/// Increments the `INVALID_RBAC_REGISTRATION_COUNT` metric.
+pub(crate) fn inc_invalid_rbac_reg_count() {
+    let api_host_names = Settings::api_host_names().join(",");
+    let service_id = Settings::service_id();
+    let network = Settings::cardano_network().to_string();
+
+    reporter::INVALID_RBAC_REGISTRATION_COUNT
+        .with_label_values(&[&api_host_names, service_id, &network])
+        .inc();
+}
+
 /// All the related RBAC Registration Chain Caching reporting metrics to the Prometheus
 /// service are inside this module.
 pub(crate) mod reporter {
@@ -297,6 +308,18 @@ pub(crate) mod reporter {
             register_int_counter_vec!(
                 "indexing_synchronization_count",
                 "Number of RBAC indexing synchronizations",
+                &METRIC_LABELS
+            )
+            .unwrap()
+        });
+
+    /// This counter increases every when we found invalid RBAC registration during
+    /// indexing.
+    pub(crate) static INVALID_RBAC_REGISTRATION_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec!(
+                "invalid_rbac_registration_count",
+                "Number of Invalid RBAC registrations found during indexing",
                 &METRIC_LABELS
             )
             .unwrap()


### PR DESCRIPTION
# Description

Added a new metric counter to track a number of invalid RBAC registrations appeared during indexing

## Related Pull Requests

Port of https://github.com/input-output-hk/catalyst-voices/pull/3175

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
