### PR TITLE
fix(cat-voices): update email validation logic and add tests for new conditions

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/base_profile_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/registration/cubits/base_profile_cubit.dart
@@ -45,7 +45,7 @@ final class BaseProfileCubit extends Cubit<BaseProfileStateData>
   @override
   void updateEmail(Email value) {
     final receiveEmails = state.receiveEmails.copyWith(
-      isAccepted: value.isNotValid ? false : null,
+      isAccepted: value.isEmptyOrNotValid ? false : null,
       isEnabled: value.isNonEmptyAndValid,
     );
 

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/test/registration/cubits/base_profile_cubit_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/test/registration/cubits/base_profile_cubit_test.dart
@@ -1,0 +1,174 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:catalyst_voices_blocs/src/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_blocs/src/registration/cubits/base_profile_cubit.dart';
+import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(BaseProfileCubit, () {
+    late BaseProfileCubit baseProfileCubit;
+
+    setUp(() {
+      baseProfileCubit = BaseProfileCubit();
+    });
+
+    tearDown(() async {
+      await baseProfileCubit.close();
+    });
+
+    test('creates recovery progress with current username and email', () {
+      baseProfileCubit
+        ..updateUsername(const Username.dirty('testuser'))
+        ..updateEmail(const Email.dirty('test@example.com'));
+
+      final progress = baseProfileCubit.createRecoverProgress();
+
+      expect(progress.username, 'testuser');
+      expect(progress.email, 'test@example.com');
+    });
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated conditionsAccepted when updateConditions is called with true',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateConditions(accepted: true),
+      expect: () => [
+        isA<BaseProfileStateData>().having((e) => e.conditionsAccepted, 'conditionsAccepted', true),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated conditionsAccepted when updateConditions is called with false',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateConditions(accepted: false),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.conditionsAccepted,
+          'conditionsAccepted',
+          false,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated drepApprovalContingencyAccepted when updateDrepApprovalContingency is called with true',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateDrepApprovalContingency(accepted: true),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.drepApprovalContingencyAccepted,
+          'drepApprovalContingencyAccepted',
+          true,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated drepApprovalContingencyAccepted when updateDrepApprovalContingency is called with false',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateDrepApprovalContingency(accepted: false),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.drepApprovalContingencyAccepted,
+          'drepApprovalContingencyAccepted',
+          false,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated email when updateEmail is called with valid email',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateEmail(const Email.dirty('test@example.com')),
+      expect: () => [
+        isA<BaseProfileStateData>()
+            .having((e) => e.email.value, 'email', 'test@example.com')
+            .having((e) => e.receiveEmails.isEnabled, 'receiveEmails.isEnabled', true),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated email with disabled receiveEmails when updateEmail is called with invalid email',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateEmail(const Email.dirty('invalid')),
+      expect: () => [
+        isA<BaseProfileStateData>()
+            .having((e) => e.email.value, 'email', 'invalid')
+            .having((e) => e.receiveEmails.isEnabled, 'receiveEmails.isEnabled', false)
+            .having((e) => e.receiveEmails.isAccepted, 'receiveEmails.isAccepted', false),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated email with disabled receiveEmails when updateEmail is called with empty email',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateEmail(const Email.dirty()),
+      expect: () => [
+        isA<BaseProfileStateData>()
+            .having((e) => e.email.value, 'email', '')
+            .having((e) => e.receiveEmails.isEnabled, 'receiveEmails.isEnabled', false)
+            .having((e) => e.receiveEmails.isAccepted, 'receiveEmails.isAccepted', false),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated receiveEmails when updateReceiveEmails is called with true',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateReceiveEmails(isAccepted: true),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.receiveEmails.isAccepted,
+          'receiveEmails.isAccepted',
+          true,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated receiveEmails when updateReceiveEmails is called with false',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateReceiveEmails(isAccepted: false),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.receiveEmails.isAccepted,
+          'receiveEmails.isAccepted',
+          false,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated tosAndPrivacyPolicyAccepted when updateTosAndPrivacyPolicy is called with true',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateTosAndPrivacyPolicy(accepted: true),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.tosAndPrivacyPolicyAccepted,
+          'tosAndPrivacyPolicyAccepted',
+          true,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated tosAndPrivacyPolicyAccepted when updateTosAndPrivacyPolicy is called with false',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateTosAndPrivacyPolicy(accepted: false),
+      expect: () => [
+        isA<BaseProfileStateData>().having(
+          (e) => e.tosAndPrivacyPolicyAccepted,
+          'tosAndPrivacyPolicyAccepted',
+          false,
+        ),
+      ],
+    );
+
+    blocTest<BaseProfileCubit, BaseProfileStateData>(
+      'emits updated username when updateUsername is called',
+      build: () => baseProfileCubit,
+      act: (cubit) => cubit.updateUsername(const Username.dirty('testuser')),
+      expect: () => [
+        isA<BaseProfileStateData>().having((e) => e.username.value, 'username', 'testuser'),
+      ],
+    );
+  });
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/authentication/email.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/authentication/email.dart
@@ -15,6 +15,8 @@ final class Email extends FormzInput<String, EmailValidationException> {
 
   bool get isNonEmptyAndValid => value.isNotEmpty && isValid;
 
+  bool get isEmptyOrNotValid => value.isEmpty || isNotValid;
+
   @override
   EmailValidationException? validator(String value) {
     if (!lengthRange.contains(value.length)) {

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/test/authentication/email_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/test/authentication/email_test.dart
@@ -39,6 +39,36 @@ void main() {
 
         expect(error, isA<EmailPatternInvalidException>());
       });
+
+      test('isEmptyOrNotValid returns true for empty email', () {
+        // When
+        const email = Email.pure();
+
+        // Then
+        expect(email.isEmptyOrNotValid, isTrue);
+      });
+
+      test('isEmptyOrNotValid returns true for invalid email', () {
+        // Given
+        const value = 'invalid@email';
+
+        // When
+        const email = Email.pure(value);
+
+        // Then
+        expect(email.isEmptyOrNotValid, isTrue);
+      });
+
+      test('isEmptyOrNotValid returns false for valid email', () {
+        // Given
+        const value = 'dev@iohk.com';
+
+        // When
+        const email = Email.pure(value);
+
+        // Then
+        expect(email.isEmptyOrNotValid, isFalse);
+      });
     });
   });
 }


### PR DESCRIPTION
# Description

This PR fixes a bug where the "agree to receive emails" checkbox remained checked and unresponsive after the user deleted the email address from the input field. The checkbox automatically unchecks when the email field is cleared.

## Related Issue(s)

Closes #2935

## Description of Changes

- Added logic to automatically uncheck the consent checkbox when the email input field is cleared/emptied

The checkbox now correctly resets to an unchecked state when no email address is present in the input field, preventing users from being stuck with a checked consent box without an email.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
