### PR TITLE
fix: CI release after last changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       not-only-docs: ${{ steps.filter.outputs.not-only-docs }}
     steps:
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -66,7 +67,7 @@ jobs:
       forge_version: 0.21.0
 
   ci:
-    if: ${{ !github.event.pull_request.draft && needs.paths-filter.outputs.not-only-docs == 'true' }}
+    if: ${{ (!github.event.pull_request.draft && needs.paths-filter.outputs.not-only-docs == 'true') || startsWith(github.ref, 'refs/tags/') }}
     needs: [reject, paths-filter]
     uses: input-output-hk/catalyst-forge/.github/workflows/ci.yml@ci/v1.10.0
     with:


### PR DESCRIPTION
# Description

Fix CI release when merge to main or add tag

## Related Issue(s)

Release part is skipped after last changes https://github.com/input-output-hk/catalyst-voices/pull/3667
See run: https://github.com/input-output-hk/catalyst-voices/actions/runs/19261691441

## Description of Changes

After last changes release part is skipped. This happens due to added paths-filter job as dependency for ci job but paths-filter job run only on pull_request event.

## Related Pull Requests

https://github.com/input-output-hk/catalyst-voices/pull/3667

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
