### PR TITLE
chore(cat-gateway): Bump the api version to 0.7.0 to include cardano assets endpoint changes

### DIFF
--- a/catalyst-gateway/bin/src/service/api/mod.rs
+++ b/catalyst-gateway/bin/src/service/api/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod health;
 const API_TITLE: &str = "Catalyst Gateway";
 
 /// The version of the API
-const API_VERSION: &str = "0.6.0";
+const API_VERSION: &str = "0.7.0";
 
 /// Get the contact details for inquiring about the API
 fn get_api_contact() -> ContactObject {


### PR DESCRIPTION
# Description

Bump the api version to 0.7.0 to include cardano assets endpoint changes.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/3606
