### PR TITLE
feat(cat-voices): sort translations when melos l10n is run

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/src/manage_l10n.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/src/manage_l10n.dart
@@ -25,6 +25,9 @@ void main(List<String> args) {
   ).process();
 }
 
+const _ciRootDir = '/frontend';
+const _localRootDir = '/catalyst_voices';
+
 class ArbManager {
   final bool clean;
   final bool sort;
@@ -149,12 +152,12 @@ class ArbManager {
   Directory _findRootDir() {
     var current = Directory.current;
     while (current.path != current.parent.path) {
-      if (current.path.endsWith('catalyst_voices')) {
+      if (current.path.endsWith(_localRootDir) || current.path.endsWith(_ciRootDir)) {
         return current;
       }
       current = current.parent;
     }
-    throw Exception('Could not find catalyst_voices directory');
+    throw Exception('Could not find root directory, searched for [$_localRootDir, $_ciRootDir]');
   }
 
   List<File> _getAllDartFiles(Directory dir) {

--- a/catalyst_voices/pubspec.yaml
+++ b/catalyst_voices/pubspec.yaml
@@ -73,8 +73,8 @@ melos:
 
     l10n:
       run: |
-        melos exec --scope="catalyst_voices_localization" -- flutter gen-l10n && \
-        melos exec --scope="catalyst_voices_localization" -- dart lib/src/manage_l10n.dart --sort
+        melos exec --scope="catalyst_voices_localization" -- dart lib/src/manage_l10n.dart --sort && \
+        melos exec --scope="catalyst_voices_localization" -- flutter gen-l10n
       description: |
         Run `flutter gen-l10n` in catalyst_voices_localization package to generate l10n bindings.
 


### PR DESCRIPTION
# Description

Adds translations sorting when running `melos l10n`.

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
