### PR TITLE
fix(cat-voices): category shimmer in category detail

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/category/category_detail_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/category/category_detail_cubit.dart
@@ -44,7 +44,9 @@ class CategoryDetailCubit extends Cubit<CategoryDetailState> {
   }
 
   Future<void> getCategoryDetail(SignedDocumentRef categoryId) async {
-    if (categoryId.id == state.category?.id.id) return;
+    if (categoryId.id == state.category?.id.id) {
+      return emit(state.copyWith(isLoading: false));
+    }
 
     if (!state.isLoading) {
       emit(state.copyWith(isLoading: true));


### PR DESCRIPTION
# Description

When user enters again the same category loading was never set to false.

## Related Issue(s)

Closes #3574 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
