### PR TITLE
fix(cat-voices): display consent status on final proposal

### DIFF
--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/test/display_consent/display_consent_cubit_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/test/display_consent/display_consent_cubit_test.dart
@@ -109,6 +109,7 @@ void main() {
               ProposalDataCollaborator(
                 id: catalystId,
                 status: ProposalsCollaborationStatus.pending,
+                invitation: ProposalInvitationStatus.pending,
                 createdAt: DateTime(2024, 1, 2),
               ),
             ],
@@ -170,6 +171,7 @@ void main() {
             ProposalDataCollaborator(
               id: catalystId,
               status: ProposalsCollaborationStatus.pending,
+              invitation: ProposalInvitationStatus.pending,
               createdAt: DateTime(2024, 1, 2),
             ),
           ],
@@ -441,6 +443,7 @@ void main() {
               ProposalDataCollaborator(
                 id: catalystId,
                 status: ProposalsCollaborationStatus.pending,
+                invitation: ProposalInvitationStatus.pending,
                 createdAt: DateTime(2024, 1, 4),
               ),
             ],

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/data/proposal_brief_data.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/data/proposal_brief_data.dart
@@ -74,9 +74,9 @@ final class ProposalBriefData extends Equatable implements Comparable<ProposalBr
         final rawCollaboratorAction = collaboratorsActions[id.toSignificant()];
         return ProposalDataCollaborator.fromAction(
           id: id,
-          action: rawCollaboratorAction?.action,
+          rawAction: rawCollaboratorAction,
+          proposalId: data.proposal.id,
           isProposalFinal: isFinal,
-          actionId: rawCollaboratorAction?.actionId,
         );
       },
     ).toList();

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/data/proposal_data_v2.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/data/proposal_data_v2.dart
@@ -49,6 +49,7 @@ final class ProposalDataV2 extends Equatable {
     final versions = data.versionIds.map((ver) => id.copyWith(ver: Optional(ver))).toList();
 
     final collaborators = ProposalDataCollaborator.resolveCollaboratorStatuses(
+      proposalId: id,
       isProposalFinal: isFinal,
       currentCollaborators: data.proposal.metadata.collaborators ?? [],
       collaboratorsActions: collaboratorsActions,

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal.dart
@@ -14,6 +14,7 @@ export 'proposal_creation_step.dart';
 export 'proposal_data.dart';
 export 'proposal_enums.dart';
 export 'proposal_forget_actions.dart';
+export 'proposal_invitation_status.dart';
 export 'proposal_model.dart';
 export 'proposal_or_document.dart';
 export 'proposal_version.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal_invitation_status.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/lib/src/proposal/proposal_invitation_status.dart
@@ -1,0 +1,14 @@
+enum ProposalInvitationStatus {
+  /// No action from collaborator for proposal's (id)  any version
+  pending,
+
+  /// Latest action from collaborator for proposal (id) is draft or final
+  accepted,
+
+  /// Latest action from collaborator for proposal (id) is hide
+  rejected;
+
+  const ProposalInvitationStatus();
+
+  bool get isAccepted => this == ProposalInvitationStatus.accepted;
+}

--- a/catalyst_voices/packages/internal/catalyst_voices_models/test/proposal/data/proposal_data_collaborator_test.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_models/test/proposal/data/proposal_data_collaborator_test.dart
@@ -26,6 +26,7 @@ void main() {
           prevCollaborators: collaborators,
           prevAuthors: [authorCatalystId],
           isProposalFinal: false,
+          proposalId: SignedDocumentRef.generateFirstRef(),
         );
 
         expect(
@@ -40,6 +41,7 @@ void main() {
       'and versions are the same and proposal is a draft',
       () {
         final collaborators = [collaborator1Id, collaborator2Id, collaborator3Id, collaborator4Id];
+        final proposalId = SignedDocumentRef.generateFirstRef();
         final result = ProposalDataCollaborator.resolveCollaboratorStatuses(
           currentCollaborators: collaborators,
           prevCollaborators: collaborators,
@@ -48,23 +50,24 @@ void main() {
             collaborator2Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.draft,
               id: collaborator2Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
             collaborator3Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.aFinal,
               id: collaborator4Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
             collaborator4Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.hide,
               id: collaborator4Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
           },
           isProposalFinal: false,
+          proposalId: proposalId,
         );
 
         expect(
@@ -84,6 +87,7 @@ void main() {
       'and versions are the same and proposal is final',
       () {
         final collaborators = [collaborator1Id, collaborator2Id, collaborator3Id, collaborator4Id];
+        final proposalId = SignedDocumentRef.generateFirstRef();
         final result = ProposalDataCollaborator.resolveCollaboratorStatuses(
           currentCollaborators: collaborators,
           prevCollaborators: collaborators,
@@ -92,23 +96,24 @@ void main() {
             collaborator2Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.draft,
               id: collaborator2Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
             collaborator3Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.aFinal,
               id: collaborator4Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
             collaborator4Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.hide,
               id: collaborator4Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
           },
           isProposalFinal: true,
+          proposalId: proposalId,
         );
 
         expect(
@@ -131,6 +136,7 @@ void main() {
           prevCollaborators: [collaborator1Id],
           prevAuthors: [collaborator1Id],
           isProposalFinal: false,
+          proposalId: SignedDocumentRef.generateFirstRef(),
         );
 
         expect(
@@ -151,6 +157,7 @@ void main() {
           prevCollaborators: [collaborator1Id],
           prevAuthors: [authorCatalystId],
           isProposalFinal: false,
+          proposalId: SignedDocumentRef.generateFirstRef(),
         );
 
         expect(
@@ -166,6 +173,7 @@ void main() {
       'sets collaborators status as removed when he is not the author of proposal '
       'and is absent in collaborators list but he accepted invitation',
       () {
+        final proposalId = SignedDocumentRef.generateFirstRef();
         final result = ProposalDataCollaborator.resolveCollaboratorStatuses(
           currentCollaborators: [],
           prevCollaborators: [collaborator1Id],
@@ -174,11 +182,12 @@ void main() {
             collaborator1Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.draft,
               id: collaborator1Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
           },
           isProposalFinal: false,
+          proposalId: proposalId,
         );
 
         expect(
@@ -194,6 +203,7 @@ void main() {
       'sets collaborators status as left when he is the author of proposal '
       'and is absent in collaborators list but he accepted invitation',
       () {
+        final proposalId = SignedDocumentRef.generateFirstRef();
         final result = ProposalDataCollaborator.resolveCollaboratorStatuses(
           currentCollaborators: [],
           prevCollaborators: [collaborator1Id],
@@ -202,11 +212,12 @@ void main() {
             collaborator1Id.toSignificant(): RawCollaboratorAction(
               action: ProposalSubmissionAction.draft,
               id: collaborator1Id,
-              proposalId: SignedDocumentRef.generateFirstRef(),
+              proposalId: proposalId,
               actionId: SignedDocumentRef.generateFirstRef(),
             ),
           },
           isProposalFinal: false,
+          proposalId: proposalId,
         );
 
         expect(
@@ -214,6 +225,46 @@ void main() {
           equals([
             ProposalsCollaborationStatus.left,
           ]),
+        );
+      },
+    );
+
+    test(
+      'collaborator invitation status is accepted and status pending '
+      'when latest action was taken on not latest version',
+      () {
+        final collaborators = [collaborator1Id];
+        final proposalIdVer1 = SignedDocumentRef.generateFirstRef();
+        final proposalIdVer2 = proposalIdVer1.nextVersion().toSignedDocumentRef();
+
+        final result = ProposalDataCollaborator.resolveCollaboratorStatuses(
+          currentCollaborators: collaborators,
+          prevCollaborators: collaborators,
+          prevAuthors: [authorCatalystId],
+          collaboratorsActions: {
+            // accepted invitation for first version
+            collaborator1Id.toSignificant(): RawCollaboratorAction(
+              action: ProposalSubmissionAction.draft,
+              id: collaborator1Id,
+              proposalId: proposalIdVer1,
+              actionId: SignedDocumentRef.generateFirstRef(),
+            ),
+          },
+          // section version is final
+          isProposalFinal: true,
+          proposalId: proposalIdVer2,
+        );
+
+        final statuses = result.map((c) => c.status).toList();
+        final invitations = result.map((c) => c.invitation).toList();
+
+        expect(
+          statuses,
+          equals([ProposalsCollaborationStatus.pending]),
+        );
+        expect(
+          invitations,
+          equals([ProposalInvitationStatus.accepted]),
         );
       },
     );

--- a/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_repositories/lib/src/proposal/proposal_repository.dart
@@ -711,11 +711,10 @@ final class ProposalRepositoryImpl implements ProposalRepository {
       proposalId: proposalId,
     );
 
-    final isFinal = action == ProposalSubmissionAction.aFinal;
-
     final collaboratorsActions = await _proposalsLocalSource.getCollaboratorsActions(
-      // if proposal is final find actions for specific version
-      proposalsRefs: [if (isFinal) proposalId else proposalId.toLoose()],
+      // Get latest submission action for any version of proposal.
+      // Later it will be resolved in ProposalDataCollaborator.fromAction
+      proposalsRefs: [proposalId.toLoose()],
     );
     final proposalCollaboratorsActions = collaboratorsActions[proposalId.id]?.data ?? const {};
 

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/collaborators/collaborator_proposal_display_consent.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/collaborators/collaborator_proposal_display_consent.dart
@@ -12,13 +12,12 @@ enum CollaboratorDisplayConsentStatus {
   const CollaboratorDisplayConsentStatus();
 
   factory CollaboratorDisplayConsentStatus.fromCollaborationStatus(
-    ProposalsCollaborationStatus? status,
+    ProposalInvitationStatus status,
   ) {
     return switch (status) {
-      ProposalsCollaborationStatus.accepted => CollaboratorDisplayConsentStatus.allowed,
-      ProposalsCollaborationStatus.rejected => CollaboratorDisplayConsentStatus.denied,
-      // For other statuses, default to pending
-      _ => CollaboratorDisplayConsentStatus.pending,
+      ProposalInvitationStatus.pending => CollaboratorDisplayConsentStatus.pending,
+      ProposalInvitationStatus.accepted => CollaboratorDisplayConsentStatus.allowed,
+      ProposalInvitationStatus.rejected => CollaboratorDisplayConsentStatus.denied,
     };
   }
 
@@ -85,9 +84,9 @@ class CollaboratorProposalDisplayConsent extends Equatable {
         'This indicates that filters used to retrieve this proposal brief data are not correct.',
       ),
     );
-    final collaboratorStatus = collaborator?.status;
+    final invitation = collaborator?.invitation ?? ProposalInvitationStatus.pending;
     final displayConsentStatus = CollaboratorDisplayConsentStatus.fromCollaborationStatus(
-      collaboratorStatus,
+      invitation,
     );
 
     return CollaboratorProposalDisplayConsent(


### PR DESCRIPTION
# Description

Fixes display constant status for final proposal with previous action

## Related Issue(s)

Fixes #4086

## Description of Changes

`ProposalDataCollaborator.fromAction` now takes latest  `RawCollaboratorAction`, instead of one point to proposal version if proposal is final. Because of that `ProposalDataCollaborator` now have to check if action was for correct version.



## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
