### PR TITLE
fix(cat-gateway): bump `cardano-chain-follower` [PORT]

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-cardano-chain-follower = { version = "0.0.10", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower-v0.0.10" }
+cardano-chain-follower = { version = "0.0.10", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower/v0.0.10-f14.1" }
 rbac-registration = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower-v0.0.10" }
 catalyst-types = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }
 cardano-blockchain-types = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }


### PR DESCRIPTION
# Description

Updating the fixed version of the `cardano-chain-follower`, which fixes an issue with not correctly reporting to mithril updates, which affects metrics of the cat-gateway.
Port to the fun-14 branch of the [PR](https://github.com/input-output-hk/catalyst-voices/pull/3206)

## Related Issue(s)

Related to https://github.com/input-output-hk/catalyst-voices/issues/2950
