### PR TITLE
fix(cat-voices): loading position proposal view

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/proposal_page.dart
@@ -43,7 +43,7 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   const _AppBar();
 
   @override
-  Size get preferredSize => const VoicesAppBar().preferredSize;
+  Size get preferredSize => VoicesAppBar.size;
 
   @override
   Widget build(BuildContext context) {
@@ -87,21 +87,26 @@ class _ProposalPageState extends State<ProposalPage>
       child: Scaffold(
         appBar: const _AppBar(),
         endDrawer: const OpportunitiesDrawer(),
-        floatingActionButton:
-            _ScrollToTopButton(segmentsScrollController: _segmentsScrollController),
-        body: ProposalHeaderWrapper(
-          child: ProposalSidebars(
-            navPanel: const ProposalNavigationPanel(),
-            body: Stack(
-              children: [
-                ProposalContent(
-                  scrollController: _segmentsScrollController,
+        floatingActionButton: _ScrollToTopButton(
+          segmentsScrollController: _segmentsScrollController,
+        ),
+        body: Stack(
+          children: [
+            ProposalHeaderWrapper(
+              child: ProposalSidebars(
+                navPanel: const ProposalNavigationPanel(),
+                body: Stack(
+                  children: [
+                    ProposalContent(
+                      scrollController: _segmentsScrollController,
+                    ),
+                    const ProposalError(),
+                  ],
                 ),
-                const ProposalLoading(),
-                const ProposalError(),
-              ],
+              ),
             ),
-          ),
+            const ProposalLoading(),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
# Description

Changing postion of the loading widget to be centraly.

## Related Issue(s)

N/A

## Description of Changes

N/A

## Breaking Changes

N/A

## Screenshots

https://github.com/user-attachments/assets/bcffcb6e-034b-414b-9e5a-85db0ec5448e

## Related Pull Requests

N/A

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
