### PR TITLE
feat(cat-voices): Persist tab count while loading

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/proposals/proposals_cubit.dart
@@ -341,7 +341,7 @@ final class ProposalsCubit extends Cubit<ProposalsState>
     _proposalsCountSub = Rx.combineLatest(
       streams,
       Map<ProposalsPageTab, int>.fromEntries,
-    ).startWith({}).listen(_handleProposalsCountChange);
+    ).startWith(state.count).listen(_handleProposalsCountChange);
   }
 
   void _resetCache() {

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/voting/voting_cubit.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/voting/voting_cubit.dart
@@ -303,7 +303,7 @@ final class VotingCubit extends Cubit<VotingState>
     _proposalsCountSub = Rx.combineLatest(
       streams,
       Map<VotingPageTab, int>.fromEntries,
-    ).startWith({}).listen(_handleProposalsCountChange);
+    ).startWith(state.count).listen(_handleProposalsCountChange);
   }
 
   VotingState _rebuildState() {


### PR DESCRIPTION
# Description

Preserve proposal tab counts while data loads by initializing count streams with the existing state instead of an empty map.

# Demo

before:

https://github.com/user-attachments/assets/77b3d073-b6a2-4f9b-8224-4e7d180e26f5

after:

https://github.com/user-attachments/assets/00d53fef-386f-40b9-88f8-03b8741dcf91

## Please confirm the following checks

* [ ] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream module
