### PR TITLE
fix(cat-voices): fix for proposal builder loading

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/dao/proposals_dao.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/database/dao/proposals_dao.dart
@@ -673,8 +673,8 @@ class DriftProposalsDao extends DatabaseAccessor<DriftCatalystDatabase>
   Stream<ProposalsCount> _transformRefsStreamToCount(
     Stream<List<SignedDocumentRef>> source, {
     CatalystId? author,
-  }) async* {
-    await for (final allRefs in source) {
+  }) {
+    return source.asyncMap((allRefs) async {
       final latestActions = await _getProposalsLatestAction();
       final hiddenRefs = latestActions
           .where((element) => element.action.isHidden)
@@ -697,7 +697,7 @@ class DriftProposalsDao extends DatabaseAccessor<DriftCatalystDatabase>
       final myFinals = my.where((ref) => finalsRefs.any((myRef) => myRef.id == ref.id));
       final votedOn = notHidden.where((ref) => votedRefs.any((voted) => voted.id == ref.id));
 
-      yield ProposalsCount(
+      return ProposalsCount(
         total: total.length,
         drafts: total.length - finals.length,
         finals: finals.length,
@@ -707,7 +707,7 @@ class DriftProposalsDao extends DatabaseAccessor<DriftCatalystDatabase>
         myFinals: myFinals.length,
         voted: votedOn.length,
       );
-    }
+    });
   }
 }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/proposal/proposal_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/proposal/proposal_service.dart
@@ -352,7 +352,7 @@ final class ProposalServiceImpl implements ProposalService {
   Future<bool> isMaxProposalsLimitReached() async {
     // By default return true to prevent creating proposals
     // if we couldn't determine the state due to an error.
-    return watchMaxProposalsLimitReached().asBroadcastStream().first.catchError((_) => true);
+    return watchMaxProposalsLimitReached().first.catchError((_) => true);
   }
 
   @override


### PR DESCRIPTION
# Description

Fixed infinite proposal builder loading. Caused by https://github.com/dart-lang/sdk/issues/59793

`await for` is not aware of subscription cancellation and awaits next item before it goes to `yield` which checks for cancellation. `Stream.first` subscribes to a stream and then cancels it once first item is received. Before it returns, it awaits the subscription to be canceled, which never happens because the generator hasn't entered the line with `yield` because there was no next item.

## Related Issue(s)

Closes #3299

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
