### PR TITLE
test(cat-gateway): Add hypothesis-deadline to schemathesis vars and extend it for nightly

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           export HYPOTHESIS_MAX_EXAMPLES=5000
           export MAX_RESPONSE_TIME=25000
+          export HYPOTHESIS_DEADLINE=25000
           docker compose -f catalyst-gateway/tests/docker-compose.yml up schemathesis-runner --exit-code-from schemathesis-runner
 
       - name: Spin up catalyst-gateway with haproxy

--- a/catalyst-gateway/tests/schemathesis_tests/entry.sh
+++ b/catalyst-gateway/tests/schemathesis_tests/entry.sh
@@ -10,6 +10,7 @@ st run --checks=all ${API_SPEC} \
                     --wait-for-schema=${WAIT_FOR_SCHEMA} \
                     --max-response-time=${MAX_RESPONSE_TIME} \
                     --hypothesis-max-examples=${HYPOTHESIS_MAX_EXAMPLES} \
+                    --hypothesis-deadline=${HYPOTHESIS_DEADLINE:-15000} \
                     --data-generation-method=all \
                     --exclude-deprecated \
                     --force-schema-version=30 \


### PR DESCRIPTION
# Description

In nightly we have schemathesis running with more examples and sometimes test run longer that max 15000milis.
This will extend it for nightly run only.
<img width="3096" height="1236" alt="CleanShot 2025-12-09 at 10 35 29@2x" src="https://github.com/user-attachments/assets/7e602ecb-c3bc-48dd-9e89-59bb2cec7c8e" />


## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #1, Resolves #1  Fixes #1

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #1, #1

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
