### PR TITLE
feat(cat-gateway): New `catalyst-signed-doc` version, with fixed time validation

### DIFF
--- a/catalyst-gateway/Cargo.lock
+++ b/catalyst-gateway/Cargo.lock
@@ -828,11 +828,12 @@ dependencies = [
 [[package]]
 name = "catalyst-signed-doc"
 version = "0.0.4"
-source = "git+https://github.com/input-output-hk/catalyst-libs.git?tag=catalyst-signed-doc%2Fv0.0.4-f15-rc-2#974e33a2c611b74cb525cb3f7a23b261d4afb3f7"
+source = "git+https://github.com/input-output-hk/catalyst-libs.git?tag=catalyst-signed-doc%2Fv0.0.4-f15-rc3#88394bf6d0edfbfe122b1c6cb36edbc433eaf8ef"
 dependencies = [
  "anyhow",
  "brotli 7.0.0",
  "catalyst-types",
+ "chrono",
  "clap",
  "coset",
  "ed25519-bip32",

--- a/catalyst-gateway/bin/Cargo.toml
+++ b/catalyst-gateway/bin/Cargo.toml
@@ -19,7 +19,7 @@ cardano-chain-follower = { version = "0.0.10", git = "https://github.com/input-o
 rbac-registration = { version = "0.0.5", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "cardano-chain-follower-v0.0.10" }
 catalyst-types = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }
 cardano-blockchain-types = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }
-catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc/v0.0.4-f15-rc-2" }
+catalyst-signed-doc = { version = "0.0.4", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "catalyst-signed-doc/v0.0.4-f15-rc3" }
 c509-certificate = { version = "0.0.3", git = "https://github.com/input-output-hk/catalyst-libs.git", tag = "r20250724-01" }
 
 pallas = { version = "0.33.0" }


### PR DESCRIPTION
# Description

Bumpring `catalyst-signed-doc` version with the fixed time validation using `Utc` time instead of relying on just `SystemTime`.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-libs/pull/610

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
