### PR TITLE
chore(cat-voices): remove deprecated `synthetic-package` in l10n

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_localization/l10n.yaml
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/l10n.yaml
@@ -6,6 +6,5 @@ output-class: VoicesLocalizations
 preferred-supported-locales:
   - en
 use-deferred-loading: true
-synthetic-package: false
 use-escaping: false
 relax-syntax: true


### PR DESCRIPTION
# Description

Fixes error message:
```
melosERROR: ERROR: l10n.yaml: The argument "synthetic-package" no longer has any effect and should be removed. See http://flutter.dev/to/flutter-gen-deprecation
```

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
