### PR TITLE
fix(cat-gateway): Exclude `/metrics` endpoint for `DatabaseConnectionCheck`

### DIFF
--- a/catalyst-gateway/bin/src/service/utilities/middleware/db_check.rs
+++ b/catalyst-gateway/bin/src/service/utilities/middleware/db_check.rs
@@ -36,9 +36,9 @@ impl<E: Endpoint> Endpoint for DatabaseConnectionImpl<E> {
         let req_path = req.uri().path();
 
         // TODO: find a better way to filter URI paths
-        let is_health_endpoint = req_path.starts_with("/api/v1/health/");
+        let skip = req_path.starts_with("/api/v1/health/") || req_path == "/metrics";
 
-        if !is_health_endpoint {
+        if !skip {
             if !event_db_is_live() {
                 error!(endpoint_path = %req_path, "Event DB is not live");
                 return Err(StatusCode::SERVICE_UNAVAILABLE.into());


### PR DESCRIPTION
# Description

Exclude `/metrics` endpoint for `DatabaseConnectionCheck`, so when `event-db` or `index-db` would be down, metrics endpoint would be functional