### PR TITLE
feat(cat-voices): tracking registration status

### DIFF
--- a/catalyst_voices/apps/voices/lib/dependency/dependencies.dart
+++ b/catalyst_voices/apps/voices/lib/dependency/dependencies.dart
@@ -345,6 +345,7 @@ final class Dependencies extends DependencyProvider {
         return UserService(
           get<UserRepository>(),
           get<UserObserver>(),
+          get<RegistrationStatusPoller>(),
         );
       },
       dispose: (service) => unawaited(service.dispose()),
@@ -499,5 +500,10 @@ final class Dependencies extends DependencyProvider {
     );
     registerLazySingleton<CastedVotesObserver>(CastedVotesObserverImpl.new);
     registerLazySingleton<VotingBallotBuilder>(VotingBallotLocalBuilder.new);
+
+    // Not a singleton
+    registerFactory<RegistrationStatusPoller>(
+      () => RegistrationStatusPoller(get<UserRepository>()),
+    );
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposal/proposal_cubit.dart
@@ -245,6 +245,7 @@ final class ProposalCubit extends Cubit<ProposalState>
     final ref = _cache.ref;
     assert(ref != null, 'Proposal ref not found. Load doc first');
 
+    _cache = _cache.copyWith(isFavorite: Optional(value));
     emit(state.copyWithFavorite(isFavorite: value));
 
     if (value) {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/test/session/session_cubit_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/test/session/session_cubit_test.dart
@@ -19,6 +19,7 @@ void main() {
   late final KeychainProvider keychainProvider;
   late final _FakeUserRepository userRepository;
   late final UserObserver userObserver;
+  late final RegistrationStatusPoller poller;
 
   late final UserService userService;
   late final RegistrationService registrationService;
@@ -46,10 +47,12 @@ void main() {
     );
     userRepository = _FakeUserRepository();
     userObserver = StreamUserObserver();
+    poller = _NoOpPoller();
 
     userService = UserService(
       userRepository,
       userObserver,
+      poller,
     );
 
     registrationService = _MockRegistrationService(
@@ -367,4 +370,15 @@ class _MockRegistrationService extends Mock implements RegistrationService {
   Future<List<CardanoWallet>> getCardanoWallets() {
     return Future.value(cardanoWallets);
   }
+}
+
+final class _NoOpPoller implements RegistrationStatusPoller {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Stream<CatalystIdRegStatus> start(CatalystId catalystId) => const Stream.empty();
+
+  @override
+  void stop() {}
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/test/session/session_cubit_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/test/session/session_cubit_test.dart
@@ -2,6 +2,8 @@ import 'package:catalyst_cardano/catalyst_cardano.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_repositories/catalyst_voices_repositories.dart';
+import 'package:catalyst_voices_repositories/generated/api/cat_gateway.swagger.dart'
+    show RbacRegistrationChain;
 import 'package:catalyst_voices_services/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart' hide Uuid;
@@ -306,6 +308,11 @@ class _FakeKeychainSigner extends Fake implements KeychainSigner {}
 
 class _FakeUserRepository extends Fake implements UserRepository {
   User? _user;
+
+  @override
+  Future<RbacRegistrationChain> getRbacRegistration({CatalystId? catalystId}) {
+    throw const UnauthorizedException();
+  }
 
   @override
   Future<User> getUser() async => _user ?? const User.empty();

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/catalyst_voices_models.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/catalyst_voices_models.dart
@@ -90,6 +90,7 @@ export 'user/account.dart';
 export 'user/account_public_profile.dart';
 export 'user/account_public_rbac_status.dart';
 export 'user/account_public_status.dart';
+export 'user/account_registration_status.dart';
 export 'user/account_role.dart';
 export 'user/account_update_result.dart';
 export 'user/catalyst_id.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
@@ -40,6 +40,9 @@ final class Account extends Equatable {
   /// Whether this account is being used.
   final bool isActive;
 
+  /// Status if chain registration transaction
+  final AccountRegistrationStatus registrationStatus;
+
   const Account({
     required this.catalystId,
     this.email,
@@ -49,6 +52,7 @@ final class Account extends Equatable {
     required this.publicStatus,
     this.votingPower,
     this.isActive = false,
+    required this.registrationStatus,
   }) : assert(
          (email == null && publicStatus == AccountPublicStatus.notSetup) ||
              (email != null && publicStatus != AccountPublicStatus.notSetup),
@@ -76,6 +80,7 @@ final class Account extends Equatable {
       publicStatus: AccountPublicStatus.notSetup,
       votingPower: VotingPower.dummy(),
       isActive: isActive,
+      registrationStatus: const AccountRegistrationStatus.notIndexed(),
     );
   }
 
@@ -83,12 +88,6 @@ final class Account extends Equatable {
   bool get isAdmin => false;
 
   bool get isDummy => keychain.id == dummyKeychainId;
-
-  // TODO(damian-molinski): Update this getter.
-  /// When account registration transaction is posted on chain account is
-  /// "provisional". This means backend does not yet know about it because
-  /// transaction was not yet read.
-  bool get isProvisional => true;
 
   @override
   List<Object?> get props => [
@@ -100,6 +99,7 @@ final class Account extends Equatable {
     publicStatus,
     votingPower,
     isActive,
+    registrationStatus,
   ];
 
   String? get username => catalystId.username;
@@ -113,6 +113,7 @@ final class Account extends Equatable {
     AccountPublicStatus? publicStatus,
     Optional<VotingPower>? votingPower,
     bool? isActive,
+    AccountRegistrationStatus? registrationStatus,
   }) {
     return Account(
       catalystId: catalystId ?? this.catalystId,
@@ -123,6 +124,7 @@ final class Account extends Equatable {
       publicStatus: publicStatus ?? this.publicStatus,
       votingPower: votingPower.dataOr(this.votingPower),
       isActive: isActive ?? this.isActive,
+      registrationStatus: registrationStatus ?? this.registrationStatus,
     );
   }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account.dart
@@ -40,7 +40,7 @@ final class Account extends Equatable {
   /// Whether this account is being used.
   final bool isActive;
 
-  /// Status if chain registration transaction
+  /// Account registration transaction status
   final AccountRegistrationStatus registrationStatus;
 
   const Account({

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_registration_status.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_registration_status.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+
+final class AccountRegistrationStatus extends Equatable {
+  /// When account registration transaction is posted on chain it's not indexed right away.
+  /// This means backend does not yet know about it because transaction was not picked up.
+  final bool isIndexed;
+
+  /// If account transaction is already persistent on chain or not.
+  final bool isPersistent;
+
+  const AccountRegistrationStatus({
+    required this.isIndexed,
+    required this.isPersistent,
+  }) : assert(
+         isPersistent && isIndexed || !isPersistent,
+         'Account can be Persistent only if indexed',
+       );
+
+  const AccountRegistrationStatus.indexed({this.isPersistent = false}) : isIndexed = true;
+
+  const AccountRegistrationStatus.notIndexed() : this(isIndexed: false, isPersistent: false);
+
+  @override
+  List<Object?> get props => [isIndexed, isPersistent];
+
+  AccountRegistrationStatus copyWith({
+    bool? isIndexed,
+    bool? isPersistent,
+  }) {
+    return AccountRegistrationStatus(
+      isIndexed: isIndexed ?? this.isIndexed,
+      isPersistent: isPersistent ?? this.isPersistent,
+    );
+  }
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_registration_status.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/account_registration_status.dart
@@ -13,7 +13,7 @@ final class AccountRegistrationStatus extends Equatable {
     required this.isPersistent,
   }) : assert(
          isPersistent && isIndexed || !isPersistent,
-         'Account can be Persistent only if indexed',
+         'Account can be persistent only if already indexed',
        );
 
   const AccountRegistrationStatus.indexed({this.isPersistent = false}) : isIndexed = true;

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/recovered_account.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/user/recovered_account.dart
@@ -11,6 +11,7 @@ final class RecoveredAccount extends Equatable {
   final ShelleyAddress stakeAddress;
   final AccountPublicStatus publicStatus;
   final VotingPower? votingPower;
+  final bool isPersistent;
 
   const RecoveredAccount({
     required this.username,
@@ -19,6 +20,7 @@ final class RecoveredAccount extends Equatable {
     required this.stakeAddress,
     required this.publicStatus,
     required this.votingPower,
+    required this.isPersistent,
   });
 
   @override
@@ -29,5 +31,6 @@ final class RecoveredAccount extends Equatable {
     stakeAddress,
     publicStatus,
     votingPower,
+    isPersistent,
   ];
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/user/account_dto.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/dto/user/account_dto.dart
@@ -16,6 +16,7 @@ final class AccountDto {
   @JsonKey(unknownEnumValue: JsonKey.nullForUndefinedEnumValue)
   final AccountPublicStatus? publicStatus;
   final VotingPowerDto? votingPower;
+  final AccountRegistrationStatusDto? registrationStatus;
 
   const AccountDto({
     required this.catalystId,
@@ -25,6 +26,7 @@ final class AccountDto {
     required this.address,
     this.publicStatus,
     this.votingPower,
+    this.registrationStatus,
   });
 
   factory AccountDto.fromJson(Map<String, dynamic> json) {
@@ -44,6 +46,7 @@ final class AccountDto {
         address: data.address?.toBech32(),
         publicStatus: data.publicStatus,
         votingPower: data.votingPower != null ? VotingPowerDto.fromModel(data.votingPower!) : null,
+        registrationStatus: AccountRegistrationStatusDto.fromModel(data.registrationStatus),
       );
 
   // As part of migration falling back to unknown if email is not set.
@@ -70,11 +73,45 @@ final class AccountDto {
       publicStatus: _publicStatus,
       votingPower: votingPower?.toModel(),
       isActive: keychainId == activeKeychainId,
+      registrationStatus:
+          registrationStatus?.toModel() ??
+          // This assumes already existing accounts are indexed and persistent
+          const AccountRegistrationStatus.indexed(isPersistent: true),
     );
   }
 
   static void _jsonMigration(Map<String, dynamic> json) {
     // empty at the moment.
+  }
+}
+
+@JsonSerializable()
+final class AccountRegistrationStatusDto {
+  final bool isIndexed;
+  final bool isPersistent;
+
+  AccountRegistrationStatusDto({
+    required this.isIndexed,
+    required this.isPersistent,
+  });
+
+  factory AccountRegistrationStatusDto.fromJson(Map<String, dynamic> json) {
+    return _$AccountRegistrationStatusDtoFromJson(json);
+  }
+
+  AccountRegistrationStatusDto.fromModel(AccountRegistrationStatus data)
+    : this(
+        isIndexed: data.isIndexed,
+        isPersistent: data.isPersistent,
+      );
+
+  Map<String, dynamic> toJson() => _$AccountRegistrationStatusDtoToJson(this);
+
+  AccountRegistrationStatus toModel() {
+    return AccountRegistrationStatus(
+      isIndexed: isIndexed,
+      isPersistent: isPersistent,
+    );
   }
 }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/user/user_repository.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/user/user_repository.dart
@@ -1,6 +1,8 @@
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_repositories/catalyst_voices_repositories.dart';
+import 'package:catalyst_voices_repositories/generated/api/cat_gateway.swagger.dart'
+    show RbacRegistrationChain;
 import 'package:catalyst_voices_repositories/generated/api/cat_reviews.models.swagger.dart';
 import 'package:catalyst_voices_repositories/src/common/rbac_token_ext.dart';
 import 'package:catalyst_voices_repositories/src/common/response_mapper.dart';
@@ -23,6 +25,8 @@ abstract interface class UserRepository {
   Future<TransactionHash> getPreviousRegistrationTransactionId({
     required CatalystId catalystId,
   });
+
+  Future<RbacRegistrationChain> getRbacRegistration({CatalystId? catalystId});
 
   Future<User> getUser();
 
@@ -62,11 +66,7 @@ final class UserRepositoryImpl implements UserRepository {
   Future<TransactionHash> getPreviousRegistrationTransactionId({
     required CatalystId catalystId,
   }) async {
-    final lookup = catalystId.toSignificant().toUri().toStringWithoutScheme();
-
-    final rbacChain = await _apiServices.gateway
-        .apiGatewayV1RbacRegistrationGet(lookup: lookup)
-        .successBodyOrThrow();
+    final rbacChain = await getRbacRegistration(catalystId: catalystId);
 
     final transactionId = rbacChain.lastVolatileTxn ?? rbacChain.lastPersistentTxn;
 
@@ -75,6 +75,13 @@ final class UserRepositoryImpl implements UserRepository {
     }
 
     return TransactionHash.fromHex(transactionId);
+  }
+
+  @override
+  Future<RbacRegistrationChain> getRbacRegistration({CatalystId? catalystId}) {
+    return _apiServices.gateway
+        .apiGatewayV1RbacRegistrationGet(lookup: catalystId?.toUri().toStringWithoutScheme())
+        .successBodyOrThrow();
   }
 
   @override
@@ -114,9 +121,7 @@ final class UserRepositoryImpl implements UserRepository {
     required CatalystId catalystId,
     required RbacToken rbacToken,
   }) async {
-    final rbacRegistration = await _apiServices.gateway
-        .apiGatewayV1RbacRegistrationGet(lookup: catalystId.toUri().toStringWithoutScheme())
-        .successBodyOrThrow();
+    final rbacRegistration = await getRbacRegistration(catalystId: catalystId);
 
     final publicProfile = await _getAccountPublicProfile(token: rbacToken);
     final username =
@@ -130,6 +135,7 @@ final class UserRepositoryImpl implements UserRepository {
       stakeAddress: rbacRegistration.stakeAddress,
       publicStatus: publicProfile?.status ?? AccountPublicStatus.notSetup,
       votingPower: votingPower,
+      isPersistent: rbacRegistration.lastPersistentTxn != null,
     );
   }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/catalyst_voices_services.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/catalyst_voices_services.dart
@@ -32,6 +32,7 @@ export 'share/share_reviews_resource_url_resolver.dart';
 export 'share/share_service.dart' show ShareService;
 export 'sync/sync_manager.dart' show SyncManager;
 export 'user/keychain_signer_service.dart' show KeychainSignerService;
+export 'user/registration_status_poller.dart';
 export 'user/signer_service.dart';
 export 'user/user_service.dart' show UserService;
 export 'voting/voting_service.dart' show VotingService;

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/registration/registration_service.dart
@@ -35,6 +35,7 @@ abstract interface class RegistrationService {
     AccountPublicStatus? publicStatus,
     bool isActive,
     bool unlocked,
+    AccountRegistrationStatus registrationStatus,
   });
 
   /// Creates a dummy [Account] using [Account.dummySeedPhrase] and other
@@ -135,6 +136,9 @@ final class RegistrationServiceImpl implements RegistrationService {
     AccountPublicStatus? publicStatus,
     bool isActive = false,
     bool unlocked = true,
+    AccountRegistrationStatus registrationStatus = const AccountRegistrationStatus.indexed(
+      isPersistent: true,
+    ),
   }) async {
     return _keyDerivationService.deriveMasterKey(seedPhrase: seedPhrase).use((masterKey) async {
       final keychain = await _keychainProvider.create(keychainId ?? const Uuid().v4());
@@ -168,6 +172,7 @@ final class RegistrationServiceImpl implements RegistrationService {
           address: address,
           publicStatus: publicStatus ?? AccountPublicStatus.notSetup,
           isActive: isActive,
+          registrationStatus: registrationStatus,
         );
       });
     });
@@ -324,6 +329,10 @@ final class RegistrationServiceImpl implements RegistrationService {
         final keychainId = const Uuid().v4();
         final keychain = await _keychainProvider.create(keychainId);
 
+        final registrationStatus = AccountRegistrationStatus.indexed(
+          isPersistent: recovered.isPersistent,
+        );
+
         return Account(
           catalystId: catalystId.copyWith(
             username: Optional(recovered.username),
@@ -334,6 +343,7 @@ final class RegistrationServiceImpl implements RegistrationService {
           address: recovered.stakeAddress,
           publicStatus: recovered.publicStatus,
           votingPower: recovered.votingPower,
+          registrationStatus: registrationStatus,
         );
       });
     });
@@ -374,6 +384,7 @@ final class RegistrationServiceImpl implements RegistrationService {
             publicStatus: data.email != null
                 ? AccountPublicStatus.verifying
                 : AccountPublicStatus.notSetup,
+            registrationStatus: const AccountRegistrationStatus.notIndexed(),
           );
         });
       });

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/registration_status_poller.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/registration_status_poller.dart
@@ -2,73 +2,117 @@ import 'dart:async';
 
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_repositories/catalyst_voices_repositories.dart';
-import 'package:flutter/foundation.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
+
+final _logger = Logger('RegistrationStatusPoller');
+
+typedef CatalystIdRegStatus = ({CatalystId catalystId, AccountRegistrationStatus status});
 
 abstract interface class RegistrationStatusPoller {
   factory RegistrationStatusPoller(UserRepository userRepository) = _RegistrationStatusPollerImpl;
 
-  void start(
-    Account account, {
-    required ValueChanged<AccountRegistrationStatus> onChanged,
-  });
+  Future<void> dispose();
+
+  Stream<CatalystIdRegStatus> start(CatalystId catalystId);
 
   void stop();
 }
 
 final class _RegistrationStatusPollerImpl implements RegistrationStatusPoller {
   final UserRepository _userRepository;
+  final _statusStreamController = StreamController<CatalystIdRegStatus>();
 
   Timer? _pullStatusTimer;
+  CatalystId? _catalystId;
 
   _RegistrationStatusPollerImpl(
     this._userRepository,
-  );
+  ) {
+    _statusStreamController
+      ..onListen = _schedulePull
+      ..onPause = _cancelPulling
+      ..onResume = _schedulePull
+      ..onCancel = stop;
+  }
 
   @override
-  void start(
-    Account account, {
-    required ValueChanged<AccountRegistrationStatus> onChanged,
-  }) {
+  Future<void> dispose() async {
+    _logger.finest('Disposing');
+
     stop();
 
-    _pullStatusTimer = Timer.periodic(
-      const Duration(minutes: 1),
-      (timer) {
-        unawaited(_pullRegistrationStatus(account: account, onChanged: onChanged));
-      },
-    );
+    await _statusStreamController.close();
+  }
+
+  @override
+  Stream<CatalystIdRegStatus> start(CatalystId catalystId) {
+    _logger.finest('Starting for $catalystId');
+
+    assert(_catalystId == null, 'Stop pulling before starting new one');
+    _catalystId = catalystId;
+    return _statusStreamController.stream;
   }
 
   @override
   void stop() {
+    _logger.finest('Stopping');
+
+    _cancelPulling();
+
+    _catalystId = null;
+  }
+
+  void _cancelPulling() {
+    _logger.finest('Cancelling');
+
     _pullStatusTimer?.cancel();
     _pullStatusTimer = null;
   }
 
-  Future<void> _pullRegistrationStatus({
-    required Account account,
-    required ValueChanged<AccountRegistrationStatus> onChanged,
-  }) async {
-    if (!await account.keychain.isUnlocked) {
-      return;
-    }
+  Future<void> _pullRegistrationStatus() async {
+    final catalystId = _catalystId;
+    assert(catalystId != null, 'Tried pulling registration status but catalystId was empty');
+    catalystId!;
 
-    final catalystId = account.catalystId;
     try {
       final registration = await _userRepository.getRbacRegistration(catalystId: catalystId);
 
       final isPersistent = registration.lastPersistentTxn != null;
       final status = AccountRegistrationStatus.indexed(isPersistent: isPersistent);
+      final event = (catalystId: catalystId, status: status);
 
-      onChanged(status);
+      _logger.finest('Pulled account($catalystId) registration status -> $status');
+
+      _statusStreamController.add(event);
     } on UnauthorizedException catch (_) {
       const status = AccountRegistrationStatus.notIndexed();
-      onChanged(status);
+      final event = (catalystId: catalystId, status: status);
+
+      _logger.finest('Pulled account($catalystId) failed with unauthorized. Not indexed.');
+
+      _statusStreamController.add(event);
     } on NotFoundException catch (_) {
       const status = AccountRegistrationStatus.notIndexed();
-      onChanged(status);
-    } catch (_) {
+      final event = (catalystId: catalystId, status: status);
+
+      _logger.finest('Pulled account($catalystId) failed with not found. Not indexed.');
+
+      _statusStreamController.add(event);
+    } catch (error) {
+      _logger.finest('Pulled account($catalystId) failed with ${error.runtimeType}.');
+
       //no-op
     }
+  }
+
+  void _schedulePull() {
+    _logger.finest('Scheduling');
+
+    _pullStatusTimer = Timer.periodic(
+      const Duration(minutes: 1),
+      (timer) {
+        unawaited(_pullRegistrationStatus());
+      },
+    );
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/registration_status_poller.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/user/registration_status_poller.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_repositories/catalyst_voices_repositories.dart';
+import 'package:flutter/foundation.dart';
+
+abstract interface class RegistrationStatusPoller {
+  factory RegistrationStatusPoller(UserRepository userRepository) = _RegistrationStatusPollerImpl;
+
+  void start(
+    Account account, {
+    required ValueChanged<AccountRegistrationStatus> onChanged,
+  });
+
+  void stop();
+}
+
+final class _RegistrationStatusPollerImpl implements RegistrationStatusPoller {
+  final UserRepository _userRepository;
+
+  Timer? _pullStatusTimer;
+
+  _RegistrationStatusPollerImpl(
+    this._userRepository,
+  );
+
+  @override
+  void start(
+    Account account, {
+    required ValueChanged<AccountRegistrationStatus> onChanged,
+  }) {
+    stop();
+
+    _pullStatusTimer = Timer.periodic(
+      const Duration(minutes: 1),
+      (timer) {
+        unawaited(_pullRegistrationStatus(account: account, onChanged: onChanged));
+      },
+    );
+  }
+
+  @override
+  void stop() {
+    _pullStatusTimer?.cancel();
+    _pullStatusTimer = null;
+  }
+
+  Future<void> _pullRegistrationStatus({
+    required Account account,
+    required ValueChanged<AccountRegistrationStatus> onChanged,
+  }) async {
+    if (!await account.keychain.isUnlocked) {
+      return;
+    }
+
+    final catalystId = account.catalystId;
+    try {
+      final registration = await _userRepository.getRbacRegistration(catalystId: catalystId);
+
+      final isPersistent = registration.lastPersistentTxn != null;
+      final status = AccountRegistrationStatus.indexed(isPersistent: isPersistent);
+
+      onChanged(status);
+    } on UnauthorizedException catch (_) {
+      const status = AccountRegistrationStatus.notIndexed();
+      onChanged(status);
+    } on NotFoundException catch (_) {
+      const status = AccountRegistrationStatus.notIndexed();
+      onChanged(status);
+    } catch (_) {
+      //no-op
+    }
+  }
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -39,7 +39,7 @@ void main() {
       userObserver = StreamUserObserver();
 
       registerFallbackValue(CatalystId(host: '', role0Key: Uint8List(32)));
-      poller = _MockPooler();
+      poller = _MockPoller();
       when(() => poller.start(any())).thenAnswer((_) => const Stream.empty());
       when(() => poller.stop()).thenAnswer((_) => {});
       when(() => poller.dispose()).thenAnswer((_) => Future(() {}));
@@ -794,6 +794,6 @@ class _FakeUserRepository extends Fake implements UserRepository {
   }
 }
 
-class _MockPooler extends Mock implements RegistrationStatusPoller {}
+class _MockPoller extends Mock implements RegistrationStatusPoller {}
 
 class _MockUserRepository extends Mock implements UserRepository {}

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -1,6 +1,8 @@
 import 'package:catalyst_cardano_serialization/catalyst_cardano_serialization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_repositories/catalyst_voices_repositories.dart';
+import 'package:catalyst_voices_repositories/generated/api/cat_gateway.swagger.dart'
+    show RbacRegistrationChain;
 import 'package:catalyst_voices_services/src/catalyst_voices_services.dart';
 import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -752,6 +754,11 @@ class _FakeUserRepository extends Fake implements UserRepository {
     required CatalystId catalystId,
   }) async {
     return _transactionHash;
+  }
+
+  @override
+  Future<RbacRegistrationChain> getRbacRegistration({CatalystId? catalystId}) {
+    throw const UnauthorizedException();
   }
 
   @override

--- a/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/test/src/user/user_service_test.dart
@@ -353,6 +353,18 @@ void main() {
     group('refreshActiveAccountProfile', () {
       setUp(() {
         userRepository = _MockUserRepository();
+        when(
+          () => userRepository.getRbacRegistration(catalystId: any(named: 'catalystId')),
+        ).thenAnswer(
+          (_) {
+            const rbac = RbacRegistrationChain(
+              catalystId: '',
+              purpose: [],
+              roles: '',
+            );
+            return Future.value(rbac);
+          },
+        );
         service = UserService(userRepository, userObserver);
 
         registerFallbackValue(const User.empty());


### PR DESCRIPTION
# Description

This PR extends Account model with registration status object and keeps track of it.

## Related Issue(s)

Fixes https://github.com/input-output-hk/catalyst-voices/issues/2936
Resolves https://github.com/input-output-hk/catalyst-internal-docs/issues/305

## Description of Changes

Added new `AccountRegistrationStatus` object with `isIndexed` and `isPersistent` fields. `isIndexed` is true when gateway returns 200 rbac endpoint.

This enables us to check if account is indexed before asking reviews API for account public profile status. 

## Demo

### Fresh account - not indexed

https://github.com/user-attachments/assets/c28459d2-08f2-4f92-9c4f-4b48ae3c1966

### Fresh account - becomes indexed

https://github.com/user-attachments/assets/5436b8cb-bdef-4d40-8e23-355c7aeeeb7e

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
