### PR TITLE
chore(cat-voices): prettier formatter

### DIFF
--- a/catalyst_voices/.prettierrc.yaml
+++ b/catalyst_voices/.prettierrc.yaml
@@ -1,0 +1,6 @@
+printWidth: 100
+trailingComma: es5
+useTabs: false
+tabWidth: 2
+semi: true
+singleQuote: false

--- a/catalyst_voices/README.md
+++ b/catalyst_voices/README.md
@@ -6,6 +6,7 @@ This repository contains the Catalyst Voices app and packages.
 
 * [Catalyst Voices](#catalyst-voices)
   * [Requirements](#requirements)
+  * [Recommended VS code plugins](#recommended-vs-code-plugins)
   * [Platforms](#platforms)
   * [Getting Started](#getting-started)
     * [Bootstrapping](#bootstrapping)
@@ -40,6 +41,10 @@ This repository contains the Catalyst Voices app and packages.
 * [Rust](https://rustup.rs/): 1.80.0+
 
 ❗️We recommend using **Visual Studio Code** as the **default editor** for this project.
+
+## Recommended VS code plugins
+
+* [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - formatting html and js files.
 
 ## Platforms
 

--- a/catalyst_voices/apps/voices/web/index.html
+++ b/catalyst_voices/apps/voices/web/index.html
@@ -1,137 +1,135 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <base href="$FLUTTER_BASE_HREF" />
 
-<head>
-  <!--
-      If you are serving your web app in a path other than the root, change the
-      href value below to reflect the base path you are serving from.
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta content="Catalyst App" name="description" />
 
-      The path provided below has to start and end with a slash "/" in order for
-      it to work correctly.
+    <!-- iOS meta tags & icons -->
+    <meta content="yes" name="mobile-web-app-capable" />
+    <meta content="black" name="apple-mobile-web-app-status-bar-style" />
+    <meta content="Catalyst App" name="apple-mobile-web-app-title" />
+    <link href="icons/favicon-192.png" rel="apple-touch-icon" />
 
-      For more details:
-      * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+    <!-- Light mode favicon -->
+    <link rel="icon" href="icons/favicon_light.png" media="(prefers-color-scheme: light)" />
 
-      This is a placeholder for base href that will be replaced by the value of
-      the `--base-href` argument provided to `flutter build`.
-    -->
-  <base href="$FLUTTER_BASE_HREF">
+    <!-- Dark mode favicon -->
+    <link rel="icon" href="icons/favicon_dark.png" media="(prefers-color-scheme: dark)" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta content="Catalyst App" name="description">
+    <title>Catalyst</title>
+    <link href="manifest.json" rel="manifest" />
+    <script
+      src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"
+      type="module"
+    ></script>
+    <script
+      defer=""
+      src="/assets/packages/flutter_inappwebview_web/assets/web/web_support.js"
+      type="application/javascript"
+    ></script>
 
-  <!-- iOS meta tags & icons -->
-  <meta content="yes" name="mobile-web-app-capable">
-  <meta content="black" name="apple-mobile-web-app-status-bar-style">
-  <meta content="Catalyst App" name="apple-mobile-web-app-title">
-  <link href="icons/favicon-192.png" rel="apple-touch-icon">
+    <meta
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      name="viewport"
+    />
 
-  <!-- Light mode favicon -->
-  <link rel="icon" href="icons/favicon_light.png" media="(prefers-color-scheme: light)">
+    <style id="splash-screen-style">
+      html {
+        height: 100%;
+      }
 
-  <!-- Dark mode favicon -->
-  <link rel="icon" href="icons/favicon_dark.png" media="(prefers-color-scheme: dark)">
+      body {
+        margin: 0;
+        min-height: 100%;
+        background-color: #dce9fe;
+        background-image: url("splash/img/light-background.png");
+        background-size: 100% 100%;
+      }
 
-  <title>Catalyst</title>
-  <link href="manifest.json" rel="manifest">
-  <script src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js" type="module"></script>
-  <script defer="" src="/assets/packages/flutter_inappwebview_web/assets/web/web_support.js"
-    type="application/javascript"></script>
+      .center {
+        margin: 0;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        -ms-transform: translate(-50%, -50%);
+        transform: translate(-50%, -50%);
+      }
 
-  <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
+      .contain {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+      }
 
+      .stretch {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
 
+      .cover {
+        display: block;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
 
-  <style id="splash-screen-style">
-    html {
-      height: 100%
-    }
+      .bottom {
+        position: absolute;
+        bottom: 0;
+        left: 50%;
+        -ms-transform: translate(-50%, 0);
+        transform: translate(-50%, 0);
+      }
 
-    body {
-      margin: 0;
-      min-height: 100%;
-      background-color: #dce9fe;
-      background-image: url("splash/img/light-background.png");
-      background-size: 100% 100%;
-    }
+      .bottomLeft {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+      }
 
-    .center {
-      margin: 0;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      -ms-transform: translate(-50%, -50%);
-      transform: translate(-50%, -50%);
-    }
+      .bottomRight {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+      }
+    </style>
+    <script id="splash-screen-script">
+      function removeSplashFromWeb() {
+        document.getElementById("splash")?.remove();
+        document.getElementById("splash-branding")?.remove();
+        document.body.style.background = "transparent";
+      }
+    </script>
+  </head>
 
-    .contain {
-      display: block;
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-    }
+  <body>
+    <picture id="splash">
+      <source
+        srcset="
+          splash/img/light-1x.gif 1x,
+          splash/img/light-2x.gif 2x,
+          splash/img/light-3x.gif 3x,
+          splash/img/light-4x.gif 4x
+        "
+        media="(prefers-color-scheme: light)"
+      />
+      <source
+        srcset="
+          splash/img/dark-1x.gif 1x,
+          splash/img/dark-2x.gif 2x,
+          splash/img/dark-3x.gif 3x,
+          splash/img/dark-4x.gif 4x
+        "
+        media="(prefers-color-scheme: dark)"
+      />
+      <img class="center" aria-hidden="true" src="splash/img/light-1x.gif" alt="" />
+    </picture>
 
-    .stretch {
-      display: block;
-      width: 100%;
-      height: 100%;
-    }
-
-    .cover {
-      display: block;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-
-    .bottom {
-      position: absolute;
-      bottom: 0;
-      left: 50%;
-      -ms-transform: translate(-50%, 0);
-      transform: translate(-50%, 0);
-    }
-
-    .bottomLeft {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-    }
-
-    .bottomRight {
-      position: absolute;
-      bottom: 0;
-      right: 0;
-    }
-  </style>
-  <script id="splash-screen-script">
-    function removeSplashFromWeb() {
-      document.getElementById("splash")?.remove();
-      document.getElementById("splash-branding")?.remove();
-      document.body.style.background = "transparent";
-    }
-  </script>
-</head>
-
-<body>
-  <picture id="splash">
-    <source
-      srcset="splash/img/light-1x.gif 1x, splash/img/light-2x.gif 2x, splash/img/light-3x.gif 3x, splash/img/light-4x.gif 4x"
-      media="(prefers-color-scheme: light)">
-    <source
-      srcset="splash/img/dark-1x.gif 1x, splash/img/dark-2x.gif 2x, splash/img/dark-3x.gif 3x, splash/img/dark-4x.gif 4x"
-      media="(prefers-color-scheme: dark)">
-    <img class="center" aria-hidden="true" src="splash/img/light-1x.gif" alt="">
-  </picture>
-
-
-
-  <script async="" src="flutter_bootstrap.js"></script>
-
-
-
-
-</body>
-
+    <script async="" src="flutter_bootstrap.js"></script>
+  </body>
 </html>

--- a/catalyst_voices/packages/internal/catalyst_voices_assets/example/web/index.html
+++ b/catalyst_voices/packages/internal/catalyst_voices_assets/example/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -14,25 +14,25 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="example" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>example</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>example</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/web/index.html
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/example/web/index.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -15,28 +14,30 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="Demonstrates usage of catalyst_cardano plugin">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="Demonstrates usage of catalyst_cardano plugin" />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="example" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png" />
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>example</title>
-  <link rel="manifest" href="manifest.json">
-  <script type="module" src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"></script>
-</head>
+    <title>example</title>
+    <link rel="manifest" href="manifest.json" />
+    <script
+      type="module"
+      src="/assets/packages/catalyst_cardano_web/assets/js/catalyst_cardano.js"
+    ></script>
+  </head>
 
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
-
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/example/web/index.html
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/example/web/index.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -15,27 +14,26 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="Catalyst Voices">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="Catalyst Voices" />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="Catalyst Voices">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="Catalyst Voices" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png" />
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>Catalyst Key Derivation Example</title>
-  <link rel="manifest" href="manifest.json">
-</head>
+    <title>Catalyst Key Derivation Example</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
 
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
-
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/catalyst_voices/utilities/poc_local_storage/web/index.html
+++ b/catalyst_voices/utilities/poc_local_storage/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -14,25 +14,25 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="poc_local_storage">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="poc_local_storage" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>poc_local_storage</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>poc_local_storage</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/catalyst_voices/utilities/remote_widgets/example/web/index.html
+++ b/catalyst_voices/utilities/remote_widgets/example/web/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <!--
+  <head>
+    <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.
 
@@ -14,25 +14,25 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-  <meta charset="UTF-8">
-  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
-  <!-- iOS meta tags & icons -->
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="example">
-  <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <!-- iOS meta tags & icons -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="example" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="favicon.png" />
 
-  <title>example</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <script src="flutter_bootstrap.js" async></script>
-</body>
+    <title>example</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/catalyst_voices/utilities/uikit_example/web/index.html
+++ b/catalyst_voices/utilities/uikit_example/web/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head>
+  <head>
     <!--
       If you are serving your web app in a path other than the root, change the
       href value below to reflect the base path you are serving from.
@@ -14,25 +14,25 @@
       This is a placeholder for base href that will be replaced by the value of
       the `--base-href` argument provided to `flutter build`.
     -->
-    <base href="$FLUTTER_BASE_HREF">
+    <base href="$FLUTTER_BASE_HREF" />
 
-    <meta charset="UTF-8">
-    <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-    <meta name="description" content="A new Flutter project.">
+    <meta charset="UTF-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta name="description" content="A new Flutter project." />
 
     <!-- iOS meta tags & icons -->
-    <meta name="mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black">
-    <meta name="apple-mobile-web-app-title" content="uikit_example">
-    <link rel="apple-touch-icon" href="icons/Icon-192.png">
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <meta name="apple-mobile-web-app-title" content="uikit_example" />
+    <link rel="apple-touch-icon" href="icons/Icon-192.png" />
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="favicon.png"/>
+    <link rel="icon" type="image/png" href="favicon.png" />
 
     <title>uikit_example</title>
-    <link rel="manifest" href="manifest.json">
-</head>
-<body>
-<script src="flutter_bootstrap.js" async></script>
-</body>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
 </html>

--- a/utilities/wallet-tester/index.html
+++ b/utilities/wallet-tester/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script type="module" src="/src/main.tsx"></script>
     <title>Cardano Wallet Tester</title>


### PR DESCRIPTION
# Description

- Adds prettier formatter configuration for html and js files. The config was copied from `/utilities/wallet-tester`.
- Reformated all index.html files.
- Removed from catalyst_voices/apps/voices/index.html the default comments about `--base-href`, our http server does not strip these comments and they end up being served to the end user which is not professional.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
