### PR TITLE
test(cat-gateway): Wait more for gateway to fail after index db gets unreachable

### DIFF
--- a/catalyst-gateway/tests/api_tests/integration/test_health_thru_proxy.py
+++ b/catalyst-gateway/tests/api_tests/integration/test_health_thru_proxy.py
@@ -110,7 +110,7 @@ def test_ready_endpoint_with_index_db_outage(index_db_proxy, rbac_chain_factory)
     index_db_proxy.disable()
     health.is_ready()  # assertion
     # index-db threshold to start returning 503
-    health.is_not_ready(380)  # assertion
+    health.is_not_ready(480)  # assertion
     # Event DB testing
     resp = document.post(filter={}, limit=10, page=0)
     assert resp.status_code == 503, (


### PR DESCRIPTION
# Description

Wait more for gateway to fail after index db gets unreachable

## Related Issue(s)

List the issue numbers related to this pull request.

> e.g., Closes #1, Resolves #1  Fixes #1

## Description of Changes

Provide a clear and concise description of what the pull request changes.

## Breaking Changes

Describe any breaking changes and the impact.

## Screenshots

If applicable, add screenshots to help explain your changes.

## Related Pull Requests

If applicable, list any related pull requests.

> e.g., #1, #1

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
