### PR TITLE
chore(cat-voices): adding voting page guard and access to account page

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/campaign/stage/campaign_background.dart
+++ b/catalyst_voices/apps/voices/lib/pages/campaign/stage/campaign_background.dart
@@ -1,8 +1,6 @@
 import 'dart:math';
 
 import 'package:catalyst_voices/widgets/painter/bubble_painter.dart';
-import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
-import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:flutter/material.dart';
 
 class CampaignBackground extends StatelessWidget {
@@ -18,7 +16,6 @@ class CampaignBackground extends StatelessWidget {
         children: [
           const _Background(),
           const _BubbleShapes(),
-          const _Logo(),
           child,
         ],
       ),
@@ -120,22 +117,5 @@ class _BubbleShapes extends StatelessWidget {
         ),
       ),
     ];
-  }
-}
-
-class _Logo extends StatelessWidget {
-  const _Logo();
-
-  @override
-  Widget build(BuildContext context) {
-    return Positioned(
-      left: 60,
-      top: 40,
-      child: Theme.of(context).brandAssets.brand
-          .logo(context)
-          .buildPicture(
-            height: 35,
-          ),
-    );
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/spaces_appbar/discovery_appbar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/spaces_appbar/discovery_appbar.dart
@@ -25,15 +25,35 @@ class DiscoveryAppbar extends StatelessWidget implements PreferredSizeWidget {
     return CampaignPhaseAware.orElse(
       phase: CampaignPhaseType.proposalSubmission,
       showOnlyDataState: true,
-      orElse: (_, __, ___) => const SizedBox.shrink(),
-      active: (_, __, ___) => VoicesAppBar(
-        leading: isAppUnlock ? const DrawerToggleButton() : null,
-        actions: [
-          if (isProposer) const CreateProposalButton(),
-          const SessionCtaAction(),
-          const AccountSettingsAction(),
-        ],
-      ),
+      active: (_, _, _) =>
+          _AppBar(isAppUnlock: isAppUnlock, isProposer: isProposer, isActivePhase: true),
+      orElse: (_, _, _) =>
+          _AppBar(isAppUnlock: isAppUnlock, isProposer: isProposer, isActivePhase: false),
+    );
+  }
+}
+
+class _AppBar extends StatelessWidget {
+  final bool isAppUnlock;
+  final bool isProposer;
+  final bool isActivePhase;
+
+  const _AppBar({
+    required this.isAppUnlock,
+    required this.isProposer,
+    required this.isActivePhase,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return VoicesAppBar(
+      automaticallyImplyLeading: false,
+      leading: (isAppUnlock && isActivePhase) ? const DrawerToggleButton() : null,
+      actions: [
+        if (isProposer && isActivePhase) const CreateProposalButton(),
+        const SessionCtaAction(),
+        const AccountSettingsAction(),
+      ],
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/pages/spaces/appbar/spaces_appbar/workspace_appbar.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/appbar/spaces_appbar/workspace_appbar.dart
@@ -22,14 +22,30 @@ class WorkspaceAppbar extends StatelessWidget implements PreferredSizeWidget {
     return CampaignPhaseAware.orElse(
       phase: CampaignPhaseType.proposalSubmission,
       showOnlyDataState: true,
-      orElse: (_, __, ___) => const SizedBox.shrink(),
-      active: (_, __, ___) => VoicesAppBar(
-        leading: isAppUnlock ? const DrawerToggleButton() : null,
-        actions: const [
-          SessionCtaAction(),
-          AccountSettingsAction(),
-        ],
-      ),
+      active: (_, _, _) => _AppBar(isAppUnlock: isAppUnlock, isActivePhase: true),
+      orElse: (_, _, _) => _AppBar(isAppUnlock: isAppUnlock, isActivePhase: false),
+    );
+  }
+}
+
+class _AppBar extends StatelessWidget {
+  final bool isActivePhase;
+  final bool isAppUnlock;
+
+  const _AppBar({
+    required this.isAppUnlock,
+    required this.isActivePhase,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return VoicesAppBar(
+      automaticallyImplyLeading: false,
+      leading: (isAppUnlock && isActivePhase) ? const DrawerToggleButton() : null,
+      actions: const [
+        SessionCtaAction(),
+        AccountSettingsAction(),
+      ],
     );
   }
 }

--- a/catalyst_voices/apps/voices/lib/routes/guards/user_access_guard.dart
+++ b/catalyst_voices/apps/voices/lib/routes/guards/user_access_guard.dart
@@ -35,7 +35,8 @@ final class UserAccessGuard implements RouteGuard {
     if (account.isAdmin) {
       return null;
     }
-    if (state.path == const FundedProjectsRoute().location) {
+    if (state.path == const FundedProjectsRoute().location ||
+        state.path == const VotingRoute().location) {
       return const DiscoveryRoute().location;
     }
 

--- a/catalyst_voices/apps/voices/lib/routes/routing/spaces_route.dart
+++ b/catalyst_voices/apps/voices/lib/routes/routing/spaces_route.dart
@@ -180,7 +180,7 @@ final class TreasuryRoute extends GoRouteData
   }
 }
 
-final class VotingRoute extends GoRouteData with FadePageTransitionMixin {
+final class VotingRoute extends GoRouteData with FadePageTransitionMixin, CompositeRouteGuardMixin {
   final String? categoryId;
   final String? tab;
   final bool? $extra;
@@ -190,6 +190,9 @@ final class VotingRoute extends GoRouteData with FadePageTransitionMixin {
     this.tab,
     this.$extra,
   });
+
+  @override
+  List<RouteGuard> get routeGuards => [const UserAccessGuard()];
 
   @override
   Widget build(BuildContext context, GoRouterState state) {


### PR DESCRIPTION
# Description

- Adding `VotingPage` to `UserAccessGuard` so it can be accessed. 
- displaying AppBar on Discovery and Workspace even when its before or after proposal submission
- disable menu icon to access drawer in before and after proposal submission state

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
