### PR TITLE
feat(docs): Docs only release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
               - 'docs/**'
               - '.config/dictionaries/project.dic'
             not-only-docs:
-              - '!((docs)/**|.config/dictionaries/project.dic)'
+              - '!((docs/**)|.config/dictionaries/project.dic)'
 
   reject:
     if: ${{ !github.event.pull_request.draft }}


### PR DESCRIPTION
# Description

Skip CI when only project.dic or docs files have been changed

## Description of Changes

Currently, when you edit or add any files to the documents folder, you have to wait for the entire CI process to complete.
New workflow job will check if changes have been made in project.dic or docs and if yes only docs release will be executed. 
If you also add or edit any other files elsewhere, the entire CI workflow will be executed.

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
