### PR TITLE
feat(cat-gateway): Restore the 'purpose' field in the 'rbac_registration' table

### DIFF
--- a/catalyst-gateway/bin/src/db/index/block/rbac509/cql/insert_rbac509.cql
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/cql/insert_rbac509.cql
@@ -5,12 +5,14 @@ INSERT INTO rbac_registration (
     txn_index,
     txn_id,
     prv_txn_id,
-    removed_stake_addresses
+    removed_stake_addresses,
+    purpose
 ) VALUES (
     :catalyst_id,
     :slot_no,
     :txn_index,
     :txn_id,
     :prv_txn_id,
-    :removed_stake_addresses
+    :removed_stake_addresses,
+    :purpose
 );

--- a/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/block/rbac509/mod.rs
@@ -134,6 +134,7 @@ impl Rbac509InsertQuery {
                 stake_addresses,
                 public_keys,
                 modified_chains,
+                purpose,
             }) => {
                 // Record the transaction identifier (hash) of a new registration.
                 self.catalyst_id_for_txn_id
@@ -173,6 +174,7 @@ impl Rbac509InsertQuery {
                     // Addresses can only be removed from other chains, so this list is always
                     // empty for the chain that is being updated.
                     HashSet::new(),
+                    purpose,
                 ));
 
                 // Update other chains that were affected by this registration.
@@ -187,6 +189,7 @@ impl Rbac509InsertQuery {
                         // that is being updated.
                         None,
                         removed_addresses,
+                        None,
                     ));
                 }
             },

--- a/catalyst-gateway/bin/src/db/index/schema/cql/rbac_registration.cql
+++ b/catalyst-gateway/bin/src/db/index/schema/cql/rbac_registration.cql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS rbac_registration (
     prv_txn_id                 blob,         -- 32 Bytes from Previous Transaction Hash.
     removed_stake_addresses    set<blob>,    -- A set of stake addresses that were removed by other chain.
                                              -- The set is empty for all registrations of this chain.
+    purpose                    uuid,         -- 16 Bytes of UUIDv4 Purpose.
 
     PRIMARY KEY (catalyst_id, slot_no, txn_index)
 )

--- a/catalyst-gateway/bin/src/db/index/schema/mod.rs
+++ b/catalyst-gateway/bin/src/db/index/schema/mod.rs
@@ -265,7 +265,7 @@ mod tests {
     /// This constant is ONLY used by Unit tests to identify when the schema version will
     /// change accidentally, and is NOT to be used directly to set the schema version of
     /// the table namespaces.
-    const SCHEMA_VERSION: &str = "141f7b75-6a5f-8fe4-91cb-596e3584fd7d";
+    const SCHEMA_VERSION: &str = "69e28bc1-be89-8407-83dc-9c4cc408d3a9";
 
     #[test]
     /// This test is designed to fail if the schema version has changed.

--- a/catalyst-gateway/bin/src/db/index/tests/scylla_purge.rs
+++ b/catalyst-gateway/bin/src/db/index/tests/scylla_purge.rs
@@ -259,6 +259,7 @@ async fn rbac509_registration() {
             0.into(),
             None,
             HashSet::new(),
+            None,
         ),
         rbac509::insert_rbac509::Params::new(
             "cardano/FftxFnOrj2qmTuB2oZG2v0YEWJfKvQ9Gg8AgNAhDsKE"
@@ -277,6 +278,7 @@ async fn rbac509_registration() {
             )]
             .into_iter()
             .collect(),
+            Some(UuidV4::new()),
         ),
     ];
     let data_len = data.len();

--- a/catalyst-gateway/bin/src/rbac/validation.rs
+++ b/catalyst-gateway/bin/src/rbac/validation.rs
@@ -129,6 +129,7 @@ async fn update_chain(
         // Only new chains can take ownership of stake addresses of existing chains, so in this case
         // other chains aren't affected.
         modified_chains: Vec::new(),
+        purpose,
     })
 }
 
@@ -239,6 +240,7 @@ async fn start_new_chain(
         stake_addresses: new_addresses,
         public_keys,
         modified_chains: updated_chains.into_iter().collect(),
+        purpose,
     })
 }
 

--- a/catalyst-gateway/bin/src/rbac/validation_result.rs
+++ b/catalyst-gateway/bin/src/rbac/validation_result.rs
@@ -26,6 +26,8 @@ pub struct RbacValidationSuccess {
     ///
     /// A new RBAC registration can take ownership of stake addresses of other chains.
     pub modified_chains: Vec<(CatalystId, HashSet<StakeAddress>)>,
+    /// A registration purpose.
+    pub purpose: Option<UuidV4>,
 }
 
 /// An error returned from the `validate_rbac_registration` method.


### PR DESCRIPTION
# Description

Restore the 'purpose' field in the 'rbac_registration' table in order to make both RBAC tables uniform.