### PR TITLE
feat(cat-voices): document id and ver freshness

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_ref.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/document/document_ref.dart
@@ -41,6 +41,8 @@ sealed class DocumentRef extends Equatable implements Comparable<DocumentRef> {
   /// Whether the ref specifies the document [version].
   bool get isExact => version != null;
 
+  bool get isGenesis => id == version;
+
   @override
   List<Object?> get props => [id, version];
 
@@ -75,8 +77,8 @@ sealed class DocumentRef extends Equatable implements Comparable<DocumentRef> {
   /// first version of the document. The [version] will be the same as [id].
   ///
   /// If [id] != [version] then only a new version is generated equalling to [DateTime.now].
-  DraftRef freshVersion() {
-    if (id == version) {
+  DraftRef fresh() {
+    if (isGenesis) {
       return DraftRef.generateFirstRef();
     }
 

--- a/catalyst_voices/packages/internal/catalyst_voices_models/test/document/document_ref_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/test/document/document_ref_test.dart
@@ -4,18 +4,18 @@ import 'package:uuid_plus/uuid_plus.dart';
 
 void main() {
   group(DocumentRef, () {
-    test('freshVersion generates new id and version for first document', () {
+    test('fresh generates new id and version for first document', () {
       final originalRef = DraftRef.generateFirstRef();
-      final freshRef = originalRef.freshVersion();
+      final freshRef = originalRef.fresh();
 
       expect(originalRef.id, isNot(freshRef.id));
       expect(originalRef.version, isNot(freshRef.version));
     });
 
-    test('freshVersion generates new version only for subsequent document', () {
+    test('fresh generates new version only for subsequent document', () {
       final originalRef = DraftRef.generateFirstRef();
       final subsequentRef = DraftRef(id: originalRef.id, version: const Uuid().v7());
-      final freshRef = subsequentRef.freshVersion();
+      final freshRef = subsequentRef.fresh();
 
       expect(originalRef.id, equals(freshRef.id));
       expect(originalRef.version, isNot(freshRef.version));

--- a/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/proposal/proposal_service.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_services/lib/src/proposal/proposal_service.dart
@@ -382,7 +382,7 @@ final class ProposalServiceImpl implements ProposalService {
     // There is a system requirement to publish fresh documents,
     // where version timestamp is not older than a predefined interval.
     // Because of it we're regenerating a version just before publishing.
-    final freshRef = originalRef.freshVersion();
+    final freshRef = originalRef.fresh();
     final freshDocument = document.copyWithSelfRef(selfRef: freshRef);
 
     await _signerService.useProposerCredentials(


### PR DESCRIPTION
# Description

Make sure that id and ver are fresh when publishing the first version of the document.

## Related Issue(s)

Closes #3910

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
