### PR TITLE
chore(cat-gateway): Remove redundant signed doc integration tests code

### DIFF
--- a/catalyst-gateway/tests/api_tests/integration/signed_doc/test_signed_doc.py
+++ b/catalyst-gateway/tests/api_tests/integration/signed_doc/test_signed_doc.py
@@ -2,29 +2,14 @@ import pytest
 from utils import uuid_v7
 from api.v1 import document as document_v1
 from api.v2 import document as document_v2
-from utils.rbac_chain import rbac_chain_factory, RoleID
+from utils.rbac_chain import rbac_chain_factory
 from utils.signed_doc import (
-    proposal_templates,
-    comment_templates,
     proposal_doc_factory,
-    comment_doc_factory,
-    submission_action_factory,
 )
-import cbor2
-import uuid
-
-
-def test_templates(proposal_templates, comment_templates):
-    templates = proposal_templates + comment_templates
-    for template_id in templates:
-        resp = document_v1.get(document_id=template_id)
-        assert (
-            resp.status_code == 200
-        ), f"Failed to get document: {resp.status_code} - {resp.text} for id {template_id}"
 
 
 @pytest.mark.preprod_indexing
-def test_proposal_doc(proposal_doc_factory, rbac_chain_factory):
+def test_document_put_and_get_endpoints(proposal_doc_factory, rbac_chain_factory):
     (proposal_doc, role_id) = proposal_doc_factory()
     rbac_chain = rbac_chain_factory()
     (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
@@ -36,11 +21,6 @@ def test_proposal_doc(proposal_doc_factory, rbac_chain_factory):
         resp.status_code == 200
     ), f"Failed to get document: {resp.status_code} - {resp.text}"
 
-    # Post a signed document with filter ID
-    resp = document_v1.post(filter={"id": {"eq": proposal_doc_id}})
-    assert (
-        resp.status_code == 404
-    ), f"Failed to post document: {resp.status_code} - {resp.text}"
     resp = document_v2.post(filter={"id": [{"eq": proposal_doc_id}]})
     assert (
         resp.status_code == 200
@@ -58,7 +38,7 @@ def test_proposal_doc(proposal_doc_factory, rbac_chain_factory):
         resp.status_code == 201
     ), f"Failed to publish document: {resp.status_code} - {resp.text}"
 
-    # Put a comment document again
+    # Put a document again
     resp = document_v1.put(
         data=new_doc_cbor,
         token=rbac_chain.auth_token(),
@@ -67,7 +47,7 @@ def test_proposal_doc(proposal_doc_factory, rbac_chain_factory):
         resp.status_code == 204
     ), f"Failed to publish document: {resp.status_code} - {resp.text}"
 
-    # Put a proposal document with same ID different content
+    # Put a non valid document with same ID different content
     invalid_doc = proposal_doc.copy()
     invalid_doc.content["setup"]["title"]["title"] = "another title"
     resp = document_v1.put(
@@ -90,336 +70,79 @@ def test_proposal_doc(proposal_doc_factory, rbac_chain_factory):
         resp.status_code == 201
     ), f"Failed to publish document: {resp.status_code} - {resp.text}"
 
-    # Put a proposal document with the not known template field
-    invalid_doc = proposal_doc.copy()
-    invalid_doc.metadata["template"] = {"id": uuid_v7.uuid_v7()}
-    resp = document_v1.put(
-        data=invalid_doc.build_and_sign(cat_id, sk_hex),
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 422
-    ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-    # Put a proposal document with empty content
-    invalid_doc = proposal_doc.copy()
-    invalid_doc.metadata["ver"] = uuid_v7.uuid_v7()
-    invalid_doc.content = {}
-    resp = document_v1.put(
-        data=invalid_doc.build_and_sign(cat_id, sk_hex),
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 422
-    ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-    # Put a submission action document with the non allowed RoleID
-    for invalid_role in RoleID:
-        if invalid_role != role_id:
-            invalid_doc = proposal_doc.copy()
-            invalid_doc.metadata["ver"] = uuid_v7.uuid_v7()
-            (inv_cat_id, inv_sk_hex) = rbac_chain.cat_id_for_role(invalid_role)
-            resp = document_v1.put(
-                data=invalid_doc.build_and_sign(inv_cat_id, inv_sk_hex),
-                token=rbac_chain.auth_token(),
-            )
-            assert (
-                resp.status_code == 422
-            ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-
-@pytest.mark.preprod_indexing
-def test_comment_doc(comment_doc_factory, rbac_chain_factory):
-    (comment_doc, role_id) = comment_doc_factory()
-    rbac_chain = rbac_chain_factory()
-    (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
-    comment_doc_id = comment_doc.metadata["id"]
-
-    # Get the comment document
-    resp = document_v1.get(document_id=comment_doc_id)
-    assert (
-        resp.status_code == 200
-    ), f"Failed to get document: {resp.status_code} - {resp.text}"
-
-    # Post a signed document with filter ID
-    resp = document_v1.post(filter={"id": {"eq": comment_doc_id}})
-    assert (
-        resp.status_code == 404
-    ), f"Failed to post document: {resp.status_code} - {resp.text}"
-    resp = document_v2.post(filter={"id": [{"eq": comment_doc_id}]})
-    assert (
-        resp.status_code == 200
-    ), f"Failed to post document: {resp.status_code} - {resp.text}"
-
-    # Put document with different ver
-    new_doc = comment_doc.copy()
-    new_doc.metadata["ver"] = uuid_v7.uuid_v7()
-    new_doc_cbor = new_doc.build_and_sign(cat_id, sk_hex)
-    resp = document_v1.put(
-        data=new_doc_cbor,
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 201
-    ), f"Failed to publish document: {resp.status_code} - {resp.text}"
-
-    # Put a comment document again
-    resp = document_v1.put(
-        data=new_doc_cbor,
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 204
-    ), f"Failed to publish document: {resp.status_code} - {resp.text}"
-
-    # Put a comment document with empty content
-    invalid_doc = comment_doc.copy()
-    invalid_doc.metadata["ver"] = uuid_v7.uuid_v7()
-    invalid_doc.content = {}
-    resp = document_v1.put(
-        data=invalid_doc.build_and_sign(cat_id, sk_hex),
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 422
-    ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-    # Put a comment document referencing to the not known proposal
-    invalid_doc = comment_doc.copy()
-    invalid_doc.metadata["ref"] = {"id": uuid_v7.uuid_v7()}
-    resp = document_v1.put(
-        data=invalid_doc.build_and_sign(cat_id, sk_hex),
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 422
-    ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-    # Put a submission action document with the non allowed RoleID
-    for invalid_role in RoleID:
-        if invalid_role != role_id:
-            invalid_doc = comment_doc.copy()
-            invalid_doc.metadata["ver"] = uuid_v7.uuid_v7()
-            (inv_cat_id, inv_sk_hex) = rbac_chain.cat_id_for_role(invalid_role)
-            resp = document_v1.put(
-                data=invalid_doc.build_and_sign(inv_cat_id, inv_sk_hex),
-                token=rbac_chain.auth_token(),
-            )
-            assert (
-                resp.status_code == 422
-            ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-
-@pytest.mark.preprod_indexing
-def test_submission_action(submission_action_factory, rbac_chain_factory):
-    (submission_action, role_id) = submission_action_factory()
-    rbac_chain = rbac_chain_factory()
-    (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
-    submission_action_id = submission_action.metadata["id"]
-
-    # Get the submission action doc
-    resp = document_v1.get(
-        document_id=submission_action_id,
-    )
-    assert (
-        resp.status_code == 200
-    ), f"Failed to get document: {resp.status_code} - {resp.text}"
-
-    # Post a signed document with filter ID
-    resp = document_v1.post(
-        filter={"id": {"eq": submission_action_id}},
-    )
-    assert (
-        resp.status_code == 404
-    ), f"Failed to post document: {resp.status_code} - {resp.text}"
-    resp = document_v2.post(
-        filter={"id": [{"eq": submission_action_id}]},
-    )
-    assert (
-        resp.status_code == 200
-    ), f"Failed to post document: {resp.status_code} - {resp.text}"
-
-    # Put document with different ver
-    new_doc = submission_action.copy()
-    new_doc.metadata["ver"] = uuid_v7.uuid_v7()
-    new_doc_cbor = new_doc.build_and_sign(cat_id, sk_hex)
-    resp = document_v1.put(
-        data=new_doc_cbor,
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 201
-    ), f"Failed to publish document: {resp.status_code} - {resp.text}"
-
-    # Put a comment document again
-    resp = document_v1.put(
-        data=new_doc_cbor,
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 204
-    ), f"Failed to publish document: {resp.status_code} - {resp.text}"
-
-    # Submission action document MUST have a ref
-    invalid_doc = submission_action.copy()
-    invalid_doc.metadata["ref"] = {}
-    resp = document_v1.put(
-        data=invalid_doc.build_and_sign(cat_id, sk_hex),
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 422
-    ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-    # Put a submission action document referencing an unknown proposal
-    invalid_doc = submission_action.copy()
-    invalid_doc.metadata["ref"] = {"id": uuid_v7.uuid_v7()}
-    resp = document_v1.put(
-        data=invalid_doc.build_and_sign(cat_id, sk_hex),
-        token=rbac_chain.auth_token(),
-    )
-    assert (
-        resp.status_code == 422
-    ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-    # Put a submission action document with the non allowed RoleID
-    for invalid_role in RoleID:
-        if invalid_role != role_id:
-            invalid_doc = submission_action.copy()
-            invalid_doc.metadata["ver"] = uuid_v7.uuid_v7()
-            (inv_cat_id, inv_sk_hex) = rbac_chain.cat_id_for_role(invalid_role)
-            resp = document_v1.put(
-                data=invalid_doc.build_and_sign(inv_cat_id, inv_sk_hex),
-                token=rbac_chain.auth_token(),
-            )
-            assert (
-                resp.status_code == 422
-            ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-
-@pytest.mark.preprod_indexing
-def test_invalid_signature(
-    submission_action_factory,
-    comment_doc_factory,
-    proposal_doc_factory,
-    rbac_chain_factory,
-):
-    for doc, role_id in [
-        submission_action_factory(),
-        comment_doc_factory(),
-        proposal_doc_factory(),
-    ]:
-        rbac_chain = rbac_chain_factory()
-        (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
-        doc.metadata["ver"] = uuid_v7.uuid_v7()
-        valid_doc_hex = doc.build_and_sign(cat_id, sk_hex)
-
-        # corrupt signature
-        doc_cbor = cbor2.loads(bytes.fromhex(valid_doc_hex)).value
-        doc_cbor[3][0][2] = doc_cbor[3][0][2] + b"extra bytes"
-
-        resp = document_v1.put(
-            data=cbor2.dumps(doc_cbor).hex(),
-            token=rbac_chain.auth_token(),
-        )
-        assert (
-            resp.status_code == 422
-        ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
-        # modify document without changing signature
-        doc_cbor = cbor2.loads(bytes.fromhex(valid_doc_hex)).value
-        protected_headers = cbor2.loads(doc_cbor[0])
-        protected_headers["ver"] = uuid.UUID(uuid_v7.uuid_v7())
-        doc_cbor[0] = cbor2.dumps(protected_headers)
-
-        resp = document_v1.put(
-            data=cbor2.dumps(doc_cbor).hex(),
-            token=rbac_chain.auth_token(),
-        )
-        assert (
-            resp.status_code == 422
-        ), f"Publish document, expected 422 Unprocessable Content: {resp.status_code} - {resp.text}"
-
 
 @pytest.mark.preprod_indexing
 def test_document_index_endpoint(
-    submission_action_factory,
-    comment_doc_factory,
     proposal_doc_factory,
     rbac_chain_factory,
 ):
-    for doc_factory in [
-        submission_action_factory,
-        comment_doc_factory,
-        proposal_doc_factory,
-    ]:
-        (doc, role_id) = doc_factory()
+    (doc, role_id) = proposal_doc_factory()
 
-        rbac_chain = rbac_chain_factory()
-        (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
-        # submiting 10 documents
-        total_amount = 10
+    rbac_chain = rbac_chain_factory()
+    (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
+    # submiting 10 documents
+    total_amount = 10
 
-        for _ in range(total_amount - 1):
-            doc = doc.copy()
-            # keep the same id, but different version
-            doc.metadata["ver"] = uuid_v7.uuid_v7()
-            resp = document_v1.put(
-                data=doc.build_and_sign(cat_id, sk_hex),
-                token=rbac_chain.auth_token(),
-            )
-            assert (
-                resp.status_code == 201
-            ), f"Failed to publish document: {resp.status_code} - {resp.text}"
-
-        limit = 1
-        page = 0
-        filter = {"id": [{"eq": doc.metadata["id"]}]}
-        resp = document_v2.post(
-            limit=limit,
-            page=page,
-            filter=filter,
+    for _ in range(total_amount - 1):
+        doc = doc.copy()
+        # keep the same id, but different version
+        doc.metadata["ver"] = uuid_v7.uuid_v7()
+        resp = document_v1.put(
+            data=doc.build_and_sign(cat_id, sk_hex),
+            token=rbac_chain.auth_token(),
         )
         assert (
-            resp.status_code == 200
-        ), f"Failed to post document: {resp.status_code} - {resp.text}"
+            resp.status_code == 201
+        ), f"Failed to publish document: {resp.status_code} - {resp.text}"
 
-        data = resp.json()
-        assert data["page"]["limit"] == limit
-        assert data["page"]["page"] == page
-        assert data["page"]["remaining"] == total_amount - 1 - page
+    limit = 1
+    page = 0
+    filter = {"id": [{"eq": doc.metadata["id"]}]}
+    resp = document_v2.post(
+        limit=limit,
+        page=page,
+        filter=filter,
+    )
+    assert (
+        resp.status_code == 200
+    ), f"Failed to post document: {resp.status_code} - {resp.text}"
 
-        page += 1
-        resp = document_v2.post(
-            limit=limit,
-            page=page,
-            filter=filter,
-        )
-        assert (
-            resp.status_code == 200
-        ), f"Failed to post document: {resp.status_code} - {resp.text}"
-        data = resp.json()
-        assert data["page"]["limit"] == limit
-        assert data["page"]["page"] == page
-        assert data["page"]["remaining"] == total_amount - 1 - page
+    data = resp.json()
+    assert data["page"]["limit"] == limit
+    assert data["page"]["page"] == page
+    assert data["page"]["remaining"] == total_amount - 1 - page
 
-        resp = document_v2.post(
-            limit=total_amount,
-            filter=filter,
-        )
-        assert (
-            resp.status_code == 200
-        ), f"Failed to post document: {resp.status_code} - {resp.text}"
-        data = resp.json()
-        assert data["page"]["limit"] == total_amount
-        assert data["page"]["page"] == 0  # default value
-        assert data["page"]["remaining"] == 0
+    page += 1
+    resp = document_v2.post(
+        limit=limit,
+        page=page,
+        filter=filter,
+    )
+    assert (
+        resp.status_code == 200
+    ), f"Failed to post document: {resp.status_code} - {resp.text}"
+    data = resp.json()
+    assert data["page"]["limit"] == limit
+    assert data["page"]["page"] == page
+    assert data["page"]["remaining"] == total_amount - 1 - page
 
-        # Pagination out of range
-        resp = document_v2.post(
-            page=92233720368547759,
-            filter={},
-        )
-        assert (
-            resp.status_code == 412
-        ), f"Post document, expected 412 Precondition Failed: {resp.status_code} - {resp.text}"
+    resp = document_v2.post(
+        limit=total_amount,
+        filter=filter,
+    )
+    assert (
+        resp.status_code == 200
+    ), f"Failed to post document: {resp.status_code} - {resp.text}"
+    data = resp.json()
+    assert data["page"]["limit"] == total_amount
+    assert data["page"]["page"] == 0  # default value
+    assert data["page"]["remaining"] == 0
+
+    # Pagination out of range
+    resp = document_v2.post(
+        page=92233720368547759,
+        filter={},
+    )
+    assert (
+        resp.status_code == 412
+    ), f"Post document, expected 412 Precondition Failed: {resp.status_code} - {resp.text}"

--- a/catalyst-gateway/tests/api_tests/integration/signed_doc/test_v1_signed_doc.py
+++ b/catalyst-gateway/tests/api_tests/integration/signed_doc/test_v1_signed_doc.py
@@ -5,7 +5,7 @@ from api.v1 import document as document_v1
 from api.v2 import document as document_v2
 import json
 from utils.rbac_chain import rbac_chain_factory, RoleID
-from utils.signed_doc import SignedDocumentV1, proposal_templates
+from utils.signed_doc import SignedDocumentV1
 
 
 # Getting documents using GET `/v1/document` endpoint.

--- a/catalyst-gateway/tests/api_tests/utils/signed_doc.py
+++ b/catalyst-gateway/tests/api_tests/utils/signed_doc.py
@@ -55,50 +55,13 @@ class SignedDocument(SignedDocumentBase):
         )
 
 
-@pytest.fixture
-def proposal_templates() -> List[str]:
-    # comes from the 'templates/data.rs' file
-    return [
-        "0194d492-1daa-75b5-b4a4-5cf331cd8d1a",
-        "0194d492-1daa-7371-8bd3-c15811b2b063",
-        "0194d492-1daa-79c7-a222-2c3b581443a8",
-        "0194d492-1daa-716f-a04e-f422f08a99dc",
-        "0194d492-1daa-78fc-818a-bf20fc3e9b87",
-        "0194d492-1daa-7d98-a3aa-c57d99121f78",
-        "0194d492-1daa-77be-a1a5-c238fe25fe4f",
-        "0194d492-1daa-7254-a512-30a4cdecfb90",
-        "0194d492-1daa-7de9-b535-1a0b0474ed4e",
-        "0194d492-1daa-7fce-84ee-b872a4661075",
-        "0194d492-1daa-7878-9bcc-2c79fef0fc13",
-        "0194d492-1daa-722f-94f4-687f2c068a5d",
-    ]
-
-
-@pytest.fixture
-def comment_templates() -> List[str]:
-    # comes from the 'templates/data.rs' file
-    return [
-        "0194d494-4402-7e0e-b8d6-171f8fea18b0",
-        "0194d494-4402-7444-9058-9030815eb029",
-        "0194d494-4402-7351-b4f7-24938dc2c12e",
-        "0194d494-4402-79ad-93ba-4d7a0b65d563",
-        "0194d494-4402-7cee-a5a6-5739839b3b8a",
-        "0194d494-4402-7aee-8b24-b5300c976846",
-        "0194d494-4402-7d75-be7f-1c4f3471a53c",
-        "0194d494-4402-7a2c-8971-1b4c255c826d",
-        "0194d494-4402-7074-86ac-3efd097ba9b0",
-        "0194d494-4402-7202-8ebb-8c4c47c286d8",
-        "0194d494-4402-7fb5-b680-c23fe4beb088",
-        "0194d494-4402-7aa5-9dbc-5fe886e60ebc",
-    ]
-
-
 CATEGORY_ID = "0194d490-30bf-7473-81c8-a0eaef369619"
+PROPOSAL_FORM_TEMPLATE_ID = "0194d492-1daa-75b5-b4a4-5cf331cd8d1a"
 
 
 # return a Proposal document which is already published to the cat-gateway and the corresponding RoleID
 @pytest.fixture
-def proposal_doc_factory(proposal_templates, rbac_chain_factory):
+def proposal_doc_factory(f14_proposal_templates, rbac_chain_factory):
     def __proposal_doc_factory() -> tuple[SignedDocument, RoleID]:
         role_id = RoleID.PROPOSER
         rbac_chain = rbac_chain_factory()
@@ -112,7 +75,11 @@ def proposal_doc_factory(proposal_templates, rbac_chain_factory):
             "content-encoding": "br",
             # referenced to the defined proposal template id, comes from the 'templates/data.rs' file
             "template": [
-                {"id": proposal_templates[0], "ver": proposal_templates[0], "cid": "0x"}
+                {
+                    "id": PROPOSAL_FORM_TEMPLATE_ID,
+                    "ver": PROPOSAL_FORM_TEMPLATE_ID,
+                    "cid": "0x",
+                }
             ],
             # referenced to the defined category id, comes from the 'templates/data.rs' file
             "parameters": [{"id": CATEGORY_ID, "ver": CATEGORY_ID, "cid": "0x"}],
@@ -133,92 +100,6 @@ def proposal_doc_factory(proposal_templates, rbac_chain_factory):
         return doc, role_id
 
     return __proposal_doc_factory
-
-
-# return a Comment document which is already published to the cat-gateway, with the relevant RoleID
-@pytest.fixture
-def comment_doc_factory(proposal_doc_factory, comment_templates, rbac_chain_factory):
-    def __comment_doc_factory() -> tuple[SignedDocument, RoleID]:
-        role_id = RoleID.ROLE_0
-        rbac_chain = rbac_chain_factory()
-        proposal_doc = proposal_doc_factory()[0]
-        comment_doc_id = uuid_v7.uuid_v7()
-        comment_metadata_json = {
-            "id": comment_doc_id,
-            "ver": comment_doc_id,
-            # Comment document type
-            "type": "b679ded3-0e7c-41ba-89f8-da62a17898ea",
-            "content-type": "application/json",
-            "content-encoding": "br",
-            "ref": {
-                "id": proposal_doc.metadata["id"],
-                "ver": proposal_doc.metadata["ver"],
-            },
-            "template": [
-                {"id": comment_templates[0], "ver": comment_templates[0], "cid": "0x"}
-            ],
-            "parameters": [{"id": CATEGORY_ID, "ver": CATEGORY_ID, "cid": "0x"}],
-        }
-        with open("./test_data/signed_docs/comment.json", "r") as comment_json_file:
-            comment_json = json.load(comment_json_file)
-
-        doc = SignedDocument(comment_metadata_json, comment_json)
-        (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
-        resp = document.put(
-            data=doc.build_and_sign(cat_id, sk_hex),
-            token=rbac_chain.auth_token(),
-        )
-        assert (
-            resp.status_code == 201
-        ), f"Failed to publish document: {resp.status_code} - {resp.text}"
-
-        return doc, role_id
-
-    return __comment_doc_factory
-
-
-# return a submission action document which is already published to the cat-gateway, with the relevant RoleID
-@pytest.fixture
-def submission_action_factory(proposal_doc_factory, rbac_chain_factory):
-    def __submission_action_factory() -> tuple[SignedDocument, RoleID]:
-        role_id = RoleID.PROPOSER
-        rbac_chain = rbac_chain_factory()
-        proposal_doc = proposal_doc_factory()[0]
-        submission_action_id = uuid_v7.uuid_v7()
-        sub_action_metadata_json = {
-            "id": submission_action_id,
-            "ver": submission_action_id,
-            # submission action type
-            "type": "5e60e623-ad02-4a1b-a1ac-406db978ee48",
-            "content-type": "application/json",
-            "content-encoding": "br",
-            "ref": [
-                {
-                    "id": proposal_doc.metadata["id"],
-                    "ver": proposal_doc.metadata["ver"],
-                    "cid": "0x",
-                }
-            ],
-            "parameters": [{"id": CATEGORY_ID, "ver": CATEGORY_ID, "cid": "0x"}],
-        }
-        with open(
-            "./test_data/signed_docs/submission_action.json", "r"
-        ) as comment_json_file:
-            comment_json = json.load(comment_json_file)
-
-        doc = SignedDocument(sub_action_metadata_json, comment_json)
-        (cat_id, sk_hex) = rbac_chain.cat_id_for_role(role_id)
-        resp = document.put(
-            data=doc.build_and_sign(cat_id, sk_hex),
-            token=rbac_chain.auth_token(),
-        )
-        assert (
-            resp.status_code == 201
-        ), f"Failed to publish sub_action: {resp.status_code} - {resp.text}"
-
-        return doc, role_id
-
-    return __submission_action_factory
 
 
 def build_signed_doc(

--- a/catalyst-gateway/tests/api_tests/utils/signed_doc.py
+++ b/catalyst-gateway/tests/api_tests/utils/signed_doc.py
@@ -61,7 +61,7 @@ PROPOSAL_FORM_TEMPLATE_ID = "0194d492-1daa-75b5-b4a4-5cf331cd8d1a"
 
 # return a Proposal document which is already published to the cat-gateway and the corresponding RoleID
 @pytest.fixture
-def proposal_doc_factory(f14_proposal_templates, rbac_chain_factory):
+def proposal_doc_factory(rbac_chain_factory):
     def __proposal_doc_factory() -> tuple[SignedDocument, RoleID]:
         role_id = RoleID.PROPOSER
         rbac_chain = rbac_chain_factory()


### PR DESCRIPTION
# Description

Removes all redundant catalyst signed documents test cases, which is covered on the `catalyst-signed-doc` crate.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
