### PR TITLE
fix(cat-voices): add validation based on significant part of catalystId

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/collaborators/collaborator_catalyst_id.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/collaborators/collaborator_catalyst_id.dart
@@ -43,12 +43,13 @@ final class CollaboratorCatalystId
 
   @override
   CollaboratorCatalystIdValidationException? validator(String value) {
+    final authorCatalystId = this.authorCatalystId;
     final catalystId = CatalystId.tryParse(value);
     if (catalystId == null) {
       return const InvalidCatalystIdFormatValidationException();
-    } else if (catalystId == authorCatalystId) {
+    } else if (authorCatalystId != null && catalystId.isSameAs(authorCatalystId)) {
       return const CatalystIdBelongsToMainProposerValidationException();
-    } else if (collaborators.contains(catalystId)) {
+    } else if (collaborators.any((collaborator) => collaborator.isSameAs(catalystId))) {
       return const CatalystIdAlreadyAddedValidationException();
     }
     return null;


### PR DESCRIPTION
# Description

Updated the `CollaboratorCatalystId` validation logic to compare `CatalystId` using their significant parts to ensure accurate duplicate detection.

## Related Issue(s)

Closes #3805
Fixes #3683

## Demo

https://github.com/user-attachments/assets/2e66f2da-49c9-4147-800b-96a83bc2c52b

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
