### PR TITLE
feat(cat-voices): placeholder for empty multicurrency amount

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_document_widgets.dart
+++ b/catalyst_voices/apps/voices/lib/pages/proposal_builder/proposal_builder_document_widgets.dart
@@ -62,7 +62,11 @@ class _Stats extends StatelessWidget {
         Expanded(
           child: _StatsItem(
             label: context.l10n.fundsAvailable,
-            value: category.availableFunds.list.map(MoneyFormatter.formatCompactRounded).join(', '),
+            value: MoneyFormatter.formatMultiCurrencyAmount(
+              category.availableFunds,
+              formatter: MoneyFormatter.formatCompactRounded,
+              separator: ', ',
+            ),
           ),
         ),
         Expanded(

--- a/catalyst_voices/apps/voices/lib/widgets/cards/funds_detail_card.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/cards/funds_detail_card.dart
@@ -72,7 +72,10 @@ class FundsDetailCard extends StatelessWidget {
   }
 
   String _formatFunds(MultiCurrencyAmount amount) {
-    return amount.list.map(MoneyFormatter.formatDecimal).join('\n');
+    return MoneyFormatter.formatMultiCurrencyAmount(
+      amount,
+      formatter: MoneyFormatter.formatDecimal,
+    );
   }
 }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/lib/src/formatter/money_formatter.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/lib/src/formatter/money_formatter.dart
@@ -140,4 +140,23 @@ abstract class MoneyFormatter {
       currency: money.currency,
     );
   }
+
+  /// Formats the [MultiCurrencyAmount] using the specified [formatter].
+  ///
+  /// If the amount is empty a [placeholder] is returned instead.
+  /// Separates amounts in different currencies with [separator].
+  static String formatMultiCurrencyAmount(
+    MultiCurrencyAmount amount, {
+    required String Function(Money) formatter,
+    MoneyDecoration decoration = MoneyDecoration.code,
+    String separator = '\n',
+    String placeholder = '-',
+  }) {
+    final formatted = amount.list.map(formatter).join(separator);
+    if (formatted.isNotEmpty) {
+      return formatted;
+    } else {
+      return placeholder;
+    }
+  }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_shared/test/src/formatter/money_formatter_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_shared/test/src/formatter/money_formatter_test.dart
@@ -289,5 +289,43 @@ void main() {
         expect(formatted, equals('100.00'));
       });
     });
+
+    group('formatMultiCurrencyAmount', () {
+      test('multiple', () {
+        final amount = MultiCurrencyAmount.list([
+          Currencies.ada.amount(100),
+          Currencies.usdm.amount(50),
+        ]);
+
+        final formatted = MoneyFormatter.formatMultiCurrencyAmount(
+          amount,
+          formatter: MoneyFormatter.formatDecimal,
+        );
+
+        expect(formatted, equals('\$ADA 100\n\$USDM 50.00'));
+      });
+
+      test('single', () {
+        final amount = MultiCurrencyAmount.single(Currencies.ada.amount(100));
+
+        final formatted = MoneyFormatter.formatMultiCurrencyAmount(
+          amount,
+          formatter: MoneyFormatter.formatDecimal,
+        );
+
+        expect(formatted, equals(r'$ADA 100'));
+      });
+
+      test('empty', () {
+        final amount = MultiCurrencyAmount.list(const []);
+
+        final formatted = MoneyFormatter.formatMultiCurrencyAmount(
+          amount,
+          formatter: MoneyFormatter.formatDecimal,
+        );
+
+        expect(formatted, equals('-'));
+      });
+    });
   });
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/campaign_category_view_model.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/campaign/campaign_category_view_model.dart
@@ -96,7 +96,10 @@ final class CampaignCategoryDetailsViewModel extends CampaignCategoryViewModel {
   }
 
   String get availableFundsText {
-    return availableFunds.list.map(MoneyFormatter.formatDecimal).join('\n');
+    return MoneyFormatter.formatMultiCurrencyAmount(
+      availableFunds,
+      formatter: MoneyFormatter.formatDecimal,
+    );
   }
 
   String get formattedName {


### PR DESCRIPTION
# Description

Adds `-` placeholder when a multicurrency amount is empty (i.e. in case of displaying total requested amount in campaign but there were none final proposals)

## Screenshots

<img width="1350" height="471" alt="Screenshot 2025-10-13 at 12 25 48" src="https://github.com/user-attachments/assets/9a213ba3-ac91-4014-b946-849b40246d34" />

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
