### PR TITLE
feat(cat-voices): Respect title in agreement confirmation definition

### DIFF
--- a/catalyst_voices/apps/voices/lib/widgets/document_builder/value/agreement_confirmation_widget.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/document_builder/value/agreement_confirmation_widget.dart
@@ -3,6 +3,7 @@ import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
+import 'package:catalyst_voices_shared/catalyst_voices_shared.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
 import 'package:flutter/material.dart';
 
@@ -30,6 +31,7 @@ class _AgreementConfirmationFormField extends VoicesFormField<bool> {
     required super.onChanged,
     super.enabled,
     super.validator,
+    required String title,
     required MarkdownData description,
   }) : super(
          builder: (field) {
@@ -56,7 +58,7 @@ class _AgreementConfirmationFormField extends VoicesFormField<bool> {
                  isEnabled: enabled,
                  isError: field.hasError,
                  label: Text(
-                   context.l10n.agree,
+                   title.isNotBlank ? title : context.l10n.agree,
                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                      color: !enabled && !value ? Theme.of(context).colors.textDisabled : null,
                    ),
@@ -85,6 +87,7 @@ class _AgreementConfirmationWidgetState extends State<AgreementConfirmationWidge
       onChanged: _onChanged,
       validator: _validator,
       enabled: widget.isEditMode,
+      title: widget.schema.title,
       description: widget.schema.description ?? MarkdownData.empty,
     );
   }


### PR DESCRIPTION
# Description

- Respect template title in agreement confirmation widget instead of hardcoded "I agree" text. If the title is empty then "I agree" fallback is enabled.

## Screenshots

<img width="1828" height="683" alt="Screenshot 2025-10-08 at 17 22 27" src="https://github.com/user-attachments/assets/a2a266a3-c201-42f4-9d9f-3d1fc093d2b0" />
<img width="1822" height="780" alt="Screenshot 2025-10-08 at 17 22 34" src="https://github.com/user-attachments/assets/50c69edb-27fc-4a83-9c2f-4cc9aa86218e" />
<img width="1822" height="243" alt="Screenshot 2025-10-08 at 17 23 42" src="https://github.com/user-attachments/assets/b1e35545-e702-438e-a1ef-c3ca41f73d08" />

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
