### PR TITLE
feat(cat-gateway): Bumping the latest `cat-libs` crates

### DIFF
--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -15,12 +15,12 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-cardano-chain-follower = { version = "0.0.16", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower/v0.0.16" }
-rbac-registration = { version = "0.0.12", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "rbac-registration/v0.0.12" }
-catalyst-signed-doc = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc/v0.0.8" }
+cardano-chain-follower = { version = "0.0.17", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower/v0.0.17" }
+rbac-registration = { version = "0.0.13", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "rbac-registration/v0.0.13" }
+catalyst-signed-doc = { version = "0.0.9", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc/v0.0.9" }
 catalyst-signed-doc-v1 = { package = "catalyst-signed-doc", version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc/v.0.0.4" }
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "c509-certificate-v0.0.3" }
-catalyst-types = { version = "0.0.8", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.8" }
+catalyst-types = { version = "0.0.9", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-types/v0.0.9" }
 
 clap = { version = "4.5.20", features = ["derive", "env"] }
 tracing = { version = "0.1.40", features = ["log"] }

--- a/catalyst-gateway/bin/src/rbac/get_chain.rs
+++ b/catalyst-gateway/bin/src/rbac/get_chain.rs
@@ -23,15 +23,13 @@ use crate::{
 /// Returns the latest (including the volatile part) registration chain by the given
 /// Catalyst ID.
 pub async fn latest_rbac_chain(id: &CatalystId) -> Result<Option<ChainInfo>> {
-    let id = id.as_short_id();
-
     let volatile_session =
         CassandraSession::get(false).context("Failed to get volatile Cassandra session")?;
     // Get the persistent part of the chain and volatile registrations. Both of these parts
     // can be non-existing.
     let (chain, volatile_regs) = try_join(
-        persistent_rbac_chain(&id),
-        indexed_regs(&volatile_session, &id),
+        persistent_rbac_chain(id),
+        indexed_regs(&volatile_session, id),
     )
     .await?;
 
@@ -70,14 +68,11 @@ pub async fn latest_rbac_chain(id: &CatalystId) -> Result<Option<ChainInfo>> {
 /// Returns only the persistent part of a registration chain by the given Catalyst ID.
 pub async fn persistent_rbac_chain(id: &CatalystId) -> Result<Option<RegistrationChain>> {
     let session = CassandraSession::get(true).context("Failed to get Cassandra session")?;
-
-    let id = id.as_short_id();
-
-    if let Some(chain) = cached_persistent_rbac_chain(&session, &id) {
+    if let Some(chain) = cached_persistent_rbac_chain(&session, id) {
         return Ok(Some(chain));
     }
 
-    let regs = indexed_regs(&session, &id).await?;
+    let regs = indexed_regs(&session, id).await?;
     let chain = build_rbac_chain(regs).await?.inspect(|c| {
         cache_persistent_rbac_chain(id.clone(), c.clone());
     });

--- a/catalyst-gateway/bin/src/service/api/documents/put_document/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/documents/put_document/mod.rs
@@ -76,7 +76,7 @@ pub(crate) async fn endpoint(
 
     // validate document signatures
     let verifying_key_provider =
-        match VerifyingKeyProvider::try_from_kids(&mut token, &doc.kids()).await {
+        match VerifyingKeyProvider::try_from_kids(&mut token, &doc.authors()).await {
             Ok(value) => value,
             Err(err) if err.is::<CassandraSessionError>() => {
                 return AllResponses::service_unavailable(&err, RetryAfterOption::Default)
@@ -194,7 +194,11 @@ async fn store_document_in_db(
     doc: &catalyst_signed_doc::CatalystSignedDocument,
     doc_bytes: Vec<u8>,
 ) -> anyhow::Result<bool> {
-    let authors = doc.authors().iter().map(ToString::to_string).collect();
+    let authors = doc
+        .authors()
+        .iter()
+        .map(|v| v.as_short_id().to_string())
+        .collect();
 
     let doc_meta_json = doc.doc_meta().to_json()?;
 


### PR DESCRIPTION
# Description

- Bumped `cardano-chain-follower` to the latest `0.0.17`.
- Bumped `rbac-registration` to the latest `0.0.13`.
- Bumped `catalyst-signed-doc` to the latest `0.0.9`.
- Bumped `catalyst-types` to the latest `0.0.9`.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
