### PR TITLE
chore: Update catalyst-ci to v3.6.1

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.0 AS mdlint-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.0 AS cspell-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.6.0 AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/mdlint:v3.6.1 AS mdlint-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/cspell:v3.6.1 AS cspell-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.6.1 AS postgresql-ci
 
 ARG --global REGISTRY="harbor.shared-services.projectcatalyst.io/dockerhub/library"
 FROM ${REGISTRY}/debian:stable-slim

--- a/catalyst-gateway/Earthfile
+++ b/catalyst-gateway/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.1 AS rust-ci
 IMPORT ../ AS repo-ci
 IMPORT github.com/input-output-hk/catalyst-voices/catalyst-gateway:main AS cat-gateway-main
 

--- a/catalyst-gateway/event-db/Earthfile
+++ b/catalyst-gateway/event-db/Earthfile
@@ -3,7 +3,7 @@
 # the database and its associated software.
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.6.0 AS postgresql-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/postgresql:v3.6.1 AS postgresql-ci
 
 # cspell: words
 

--- a/catalyst-gateway/tests/Earthfile
+++ b/catalyst-gateway/tests/Earthfile
@@ -1,7 +1,7 @@
 # cspell: words unittests socat
 
 VERSION 0.8
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/spectral:v3.6.0 AS spectral-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/spectral:v3.6.1 AS spectral-ci
 IMPORT .. AS gateway
 
 # build all necessary docker images required to run `docker-compose.yml` services

--- a/catalyst-gateway/tests/api_tests/Earthfile
+++ b/catalyst-gateway/tests/api_tests/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.0 AS python-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/python:v3.6.1 AS python-ci
 IMPORT github.com/input-output-hk/catalyst-libs/rust:catalyst-signed-doc/v0.0.8 AS cat-libs-rust
 IMPORT github.com/input-output-hk/catalyst-libs/rust:catalyst-signed-doc/v.0.0.4-fix-earthly-build AS dep-cat-libs-rust
 IMPORT github.com/input-output-hk/catalyst-storage AS cat-storage

--- a/catalyst_voices/Earthfile
+++ b/catalyst_voices/Earthfile
@@ -2,7 +2,7 @@ VERSION 0.8
 
 IMPORT ../ AS repo-ci
 IMPORT ../catalyst-gateway AS catalyst-gateway
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.0 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.1 AS flutter-ci
 
 # repo-catalyst-voices - Creates artifacts of all configuration files,
 # packages and folders related to catalyst_voices frontend.

--- a/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/wallet-automation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_cardano/catalyst_cardano/wallet-automation/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.0 AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/playwright:v3.6.0 AS playwright-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.1 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/playwright:v3.6.1 AS playwright-ci
 
 ARG --global REGISTRY="harbor.shared-services.projectcatalyst.io/dockerhub/"
 

--- a/catalyst_voices/packages/libs/catalyst_compression/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_compression/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
 IMPORT ../../../ AS catalyst-voices
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.0 AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:v3.6.0 AS flutter_rust_bridge
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.1 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:v3.6.1 AS flutter_rust_bridge
 
 builder:
     FROM flutter_rust_bridge+builder

--- a/catalyst_voices/packages/libs/catalyst_compression/rust/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_compression/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.1 AS rust-ci
 IMPORT ../ AS flutter-rust-bridge
 
 # builder : Setup the builder

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/Earthfile
@@ -1,8 +1,8 @@
 VERSION 0.8
 
 IMPORT ../../../ AS catalyst-voices
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.0 AS flutter-ci
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:v3.6.0 AS flutter_rust_bridge
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.1 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter_rust_bridge:v3.6.1 AS flutter_rust_bridge
 
 builder:
     FROM flutter_rust_bridge+builder

--- a/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Earthfile
+++ b/catalyst_voices/packages/libs/catalyst_key_derivation/rust/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.0 AS rust-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/rust:v3.6.1 AS rust-ci
 IMPORT ../ AS flutter-rust-bridge
 
 # builder : Setup the builder

--- a/catalyst_voices/utilities/uikit_example/Earthfile
+++ b/catalyst_voices/utilities/uikit_example/Earthfile
@@ -1,7 +1,7 @@
 VERSION 0.8
 
 IMPORT ../../ AS catalyst-voices
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.0 AS flutter-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/flutter:v3.6.1 AS flutter-ci
 
 # local-build-web - build web version of UIKit example.
 # Prefixed by "local" to make sure it's not auto triggered, the target was

--- a/docs/Earthfile
+++ b/docs/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.0 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.1 AS docs-ci
 
 IMPORT .. AS repo
 IMPORT ../catalyst-gateway AS catalyst-gateway

--- a/utilities/docs-preview/Earthfile
+++ b/utilities/docs-preview/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.8
 
-IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.0 AS docs-ci
+IMPORT github.com/input-output-hk/catalyst-ci/earthly/docs:v3.6.1 AS docs-ci
 
 # update-docs-dev-script: get the latest docs dev script from CI.
 update-docs-dev-script:


### PR DESCRIPTION
Update catalyst-ci to v3.6.1. Release: https://github.com/input-output-hk/catalyst-ci/releases/tag/v3.6.1