### PR TITLE
fix(cat-voices): show category questions in proposal viewer

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_document_section_tile.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/tiles/proposal_document_section_tile.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
+import 'package:catalyst_voices/pages/proposal/widget/proposal_category_text.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:flutter/material.dart';
@@ -21,7 +22,12 @@ class ProposalDocumentSectionTile extends StatelessWidget {
         children: [
           _SectionTitleText(property.schema.title),
           const SizedBox(height: 16),
-          DocumentPropertyReadBuilder(property: property),
+          DocumentPropertyReadBuilder(
+            property: property,
+            overrides: {
+              ProposalDocument.categoryDetailsNameNodeId: (_, __) => const ProposalCategoryText(),
+            },
+          ),
         ],
       ),
     );

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_category_text.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_category_text.dart
@@ -1,0 +1,14 @@
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:flutter/material.dart';
+
+class ProposalCategoryText extends StatelessWidget {
+  const ProposalCategoryText({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<ProposalCubit, ProposalState, String?>(
+      selector: (state) => state.data.categoryText,
+      builder: (context, state) => Text(state ?? '-'),
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/widgets/document/document_property_read_builder.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document/document_property_read_builder.dart
@@ -172,7 +172,18 @@ class _DocumentPropertyReadBuilderState extends State<DocumentPropertyReadBuilde
           yield* _calculateItemsFrom(property);
         }
       case DocumentObjectProperty():
+        // TODO(damian-molinski): remove it when categories will become a documents.
+        if (property.nodeId == ProposalDocument.categoryDetailsNodeId) {
+          yield DocumentTextListItem(
+            id: ProposalDocument.categoryDetailsNameNodeId,
+            title: property.schema.title,
+            // Value is null because category details are injected dynamically. They are not
+            // documents at the moment.
+            value: null,
+          );
+        }
         final schema = property.schema;
+
         switch (schema) {
           case DocumentSingleGroupedTagSelectorSchema():
             final value = schema.groupedTagsSelection(property);

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -305,6 +305,7 @@ final class ProposalCubit extends Cubit<ProposalState>
       isCurrentVersionLatest: currentVersion?.isLatest,
       header: header,
       segments: segments,
+      categoryText: category?.categoryText,
     );
   }
 
@@ -339,12 +340,7 @@ final class ProposalCubit extends Cubit<ProposalState>
       ),
     );
 
-    final proposalSegments = mapDocumentToSegments(
-      document.document,
-      filterOut: [
-        ProposalDocument.categoryNodeId,
-      ],
-    );
+    final proposalSegments = mapDocumentToSegments(document.document);
 
     final isNotLocalAndHasActiveAccount = !isDraftProposal && hasActiveAccount;
     final canReply = isNotLocalAndHasActiveAccount && hasAccountUsername;

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/specialized/proposal_document.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/specialized/proposal_document.dart
@@ -25,6 +25,8 @@ final class ProposalDocument extends Equatable {
   static final categoryNodeId = DocumentNodeId.fromString('campaign_category');
   static final categoryDetailsNodeId =
       DocumentNodeId.fromString('campaign_category.category_details');
+  static final categoryDetailsNameNodeId =
+      DocumentNodeId.fromString('campaign_category.category_details.details');
   static final milestonesNodeId = DocumentNodeId.fromString('milestones.milestones');
   static final milestoneListNodeId =
       DocumentNodeId.fromString('milestones.milestones.milestone_list');

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_view_data.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/proposal/proposal_view_data.dart
@@ -7,11 +7,13 @@ final class ProposalViewData extends Equatable {
   final bool? isCurrentVersionLatest;
   final ProposalViewHeader header;
   final List<Segment> segments;
+  final String? categoryText;
 
   const ProposalViewData({
     this.isCurrentVersionLatest,
     this.header = const ProposalViewHeader(),
     this.segments = const [],
+    this.categoryText,
   });
 
   @override
@@ -19,12 +21,14 @@ final class ProposalViewData extends Equatable {
         isCurrentVersionLatest,
         header,
         segments,
+        categoryText,
       ];
 
   ProposalViewData copyWith({
     Optional<bool>? isCurrentVersionLatest,
     ProposalViewHeader? header,
     List<Segment>? segments,
+    Optional<String>? categoryText,
   }) {
     return ProposalViewData(
       isCurrentVersionLatest: isCurrentVersionLatest.dataOr(
@@ -32,6 +36,7 @@ final class ProposalViewData extends Equatable {
       ),
       header: header ?? this.header,
       segments: segments ?? this.segments,
+      categoryText: categoryText.dataOr(this.categoryText),
     );
   }
 }


### PR DESCRIPTION
# Description

Proposal viewer shows category questions and name

## Related Issue(s)

Fixes #3232 

## Description of Changes

- do not filter out category section
- inject dynamic category name

## Screenshots


<img width="1496" height="846" alt="Screenshot 2025-08-18 at 17 54 50" src="https://github.com/user-attachments/assets/5f7e3d79-e699-4fe5-b8f9-1a9905d3bd2f" />
