### PR TITLE
fix(cat-voices): favorite button in proposal viewer

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -245,6 +245,7 @@ final class ProposalCubit extends Cubit<ProposalState>
     final ref = _cache.ref;
     assert(ref != null, 'Proposal ref not found. Load doc first');
 
+    _cache = _cache.copyWith(isFavorite: Optional(value));
     emit(state.copyWithFavorite(isFavorite: value));
 
     if (value) {


### PR DESCRIPTION
# Description

Favorite button was losing state after commenting*. 

## Related Issue(s)

Closes #3251

## Description of Changes

When user pressed `FavoriteButton()` it's trigger interaction with database to save that user liked that specific proposal. This acction on DB trigger watch on comments so it trigger _handleCommentsChange which uses _cache value for favorite to rebuild state via _rebuildProposalState. Solution was to save new favorite value to _cache before sending it to DB to be saved. 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
