### PR TITLE
feat(cat-voices): vote list casting vote updates

### DIFF
--- a/catalyst_voices/apps/voices/lib/pages/voting_list/widgets/voting_list_bottom_sheet.dart
+++ b/catalyst_voices/apps/voices/lib/pages/voting_list/widgets/voting_list_bottom_sheet.dart
@@ -19,9 +19,10 @@ class VotingListBottomSheet extends StatelessWidget {
       },
       builder: (context, state) {
         return switch (state) {
-          ConfirmPasswordStep(:final isLoading, :final exception) =>
+          ConfirmPasswordStep(:final isLoading, :final isRepresentative, :final exception) =>
             VotingListBottomSheetConfirmPassword(
               isLoading: isLoading,
+              isRepresentative: isRepresentative,
               exception: exception,
             ),
           SuccessfullyCastVotesStep() => const VotingListBottomSheetSuccessResult(),

--- a/catalyst_voices/apps/voices/lib/pages/voting_list/widgets/voting_list_bottom_sheet_confirm_password.dart
+++ b/catalyst_voices/apps/voices/lib/pages/voting_list/widgets/voting_list_bottom_sheet_confirm_password.dart
@@ -2,7 +2,9 @@ import 'package:catalyst_voices/common/ext/build_context_ext.dart';
 import 'package:catalyst_voices/pages/voting_list/widgets/voting_list_bottom_sheet.dart';
 import 'package:catalyst_voices/widgets/text_field/voices_password_text_field.dart';
 import 'package:catalyst_voices/widgets/text_field/voices_text_field.dart';
+import 'package:catalyst_voices_assets/catalyst_voices_assets.dart';
 import 'package:catalyst_voices_blocs/catalyst_voices_blocs.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
 import 'package:catalyst_voices_localization/catalyst_voices_localization.dart';
 import 'package:catalyst_voices_models/catalyst_voices_models.dart';
 import 'package:catalyst_voices_view_models/catalyst_voices_view_models.dart';
@@ -10,13 +12,59 @@ import 'package:flutter/material.dart';
 
 class VotingListBottomSheetConfirmPassword extends StatefulWidget {
   final bool isLoading;
+  final bool isRepresentative;
   final LocalizedException? exception;
 
-  const VotingListBottomSheetConfirmPassword({super.key, required this.isLoading, this.exception});
+  const VotingListBottomSheetConfirmPassword({
+    super.key,
+    required this.isLoading,
+    this.isRepresentative = false,
+    this.exception,
+  });
 
   @override
   State<VotingListBottomSheetConfirmPassword> createState() =>
       _VotingListBottomSheetConfirmPasswordState();
+}
+
+class _RepresentativeInfoCard extends StatelessWidget {
+  const _RepresentativeInfoCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16).add(const EdgeInsets.only(bottom: 4)),
+      decoration: BoxDecoration(
+        gradient: context.colorScheme.votingGradient,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          VoicesAssets.icons.userGroup.buildIcon(
+            size: 24,
+            color: context.colors.textOnPrimaryWhite,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            context.l10n.votingListRepresentingWithImpact,
+            style: context.textTheme.titleMedium?.copyWith(
+              color: context.colors.textOnPrimaryWhite,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            context.l10n.votingListRepresentingWithImpactMessage,
+            style: context.textTheme.bodyMedium?.copyWith(
+              color: context.colors.textOnPrimaryWhite,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _VotingListBottomSheetConfirmPasswordState
@@ -43,6 +91,10 @@ class _VotingListBottomSheetConfirmPasswordState
           ),
           const SizedBox(height: 12),
           Text(context.l10n.voteSubmissionDescription),
+          if (widget.isRepresentative) ...[
+            const SizedBox(height: 32),
+            const _RepresentativeInfoCard(),
+          ],
           const SizedBox(height: 32),
           VoicesPasswordTextField(
             autofocus: true,

--- a/catalyst_voices/apps/voices/lib/pages/voting_list/widgets/voting_list_footer.dart
+++ b/catalyst_voices/apps/voices/lib/pages/voting_list/widgets/voting_list_footer.dart
@@ -21,13 +21,22 @@ class VotingListFooter extends StatelessWidget {
 
 class _CastVotesButton extends StatelessWidget {
   final VoidCallback? onTap;
+  final bool useGradient;
 
   const _CastVotesButton({
     this.onTap,
+    this.useGradient = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    if (useGradient) {
+      return VoicesGradientButton(
+        onTap: onTap,
+        child: Text(context.l10n.votingListCastVotes),
+      );
+    }
+
     return VoicesFilledButton(
       onTap: onTap,
       style: FilledButton.styleFrom(
@@ -123,6 +132,7 @@ class _VotingListFooter extends StatelessWidget {
           ),
           Expanded(
             child: _CastVotesButton(
+              useGradient: data.isRepresentative,
               onTap: data.canCastVotes
                   ? () {
                       context.read<VotingBallotBloc>().add(const ConfirmCastingVotesEvent());

--- a/catalyst_voices/apps/voices/lib/widgets/buttons/voices_gradient_button.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/buttons/voices_gradient_button.dart
@@ -1,0 +1,90 @@
+import 'package:catalyst_voices/common/ext/build_context_ext.dart';
+import 'package:catalyst_voices/widgets/buttons/voices_button_affix_decoration.dart';
+import 'package:catalyst_voices_brands/catalyst_voices_brands.dart';
+import 'package:flutter/material.dart';
+
+/// A button with a gradient background.
+///
+/// This widget provides a filled button with a customizable gradient background.
+/// When disabled, the button will appear with reduced opacity.
+class VoicesGradientButton extends StatelessWidget {
+  /// The callback function invoked when the button is pressed.
+  final VoidCallback? onTap;
+
+  /// The widget to be displayed before the button's main content.
+  final Widget? leading;
+
+  /// The widget to be displayed after the button's main content.
+  final Widget? trailing;
+
+  /// The gradient to use for the button background.
+  final Gradient? gradient;
+
+  final BorderRadius borderRadius;
+
+  final EdgeInsetsGeometry padding;
+
+  /// The opacity when the button is disabled.
+  final double disabledOpacity;
+
+  /// The main content of the button.
+  final Widget child;
+
+  const VoicesGradientButton({
+    super.key,
+    this.onTap,
+    this.leading,
+    this.trailing,
+    this.gradient,
+    this.borderRadius = const BorderRadius.all(Radius.circular(8)),
+    this.padding = const EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+    this.disabledOpacity = 0.38,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isEnabled = onTap != null;
+    final effectiveGradient = gradient ?? context.colorScheme.votingGradient;
+    final foregroundColor = context.colors.textOnPrimaryWhite;
+
+    return Opacity(
+      opacity: isEnabled ? 1.0 : disabledOpacity,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: effectiveGradient,
+          borderRadius: borderRadius,
+        ),
+        child: Material(
+          type: MaterialType.transparency,
+          borderRadius: borderRadius,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: borderRadius,
+            splashColor: foregroundColor.withValues(alpha: 0.2),
+            child: Padding(
+              padding: padding,
+              child: Center(
+                child: DefaultTextStyle(
+                  style:
+                      context.textTheme.labelLarge?.copyWith(color: foregroundColor) ??
+                      TextStyle(color: foregroundColor),
+                  child: IconTheme(
+                    data: IconThemeData(
+                      color: foregroundColor,
+                    ),
+                    child: VoicesButtonAffixDecoration(
+                      leading: leading,
+                      trailing: trailing,
+                      child: child,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/catalyst_voices/apps/voices/lib/widgets/widgets.dart
+++ b/catalyst_voices/apps/voices/lib/widgets/widgets.dart
@@ -6,6 +6,7 @@ export 'buttons/voices_buttons.dart';
 export 'buttons/voices_counter_floating_action_button.dart';
 export 'buttons/voices_filled_button.dart';
 export 'buttons/voices_floating_action_button.dart';
+export 'buttons/voices_gradient_button.dart';
 export 'buttons/voices_icon_button.dart';
 export 'buttons/voices_keyboard_key_button.dart';
 export 'buttons/voices_logical_keyboard_key_button.dart';

--- a/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/voting_ballot/voting_ballot_bloc.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_blocs/lib/src/voting_ballot/voting_ballot_bloc.dart
@@ -213,9 +213,14 @@ final class VotingBallotBloc extends Bloc<VotingBallotEvent, VotingBallotState>
   }
 
   Future<void> _checkPassword(CheckPasswordEvent event, Emitter<VotingBallotState> emit) async {
-    const confirmPasswordStep = ConfirmPasswordStep(isLoading: true);
-    const confirmPasswordFailed = ConfirmPasswordStep(
-      exception: LocalizedUnlockPasswordException(),
+    final isRepresentative = state.footer.isRepresentative;
+    final confirmPasswordStep = ConfirmPasswordStep(
+      isLoading: true,
+      isRepresentative: isRepresentative,
+    );
+    final confirmPasswordFailed = ConfirmPasswordStep(
+      isRepresentative: isRepresentative,
+      exception: const LocalizedUnlockPasswordException(),
     );
     final newFooter = state.footer.copyWith(castingStep: confirmPasswordStep);
     emit(state.copyWith(footer: newFooter));
@@ -238,7 +243,10 @@ final class VotingBallotBloc extends Bloc<VotingBallotEvent, VotingBallotState>
     ConfirmCastingVotesEvent event,
     Emitter<VotingBallotState> emit,
   ) {
-    final newFooter = state.footer.copyWith(castingStep: const ConfirmPasswordStep());
+    final isRepresentative = state.footer.isRepresentative;
+    final newFooter = state.footer.copyWith(
+      castingStep: ConfirmPasswordStep(isRepresentative: isRepresentative),
+    );
     emitSignal(const ShowBottomSheetSignal());
     emit(state.copyWith(footer: newFooter));
   }
@@ -442,6 +450,16 @@ final class VotingBallotBloc extends Bloc<VotingBallotEvent, VotingBallotState>
       isVisible: isFabVisible,
     );
 
-    emit(state.copyWith(userSummary: userSummary, fab: fab));
+    final footer = state.footer.copyWith(
+      isRepresentative: isRepresentative,
+    );
+
+    emit(
+      state.copyWith(
+        userSummary: userSummary,
+        fab: fab,
+        footer: footer,
+      ),
+    );
   }
 }

--- a/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
+++ b/catalyst_voices/packages/internal/catalyst_voices_localization/lib/l10n/intl_en.arb
@@ -721,7 +721,7 @@
   "@confirmPassword": {
     "description": "Label for password confirmation input field"
   },
-  "confirmYourVoteSubmission": "Confirm your vote submission",
+  "confirmYourVoteSubmission": "Confirm Your Vote Submission",
   "@confirmYourVoteSubmission": {
     "description": "Title for confirm vote submission"
   },
@@ -4497,6 +4497,14 @@
   "votingListPendingVotes": "Pending votes not yet cast",
   "@votingListPendingVotes": {
     "description": "Disclaimer about proposal votes not casted yet"
+  },
+  "votingListRepresentingWithImpact": "Representing With Impact",
+  "@votingListRepresentingWithImpact": {
+    "description": "Title for representative info card in vote confirmation"
+  },
+  "votingListRepresentingWithImpactMessage": "Your representative votes will be published after voting ends.\n\nYour vote as a representative carries the voices of your community. Every choice you make helps shape a better experience for those you represent.\n\nBe aware that your votes will be public after the tally.",
+  "@votingListRepresentingWithImpactMessage": {
+    "description": "Message for representative info card in vote confirmation"
   },
   "votingOverview": "Voting Overview",
   "@votingOverview": {

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/voting/voting_list_casting_step.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/voting/voting_list_casting_step.dart
@@ -4,22 +4,30 @@ import 'package:equatable/equatable.dart';
 
 final class ConfirmPasswordStep extends VotingListCastingStep {
   final bool isLoading;
+  final bool isRepresentative;
   final LocalizedException? exception;
 
   const ConfirmPasswordStep({
     this.isLoading = false,
+    this.isRepresentative = false,
     this.exception,
   });
 
   @override
-  List<Object?> get props => [isLoading, exception];
+  List<Object?> get props => [
+    isLoading,
+    isRepresentative,
+    exception,
+  ];
 
   ConfirmPasswordStep copyWith({
     bool? isLoading,
+    bool? isRepresentative,
     Optional<LocalizedException>? exception,
   }) {
     return ConfirmPasswordStep(
       isLoading: isLoading ?? this.isLoading,
+      isRepresentative: isRepresentative ?? this.isRepresentative,
       exception: exception.dataOr(this.exception),
     );
   }

--- a/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/voting/voting_list_footer_data.dart
+++ b/catalyst_voices/packages/internal/catalyst_voices_view_models/lib/src/voting/voting_list_footer_data.dart
@@ -5,12 +5,14 @@ import 'package:equatable/equatable.dart';
 final class VotingListFooterData extends Equatable {
   final bool canCastVotes;
   final bool showPendingVotesDisclaimer;
+  final bool isRepresentative;
   final DateTime? lastCastedVoteAt;
   final VotingListCastingStep castingStep;
 
   const VotingListFooterData({
     this.canCastVotes = false,
     this.showPendingVotesDisclaimer = false,
+    this.isRepresentative = false,
     this.lastCastedVoteAt,
     this.castingStep = const PreCastVotesStep(),
   });
@@ -19,6 +21,7 @@ final class VotingListFooterData extends Equatable {
   List<Object?> get props => [
     canCastVotes,
     showPendingVotesDisclaimer,
+    isRepresentative,
     lastCastedVoteAt,
     castingStep,
   ];
@@ -26,12 +29,14 @@ final class VotingListFooterData extends Equatable {
   VotingListFooterData copyWith({
     bool? canCastVotes,
     bool? showPendingVotesDisclaimer,
+    bool? isRepresentative,
     Optional<DateTime>? lastCastedVoteAt,
     VotingListCastingStep? castingStep,
   }) {
     return VotingListFooterData(
       canCastVotes: canCastVotes ?? this.canCastVotes,
       showPendingVotesDisclaimer: showPendingVotesDisclaimer ?? this.showPendingVotesDisclaimer,
+      isRepresentative: isRepresentative ?? this.isRepresentative,
       lastCastedVoteAt: lastCastedVoteAt.dataOr(this.lastCastedVoteAt),
       castingStep: castingStep ?? this.castingStep,
     );


### PR DESCRIPTION
# Description

Added gradient styling to the `Cast Votes` button for representative users and created a reusable `VoicesGradientButton` widget. When representatives click to cast votes, a new gradient "Representing With Impact" info card is displayed in the confirmation dialog explaining their vote's community impact.

## Related Issue(s)

Closes #3974
Part of #3949

## Please confirm the following checks

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream module
