### PR TITLE
fix(cat-gateway): Fix use of LOG_LEVEL setting

### DIFF
--- a/catalyst-gateway/bin/src/settings/mod.rs
+++ b/catalyst-gateway/bin/src/settings/mod.rs
@@ -81,7 +81,7 @@ fn calculate_service_uuid() -> String {
 #[clap(version = BUILD_INFO)]
 pub(crate) struct ServiceSettings {
     /// Logging level
-    #[clap(long, default_value = LOG_LEVEL_DEFAULT)]
+    #[clap(long, env = "LOG_LEVEL", default_value = LOG_LEVEL_DEFAULT)]
     pub(crate) log_level: LogLevel,
 }
 

--- a/catalyst-gateway/entrypoint.sh
+++ b/catalyst-gateway/entrypoint.sh
@@ -6,7 +6,7 @@ if [[ -n "${DEBUG_SLEEP}" ]]; then
 fi
 
 args+=()
-args+=("run" "--log-level" "debug")
+args+=("run")
 
 echo "Starting gateway node..."
 "/app/cat-gateway" "${args[@]}"


### PR DESCRIPTION
# Description

- Use `LOG_LEVEL` env var to set the `--log-level` argument for the execution command.
- Remove hard argument from the `entrypoint.sh` for the `cat-gateway:latest` docker container.

## Related Issue(s)

Closes #3903 

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
