### PR TITLE
feat(cat-voices): cbor deterministic encoding for collaborators and document refs

### DIFF
--- a/catalyst_voices/packages/libs/catalyst_cose/lib/src/types/cose_custom_types.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/lib/src/types/cose_custom_types.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:catalyst_cose/src/types/cose_uuid.dart';
+import 'package:catalyst_cose/src/utils/cbor_deterministic_utils.dart';
 import 'package:cbor/cbor.dart';
 
 /// UTF-8 Catalyst ID URI encoded as a bytes string.
@@ -30,7 +31,9 @@ extension type const CoseCollaborators(List<CatalystIdKid> list) {
 
   /// Serializes the type as cbor.
   CborValue toCbor() {
-    return CborList(list.map((e) => e.toCbor()).toList());
+    return CborDeterministicUtils.createList(
+      list.map((e) => e.toCbor()).toList(),
+    );
   }
 }
 

--- a/catalyst_voices/packages/libs/catalyst_cose/lib/src/types/cose_document_ref.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/lib/src/types/cose_document_ref.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:catalyst_cose/src/exception/cose_format_exception.dart';
 import 'package:catalyst_cose/src/types/cose_uuid.dart';
+import 'package:catalyst_cose/src/utils/cbor_deterministic_utils.dart';
 import 'package:catalyst_cose/src/utils/cbor_utils.dart';
 import 'package:cbor/cbor.dart';
 import 'package:equatable/equatable.dart';
@@ -133,7 +134,9 @@ extension type const CoseDocumentRefs._(List<CoseDocumentRef> refs) {
 
   /// Serializes the type as cbor.
   CborValue toCbor() {
-    return CborList(refs.map((e) => e.toCbor()).toList());
+    return CborDeterministicUtils.createList(
+      refs.map((e) => e.toCbor()).toList(),
+    );
   }
 
   /// Pre v0.0.1 spec, the document ref was just a string representing the documentId, not documented.

--- a/catalyst_voices/packages/libs/catalyst_cose/lib/src/utils/cbor_deterministic_utils.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/lib/src/utils/cbor_deterministic_utils.dart
@@ -1,0 +1,64 @@
+import 'dart:typed_data';
+
+import 'package:cbor/cbor.dart';
+
+/// A set of utils to deal with deterministic CBOR as defined in:
+/// https://www.rfc-editor.org/rfc/rfc8949.html#name-deterministically-encoded-c.
+final class CborDeterministicUtils {
+  const CborDeterministicUtils._();
+
+  /// Creates a deterministically sorted [CborList].
+  ///
+  /// Applies the same set of sorting rules for the list items as applied by this spec to map keys:
+  /// https://www.rfc-editor.org/rfc/rfc8949.html#name-length-first-map-key-orderi
+  ///
+  /// The resulting [CborList] will always be encoded as definite-length
+  /// because indefinite-length must not appear as per the specification.
+  static CborList createList(
+    List<CborValue> items, {
+    List<int> tags = const [],
+  }) {
+    final encodedItems = <({CborValue value, Uint8List bytes})>[
+      for (final value in items)
+        (
+          value: value,
+          bytes: Uint8List.fromList(cbor.encode(value)),
+        ),
+    ];
+
+    // ignore: cascade_invocations
+    encodedItems.sort(_compareDeterministicElements);
+
+    return CborList(
+      encodedItems.map((e) => e.value).toList(),
+      tags: tags,
+      type: CborLengthType.definite,
+    );
+  }
+
+  static int _compareDeterministicElements(
+    ({CborValue value, Uint8List bytes}) a,
+    ({CborValue value, Uint8List bytes}) b,
+  ) {
+    final aSize = a.bytes.length;
+    final bSize = b.bytes.length;
+
+    if (aSize != bSize) {
+      // shorter one sorts earlier
+      return aSize < bSize ? -1 : 1;
+    }
+
+    for (var i = 0; i < aSize; i++) {
+      final aByte = a.bytes[i];
+      final bByte = b.bytes[i];
+
+      if (aByte != bByte) {
+        // the one with lower byte value sorts earlier
+        return aByte < bByte ? -1 : 1;
+      }
+    }
+
+    // they're the same
+    return 0;
+  }
+}

--- a/catalyst_voices/packages/libs/catalyst_cose/test/utils/cbor_deterministic_utils_test.dart
+++ b/catalyst_voices/packages/libs/catalyst_cose/test/utils/cbor_deterministic_utils_test.dart
@@ -1,0 +1,55 @@
+import 'package:catalyst_cose/src/utils/cbor_deterministic_utils.dart';
+import 'package:cbor/cbor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(CborDeterministicUtils, () {
+    test('createList always creates definite-length list', () {
+      // Given
+      final input = CborList([], type: CborLengthType.indefinite);
+
+      // When
+      final output = CborDeterministicUtils.createList(input);
+
+      // Then
+      expect(output.type, equals(CborLengthType.definite));
+    });
+
+    test('createList sorts deterministically the list', () {
+      // Given
+      final input = CborList([
+        const CborSmallInt(2),
+        CborBytes([1, 2, 3]),
+        const CborSmallInt(1),
+      ]);
+
+      // When
+      final output = CborDeterministicUtils.createList(input);
+
+      // Then
+      expect(
+        output,
+        orderedEquals([
+          const CborSmallInt(1),
+          const CborSmallInt(2),
+          CborBytes([1, 2, 3]),
+        ]),
+      );
+    });
+
+    test('createList does not modify already deterministic list', () {
+      // Given
+      final input = [
+        const CborSmallInt(1),
+        const CborSmallInt(2),
+        CborBytes([1, 2, 3]),
+      ];
+
+      // When
+      final output = CborDeterministicUtils.createList(input);
+
+      // Then
+      expect(output, orderedEquals(input));
+    });
+  });
+}


### PR DESCRIPTION
# Description

- Sort cbor arrays (lists) deterministically in collaborators and document refs.
- The solution sorts the source list before passing it to the encoder. Other approaches tried but the `cbor` package does not expose enough information or the implementation is either marked as `@internal` or private in the package.
- `CborValue` is responsible itself for encoding to binary format, however the `CborList` implementation is private and cannot be overridden. The `CborList` interface is public and could be implemented on catalyst side however it requires almost one to one copy-paste from the existing implementation  just to tweak a single method which doesn't justify it.

## Related Issue(s)

Closes #3754

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
