### PR TITLE
feat(cat-voices):  voted on mocked proposals

### DIFF
--- a/catalyst_voices/apps/voices/lib/dependency/dependencies.dart
+++ b/catalyst_voices/apps/voices/lib/dependency/dependencies.dart
@@ -359,6 +359,7 @@ final class Dependencies extends DependencyProvider {
         get<UserService>(),
         get<SignerService>(),
         get<ActiveCampaignObserver>(),
+        get<CastedVotesObserver>(),
       );
     });
     registerLazySingleton<CommentService>(() {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/voting/voting_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/voting/voting_cubit.dart
@@ -47,8 +47,10 @@ final class VotingCubit extends Cubit<VotingState>
         .distinct(listEquals)
         .listen(_handleFavoriteProposalsIds);
 
-    _watchedCastedVotesSub =
-        _votingService.watchedCastedVotes().distinct(listEquals).listen(_handleLastCastedChange);
+    _watchedCastedVotesSub = _votingService
+        .watchedCastedVotes()
+        .distinct(listEquals)
+        .listen(_handleLastCastedChange);
 
     _ballotBuilder.addListener(_handleBallotBuilderChange);
 
@@ -145,6 +147,7 @@ final class VotingCubit extends Cubit<VotingState>
     unawaited(_loadCampaign());
     unawaited(_loadVotingPower());
     unawaited(_loadFavoriteProposals());
+    unawaited(_loadLastCastedVotes());
 
     changeFilters(
       onlyMy: Optional(onlyMyProposals),
@@ -304,6 +307,13 @@ final class VotingCubit extends Cubit<VotingState>
     final favorites = await _proposalService.getFavoritesProposalsIds();
     if (!isClosed) {
       _handleFavoriteProposalsIds(favorites);
+    }
+  }
+
+  Future<void> _loadLastCastedVotes() async {
+    final lastCastedVotes = await _votingService.watchedCastedVotes().first;
+    if (!isClosed) {
+      _handleLastCastedChange(lastCastedVotes);
     }
   }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposals/proposals_count.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposals/proposals_count.dart
@@ -24,15 +24,37 @@ final class ProposalsCount extends Equatable {
 
   @override
   List<Object?> get props => [
-        total,
-        drafts,
-        finals,
-        favorites,
-        favoritesFinals,
-        my,
-        myFinals,
-        voted,
-      ];
+    total,
+    drafts,
+    finals,
+    favorites,
+    favoritesFinals,
+    my,
+    myFinals,
+    voted,
+  ];
+
+  ProposalsCount copyWith({
+    int? total,
+    int? drafts,
+    int? finals,
+    int? favorites,
+    int? favoritesFinals,
+    int? my,
+    int? myFinals,
+    int? voted,
+  }) {
+    return ProposalsCount(
+      total: total ?? this.total,
+      drafts: drafts ?? this.drafts,
+      finals: finals ?? this.finals,
+      favorites: favorites ?? this.favorites,
+      favoritesFinals: favoritesFinals ?? this.favoritesFinals,
+      my: my ?? this.my,
+      myFinals: myFinals ?? this.myFinals,
+      voted: voted ?? this.voted,
+    );
+  }
 
   int ofType(ProposalsFilterType type) {
     return switch (type) {

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/proposal/proposal_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/proposal/proposal_service_test.dart
@@ -13,6 +13,7 @@ void main() {
   late MockProposalRepository mockProposalRepository;
   late MockUserService mockUserService;
   late MockSignerService mockSignerService;
+  late MockCastedVotesObserver mockCastedVotesObserver;
 
   late ProposalService proposalService;
 
@@ -22,6 +23,7 @@ void main() {
     mockSignerService = MockSignerService();
     mockUserService = MockUserService();
     mockActiveCampaignObserver = MockActiveCampaignObserver();
+    mockCastedVotesObserver = MockCastedVotesObserver();
 
     proposalService = ProposalService(
       mockProposalRepository,
@@ -29,6 +31,7 @@ void main() {
       mockUserService,
       mockSignerService,
       mockActiveCampaignObserver,
+      mockCastedVotesObserver,
     );
 
     registerFallbackValue(const SignedDocumentRef(id: 'fallback-id'));
@@ -43,8 +46,7 @@ void main() {
   });
 
   group(ProposalService, () {
-    test(
-        'submitProposalForReview throws '
+    test('submitProposalForReview throws '
         '$ProposalLimitReachedException when over limit', () async {
       final proposalRef = SignedDocumentRef.generateFirstRef();
       final categoryId = SignedDocumentRef.generateFirstRef();
@@ -79,6 +81,8 @@ void main() {
 }
 
 class MockActiveCampaignObserver extends Mock implements ActiveCampaignObserver {}
+
+class MockCastedVotesObserver extends Mock implements CastedVotesObserver {}
 
 class MockDocumentRepository extends Mock implements DocumentRepository {}
 


### PR DESCRIPTION
# Description

This PR adds mocked voted on proposals (they are stored in cache so every reset of the app lose track of voted proposals. This is intended behavior as we wait for backend integration.

## Related Issue(s)

Closes #3213 

## Description of Changes

- adding watching on voted on proposals

## Breaking Changes

N/A

## Screenshots

https://github.com/user-attachments/assets/98e3d6f4-d23d-4548-bd46-60b0ea49658d

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
