### PR TITLE
chore(cat-voices): remove hardcoded values of f14 and fund14

### DIFF
--- a/catalyst_voices/apps/voices/lib/common/ext/active_fund_number_selector_ext.dart
+++ b/catalyst_voices/apps/voices/lib/common/ext/active_fund_number_selector_ext.dart
@@ -1,0 +1,8 @@
+import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:flutter/material.dart';
+
+extension ActiveFundNumberSelectorExt on BuildContext {
+  int get activeCampaignFundNumber {
+    return select<CampaignPhaseAwareCubit, int>((cubit) => cubit.state.fundNumber);
+  }
+}

--- a/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/sections/stay_involved.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:catalyst_voices/common/constants/constants.dart';
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/discovery/sections/session_account_catalyst_id.dart';
 import 'package:catalyst_voices/share/share_manager.dart';
@@ -295,7 +296,7 @@ class _VoterCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return _StayInvolvedCard(
       icon: VoicesAssets.icons.vote,
-      title: context.l10n.registerToVoteFund14,
+      title: context.l10n.registerToVoteFund(context.activeCampaignFundNumber),
       description: context.l10n.stayInvolvedContributorDescription,
       actions: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/current_campaign_selector.dart
+++ b/catalyst_voices/apps/voices/lib/pages/discovery/state_selectors/current_campaign_selector.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/common/typedefs.dart';
 import 'package:catalyst_voices/pages/discovery/sections/current_campaign.dart';
@@ -130,7 +131,7 @@ class _Header extends StatelessWidget {
           const SizedBox(height: 4),
           Text(
             key: const Key('Subtitle'),
-            context.l10n.catalystFundNo(14),
+            context.l10n.catalystFundNo(context.activeCampaignFundNumber),
             style: context.textTheme.displayMedium?.copyWith(
               color: context.colorScheme.primary,
             ),

--- a/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_app_closed.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal/widget/proposal_app_closed.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices/common/constants/constants.dart';
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/proposal/proposal_content.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
@@ -43,7 +44,7 @@ class _AppCloseText extends StatelessWidget {
                 style: context.textTheme.titleMedium,
               ),
               Text(
-                context.l10n.browseProposalsOnProjectCatalyst,
+                context.l10n.browseProposalsOnProjectCatalyst(context.activeCampaignFundNumber),
                 style: context.textTheme.bodyMedium?.copyWith(
                   color: context.colors.textOnPrimaryLevel1,
                 ),
@@ -67,7 +68,7 @@ class _Button extends StatelessWidget with LaunchUrlMixin {
     return VoicesFilledButton(
       trailing: VoicesAssets.icons.externalLink.buildIcon(),
       child: Text(
-        context.l10n.browseFund14Proposals,
+        context.l10n.browseFundProposals(context.activeCampaignFundNumber),
       ),
       onTap: () async {
         await launchUri(VoicesConstants.projectCatalystFund14Url.getUri());

--- a/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_fund_info.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposals/widgets/proposals_fund_info.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:flutter/material.dart';
 
@@ -14,7 +15,7 @@ class ProposalsFundInfo extends StatelessWidget {
         children: [
           Text(
             key: const Key('CurrentCampaignTitle'),
-            context.l10n.catalystFundNo(14),
+            context.l10n.catalystFundNo(context.activeCampaignFundNumber),
             style: Theme.of(context).textTheme.displayMedium,
           ),
           const SizedBox(height: 16),

--- a/catalyst_voices/apps/voices/lib/pages/registration/create_base_profile/stage/widgets/drep_approval_contingency_rich_text.dart
+++ b/catalyst_voices/apps/voices/lib/pages/registration/create_base_profile/stage/widgets/drep_approval_contingency_rich_text.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:catalyst_voices/common/constants/constants.dart';
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
@@ -28,7 +29,7 @@ class _DrepApprovalContingencyRichTextState extends State<DrepApprovalContingenc
       placeholderSpanBuilder: (context, placeholder) {
         return switch (placeholder) {
           'fund14ProposalSubmissionNotice' => TextSpan(
-            text: context.l10n.fund14ProposalSubmissionNotice,
+            text: context.l10n.fundProposalSubmissionNotice(context.activeCampaignFundNumber),
             recognizer: _f14ProposalSubmissionNoticeRecognizer,
             style: const TextStyle(decoration: TextDecoration.underline),
           ),

--- a/catalyst_voices/apps/voices/lib/pages/spaces/drawer/opportunities_drawer.dart
+++ b/catalyst_voices/apps/voices/lib/pages/spaces/drawer/opportunities_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:catalyst_voices/common/constants/constants.dart';
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/spaces/drawer/session_account_drawer_catalyst_id.dart';
 import 'package:catalyst_voices/share/share_manager.dart';
@@ -188,7 +189,7 @@ class _RegisterAsVoter extends StatelessWidget with LaunchUrlMixin {
         children: [
           const SizedBox(height: 16),
           Text(
-            context.l10n.f14Voting,
+            context.l10n.fundVoting(context.activeCampaignFundNumber),
             style: context.textTheme.headlineMedium?.copyWith(
               color: context.colorScheme.primary,
               height: 1,

--- a/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_action_buttons.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/modals/proposals/create_new_proposal_action_buttons.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/routes/routing/proposal_builder_route.dart';
 import 'package:catalyst_voices/widgets/buttons/voices_filled_button.dart';
@@ -87,7 +88,7 @@ class _AgreementCheckboxes extends StatelessWidget {
             context.read<NewProposalCubit>().updateAgreeToNoFurtherCategoryChange(value: value);
           },
           label: Text(
-            context.l10n.agreementCantChangeCategory,
+            context.l10n.agreementCantChangeCategory(context.activeCampaignFundNumber),
           ),
         ),
       ],

--- a/catalyst_voices/apps/voices/lib/widgets/text/voting_start_at_time_text.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/text/voting_start_at_time_text.dart
@@ -1,3 +1,4 @@
+import 'package:catalyst_voices/common/ext/active_fund_number_selector_ext.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
@@ -14,7 +15,8 @@ class VotingStartAtTimeText extends StatelessWidget {
       data,
       formatter: (context, dateTime) {
         final date = DateFormatter.formatFullDateTime(dateTime);
-        return context.l10n.votingForF14StartsIn(
+        return context.l10n.votingForFundStartsIn(
+          context.activeCampaignFundNumber,
           date,
         );
       },

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/campaign/campaign_phase/campaign_phase_aware_state.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/campaign/campaign_phase/campaign_phase_aware_state.dart
@@ -6,6 +6,7 @@ sealed class CampaignPhaseAwareState extends Equatable {
   const CampaignPhaseAwareState();
 
   CampaignPhaseType? get activeCampaignPhaseType => null;
+  int get fundNumber => 15;
 
   @override
   List<Object?> get props => [];
@@ -15,6 +16,7 @@ final class DataCampaignPhaseAwareState extends CampaignPhaseAwareState {
   @override
   final CampaignPhaseType? activeCampaignPhaseType;
   final List<CampaignPhaseState> phasesStates;
+  @override
   final int fundNumber;
 
   const DataCampaignPhaseAwareState({

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -125,9 +125,15 @@
   "@agree": {
     "description": "Button text for confirming agreement"
   },
-  "agreementCantChangeCategory": "I understand that I can’t change my category selection in Fund14.",
+  "agreementCantChangeCategory": "I understand that I can’t change my category selection in Fund{fundNumber}.",
   "@agreementCantChangeCategory": {
-    "description": "Text for the agreement checkbox that explains that user can't change category selection in Fund14"
+    "description": "Text for the agreement checkbox that explains that user can't change category selection in Fund",
+    "placeholders": {
+      "fundNumber": {
+        "description": "Number of fund",
+        "type": "int"
+      }
+    }
   },
   "agreementFitToCategoryCriteria": "I understand the category brief and will make sure my proposal fits the criteria.",
   "@agreementFitToCategoryCriteria": {
@@ -197,13 +203,25 @@
   "@browse": {
     "description": "Button or link text for browsing files or content"
   },
-  "browseFund14Proposals": "Browse Fund14 proposals",
-  "@browseFund14Proposals": {
-    "description": "Text shown when Catalyst app is closed"
+  "browseFundProposals": "Browse Fund{fundNumber} proposals",
+  "@browseFundProposals": {
+    "description": "Text shown when Catalyst app is closed",
+    "placeholders": {
+      "fundNumber": {
+        "description": "Number of fund",
+        "type": "int"
+      }
+    }
   },
-  "browseProposalsOnProjectCatalyst": "Please browse other Catalyst Fund14 proposals on ProjectCatalyst.io",
+  "browseProposalsOnProjectCatalyst": "Please browse other Catalyst Fund{fundNumber} proposals on ProjectCatalyst.io",
   "@browseProposalsOnProjectCatalyst": {
-    "description": "Text shown when Catalyst app is closed"
+    "description": "Text shown when Catalyst app is closed",
+    "placeholders": {
+      "fundNumber": {
+        "description": "Number of fund",
+        "type": "int"
+      }
+    }
   },
   "campaign": "Campaign",
   "@campaign": {
@@ -694,11 +712,11 @@
   "@createProfileCreatedTitle": {
     "description": "Title for the profile created"
   },
-  "createProfileDrepApprovalContingency": "I understand that for my proposal to move to Community Review and/or Voting and be eligible for funding, the Project Catalyst budget proposal must first be approved by the Cardano DReps, as detailed in the {fund14ProposalSubmissionNotice}. If the budget is not approved, my proposal will not move forward and no funding will be provided.",
+  "createProfileDrepApprovalContingency": "I understand that for my proposal to move to Community Review and/or Voting and be eligible for funding, the Project Catalyst budget proposal must first be approved by the Cardano DReps, as detailed in the {fundProposalSubmissionNotice}. If the budget is not approved, my proposal will not move forward and no funding will be provided.",
   "@createProfileDrepApprovalContingency": {
     "description": "Text acknowledging that the user is aware of the Drep Approval Contingency",
     "placeholders": {
-      "fund14ProposalSubmissionNotice": {
+      "fundProposalSubmissionNotice": {
         "type": "String"
       }
     }
@@ -1323,10 +1341,6 @@
   "@exportProposalsIndividually": {
     "description": "Title for section informing user that they can export their proposals individually"
   },
-  "f14Voting": "F14 Voting: Make sure you're ready.",
-  "@f14Voting": {
-    "description": "Title for registration for F14 voting"
-  },
   "failedAuthenticationDescription": "You did not authorise the Catalyst App in your wallet, follow specific wallet instructions.",
   "@failedAuthenticationDescription": {
     "description": "Description for failed authentication reason to not find wallet"
@@ -1407,15 +1421,31 @@
   "@from": {
     "description": "Label for start point or date"
   },
-  "fund14ProposalSubmissionNotice": "Fund14 Proposal Submission Notice",
-  "@fund14ProposalSubmissionNotice": {
-    "description": "Link to the Fund14 Proposal Submission Notice"
-  },
   "fundNoCategory": "Fund{number} Category",
   "@fundNoCategory": {
     "description": "Describes that category comes from fund number",
     "placeholders": {
       "number": {
+        "type": "int"
+      }
+    }
+  },
+  "fundProposalSubmissionNotice": "Fund{fundNumber} Proposal Submission Notice",
+  "@fundProposalSubmissionNotice": {
+    "description": "Link to the Fund Proposal Submission Notice",
+    "placeholders": {
+      "fundNumber": {
+        "description": "Number of fund",
+        "type": "int"
+      }
+    }
+  },
+  "fundVoting": "F{fundNumber} Voting: Make sure you're ready.",
+  "@fundVoting": {
+    "description": "Title for registration for F{fundNumber} voting",
+    "placeholders": {
+      "fundNumber": {
+        "description": "Number of fund",
         "type": "int"
       }
     }
@@ -2565,10 +2595,6 @@
   "@recoverKeychainMethodsListTitle": {
     "description": "Header for recovery methods selection list"
   },
-  "recoverKeychainMethodsNoKeychainFound": "No Catalyst Keychain found on this device.",
-  "@recoverKeychainMethodsNoKeychainFound": {
-    "description": "Message shown when no keychain is found on device"
-  },
   "recoverKeychainMethodsSubtitle": "Not to worry, in the next step you can choose the recovery option that applies to you for this device!",
   "@recoverKeychainMethodsSubtitle": {
     "description": "Subtitle explaining recovery options availability"
@@ -2653,9 +2679,15 @@
   "@refresh": {
     "description": "Refresh button label"
   },
-  "registerToVoteFund14": "Register to Vote in Fund14",
-  "@registerToVoteFund14": {
-    "description": "Title of the register to vote section"
+  "registerToVoteFund": "Register to Vote in Fund{fundNumber}",
+  "@registerToVoteFund": {
+    "description": "Title of the register to vote section",
+    "placeholders": {
+      "fundNumber": {
+        "description": "Number of fund",
+        "type": "int"
+      }
+    }
   },
   "registeredRoles": "Registered Roles",
   "@registeredRoles": {
@@ -3597,10 +3629,13 @@
       }
     }
   },
-  "votingForF14StartsIn": "Voting for Fund14 start {date}",
-  "@votingForF14StartsIn": {
-    "description": "Description for the voting for f14 card in stay involved section",
+  "votingForFundStartsIn": "Voting for Fund{fundNumber} start {date}",
+  "@votingForFundStartsIn": {
+    "description": "Description for the voting for fund card in stay involved section",
     "placeholders": {
+      "fundNumber": {
+        "type": "int"
+      },
       "date": {
         "type": "String"
       }


### PR DESCRIPTION
# Description

This PR removes hardcoded values of fund number in app. Fund number comes from CampaignPhaseAwareCubit as we use it to look for active camapign and it's responsible for setting proper logic that app is dependen on regarding to campaign state. 

For convenience I created an extension that uses a selector getter to retrieve that number. 

## Related Issue(s)

part of [#311](https://github.com/input-output-hk/catalyst-internal-docs/issues/311)

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
