### PR TITLE
fix(cat-voices): final proposal approval redirect to viewer

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/actions/proposal_approval/widgets/proposal_approval_decide_card.dart
+++ b/catalyst_voices/apps/voices/lib/pages/actions/proposal_approval/widgets/proposal_approval_decide_card.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/actions/proposal_approval/widgets/proposal_approval_collaborators.dart';
-import 'package:catalyst_voices/routes/routing/proposal_builder_route.dart';
+import 'package:catalyst_voices/routes/routing/proposal_route.dart';
 import 'package:catalyst_voices/widgets/widgets.dart';
 import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
@@ -69,7 +69,7 @@ class _Footer extends StatelessWidget {
       child: VoicesFilledButton(
         leading: VoicesAssets.icons.plus.buildIcon(),
         child: Text(context.l10n.openForDecision),
-        onTap: () => unawaited(ProposalBuilderRoute.fromRef(ref: proposalId).push(context)),
+        onTap: () => unawaited(ProposalRoute.fromRef(ref: proposalId).push(context)),
       ),
     );
   }


### PR DESCRIPTION
# Description

Final proposal approval card should redirect to the Proposal viewer instead of Proposal Builder

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
