### PR TITLE
feat(cat-gateway): Disable deploying a new cat-gateway on merge

### DIFF
--- a/catalyst-gateway/blueprint.cue
+++ b/catalyst-gateway/blueprint.cue
@@ -7,7 +7,6 @@ project: {
 	}
 	deployment: {
 		on: {
-			merge: {}
 			tag: {}
 		}
 


### PR DESCRIPTION
# Description

To prevent unintentional re-deploying `cat-gateway` instances on `dev` environment, disable deploying it on each merge.